### PR TITLE
Steno - Adjust PCAP disk limit

### DIFF
--- a/salt/pcap/files/config
+++ b/salt/pcap/files/config
@@ -4,7 +4,7 @@
     { "PacketsDirectory": "/nsm/pcap"
     , "IndexDirectory": "/nsm/pcapindex"
     , "MaxDirectoryFiles": 30000
-    , "DiskFreePercentage": 5
+    , "DiskFreePercentage": 10
     }
   ]
   , "StenotypePath": "/usr/bin/stenotype"


### PR DESCRIPTION
Require 10% free space versus the previous 5%.