### PR TITLE
Remove cyberchef from proxy conf

### DIFF
--- a/salt/common/nginx/nginx.conf.so-eval
+++ b/salt/common/nginx/nginx.conf.so-eval
@@ -186,18 +186,6 @@ http {
 
         }
         
-        location /cyberchef/ {
-          proxy_pass http://{{ masterip }}:9080/;
-          proxy_read_timeout    90;
-          proxy_connect_timeout 90;
-          proxy_http_version 1.1; # this is essential for chunked responses to work
-          proxy_set_header      Host $host;
-          proxy_set_header      X-Real-IP $remote_addr;
-          proxy_set_header      X-Forwarded-For $proxy_add_x_forwarded_for;
-          proxy_set_header      Proxy "";
-
-        }
-	
         location /soctopus/ {
           proxy_pass http://{{ masterip }}:7000/;
           proxy_read_timeout    90;

--- a/salt/common/nginx/nginx.conf.so-master
+++ b/salt/common/nginx/nginx.conf.so-master
@@ -188,18 +188,6 @@ http {
 
         }
 
-        location /cyberchef/ {
-          proxy_pass http://{{ masterip }}:9080/;
-          proxy_read_timeout    90;
-          proxy_connect_timeout 90;
-          proxy_http_version 1.1; # this is essential for chunked responses to work
-          proxy_set_header      Host $host;
-          proxy_set_header      X-Real-IP $remote_addr;
-          proxy_set_header      X-Forwarded-For $proxy_add_x_forwarded_for;
-          proxy_set_header      Proxy "";
-
-        }
-	
         location /soctopus/ {
           proxy_pass http://{{ masterip }}:7000/;
           proxy_read_timeout    90;


### PR DESCRIPTION
Removing cyberchef from proxy config, as it will be hosted in so-core.