### PR TITLE
Revert cyberchef version update

### DIFF
--- a/salt/cyberchef/init.sls
+++ b/salt/cyberchef/init.sls
@@ -42,7 +42,7 @@ cybercheflog:
 
 so-cyberchefimage:
  cmd.run:
-   - name: docker pull --disable-content-trust=false docker.io/soshybridhunter/so-cyberchef:HH1.1.4
+   - name: docker pull --disable-content-trust=false docker.io/soshybridhunter/so-cyberchef:HH1.1.3
 
 so-cyberchef:
   docker_container.running:


### PR DESCRIPTION
Cyberchef container image v1.1.4 has not been built yet, revert to 1.1.3 for now