### PR TITLE
Wazuh: Add auth log path for Centos

### DIFF
--- a/salt/wazuh/files/agent/ossec.conf
+++ b/salt/wazuh/files/agent/ossec.conf
@@ -179,7 +179,7 @@
     <log_format>syslog</log_format>
     <location>/var/ossec/logs/active-responses.log</location>
   </localfile>
-%- if grains['os'] == 'Ubuntu' %}
+{%- if grains['os'] == 'Ubuntu' %}
   <localfile>
     <log_format>syslog</log_format>
     <location>/var/log/auth.log</location>

--- a/salt/wazuh/files/agent/ossec.conf
+++ b/salt/wazuh/files/agent/ossec.conf
@@ -179,12 +179,17 @@
     <log_format>syslog</log_format>
     <location>/var/ossec/logs/active-responses.log</location>
   </localfile>
-
+%- if grains['os'] == 'Ubuntu' %}
   <localfile>
     <log_format>syslog</log_format>
     <location>/var/log/auth.log</location>
   </localfile>
-
+{%- else %}
+  <localfile>
+    <log_format>syslog</log_format>
+    <location>/var/log/secure</location>
+  </localfile>
+{%- endif %}
   <localfile>
     <log_format>syslog</log_format>
     <location>/var/log/syslog</location>

--- a/salt/wazuh/files/agent/wazuh-register-agent
+++ b/salt/wazuh/files/agent/wazuh-register-agent
@@ -31,6 +31,7 @@ USER="foo"
 PASSWORD="bar"
 AGENT_NAME=$(hostname)
 AGENT_IP="{{ip}}"
+AGENT_ID=001
 
 display_help() {
 cat <<HELP_USAGE
@@ -135,5 +136,10 @@ shift $(($OPTIND - 1))
 
 # Default action -> try to register the agent
 sleep 10s
-register_agent
+STATUS=$(curl -s -k -u $USER:$PASSWORD $PROTOCOL://$API_IP:$API_PORT/agents/$AGENT_ID | jq .data.status | sed s'/"//g')
+if [[ $STATUS == "Active" ]]; then 
+  echo "Agent $AGENT_ID already registered!"
+else
+  register_agent
+fi
 #remove_agent


### PR DESCRIPTION
Add auth log path for Centos so we can track and respond (AR) to failed logins