### PR TITLE
Initial support for Steno bpf

### DIFF
--- a/salt/pcap/files/compile_bpf.sh
+++ b/salt/pcap/files/compile_bpf.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ "$#" -lt 2 ]; then
+  cat 1>&2 <<EOF
+$0 compiles a BPF expression to be passed to stenotype to apply a socket filter.
+Its first argument is the interface (link type is required) and all other arguments
+are passed to TCPDump.
+
+Examples:
+ $0 eth0 dst port 80
+ $0 eth0 udp port 53
+EOF
+  exit 1
+fi
+
+interface="$1"
+shift
+sudo tcpdump -i $interface -ddd $@ | tail -n+2 |
+while read line; do
+  cols=( $line )
+  printf "%04x%02x%02x%08x" ${cols[0]} ${cols[1]} ${cols[2]} ${cols[3]}
+done
+echo ""

--- a/salt/pcap/files/config
+++ b/salt/pcap/files/config
@@ -4,13 +4,13 @@
     { "PacketsDirectory": "/nsm/pcap"
     , "IndexDirectory": "/nsm/pcapindex"
     , "MaxDirectoryFiles": 30000
-    , "DiskFreePercentage": 10
+    , "DiskFreePercentage": 5
     }
   ]
   , "StenotypePath": "/usr/bin/stenotype"
   , "Interface": "{{ interface }}"
   , "Port": 1234
   , "Host": "127.0.0.1"
-  , "Flags": ["-v", "--uid=stenographer", "--gid=stenographer"]
+  , "Flags": ["-v", "--uid=stenographer", "--gid=stenographer"{{ bpf_compiled }}]
   , "CertPath": "/etc/stenographer/certs"
 }

--- a/salt/pcap/files/config
+++ b/salt/pcap/files/config
@@ -4,7 +4,7 @@
     { "PacketsDirectory": "/nsm/pcap"
     , "IndexDirectory": "/nsm/pcapindex"
     , "MaxDirectoryFiles": 30000
-    , "DiskFreePercentage": 5
+    , "DiskFreePercentage": 10
     }
   ]
   , "StenotypePath": "/usr/bin/stenotype"

--- a/salt/pcap/init.sls
+++ b/salt/pcap/init.sls
@@ -36,6 +36,33 @@ stenoconfdir:
     - group: 939
     - makedirs: True
 
+{% set interface = salt['pillar.get']('sensor:interface', 'bond0') %}
+{% set bpf_global = salt['pillar.get']('static:steno:bpf', None) %}
+{% set bpf_steno = salt['pillar.get']('steno:bpf', None) %}
+
+{% if bpf_steno != None or bpf_global != None %}
+   {% if bpf_steno != None %}
+      {% set bpf_calc = salt['cmd.script']('salt://pcap/files/compile_bpf.sh', interface + ' ' + bpf_steno) %}
+   {% else %}
+      {% set bpf_calc = salt['cmd.script']('salt://pcap/files/compile_bpf.sh', interface + ' ' + bpf_global) %}
+   {% endif %}
+   {% if bpf_calc['stderr'] == "" %}
+      {% set bpf_compiled = bpf_calc['stdout'] %}
+   {% else  %}
+         {% set bpf_compiled = None %}
+
+bpfcompilationfailure:
+  test.configurable_test_state:
+   - name: foo
+   - changes: False
+   - result: False
+   - comment: "BPF Compilation Failed - Discarding specified BPF"
+
+   {% endif %}
+{% else  %}
+   {% set bpf_compiled = None %}
+{% endif %}
+
 stenoconf:
   file.managed:
     - name: /opt/so/conf/steno/config
@@ -44,6 +71,12 @@ stenoconf:
     - group: root
     - mode: 644
     - template: jinja
+    - defaults:
+        bpf_compiled: ""
+{% if bpf_compiled != None %}
+    - context:
+        bpf_compiled: ',"--filter={{ bpf_compiled }}"'
+{% endif %}
 
 sensoroniagentconf:
   file.managed:
@@ -113,4 +146,5 @@ so-steno:
       - /opt/so/conf/steno/sensoroni.json:/opt/sensoroni/sensoroni.json:ro
       - /opt/so/log/stenographer:/opt/sensoroni/logs:rw
     - watch:
-      - /opt/so/conf/steno/sensoroni.json
+      - file: /opt/so/conf/steno/config
+      - file: /opt/so/conf/steno/sensoroni.json

--- a/salt/pcap/init.sls
+++ b/salt/pcap/init.sls
@@ -53,7 +53,7 @@ stenoconfdir:
 
 bpfcompilationfailure:
   test.configurable_test_state:
-   - name: foo
+   - name: bpfcompfailure
    - changes: False
    - result: False
    - comment: "BPF Compilation Failed - Discarding specified BPF"


### PR DESCRIPTION
Initial commit for Steno bpf support:
-Specify bpf either globally (via Static pillar) or per node (local pillar) - local overrides global
-Steno requires a compiled bpf filter, which is done via the included shell script 
-If there is an error during bpf compilation (invalid syntax, etc), a Salt error message is raised and no BPF is applied
-If bpf compilation completes without errors, the compiled filter is written to the steno config & the steno docker is restarted (via the Watch file statement)