### PR TITLE
[fix] Use v2 of Docker http api

### DIFF
--- a/salt/common/tools/sbin/so-status
+++ b/salt/common/tools/sbin/so-status
@@ -107,7 +107,7 @@ populate_container_lists() {
     systemctl is-active --quiet docker
 
     if [[ $? = 0 ]]; then
-        mapfile -t docker_raw_list < <(curl -s --unix-socket /var/run/docker.sock http:/containers/json?all=1 \
+        mapfile -t docker_raw_list < <(curl -s --unix-socket /var/run/docker.sock http:/v2/containers/json?all=1 \
             | jq -c '.[] | { Name: .Names[0], State: .State }' \
             | tr -d '/{"}')
     else


### PR DESCRIPTION
Docker no longer exposes the default api path, so we need to use /v2 in our api call