### PR TITLE
Remove Cyberchef from top file since it is now in so-core

### DIFF
--- a/salt/top.sls
+++ b/salt/top.sls
@@ -58,7 +58,6 @@ base:
     - suricata
     - bro
     - curator
-    - cyberchef
     - elastalert
     {%- if OSQUERY != 0 %}
     - fleet
@@ -85,7 +84,6 @@ base:
     - ca
     - ssl
     - common
-    - cyberchef
     - sensoroni
     - firewall
     - master


### PR DESCRIPTION
We need to remove Cyberchef from top.sls since we are moving the files into `so-core`