### PR TITLE
send service status to /dev/null to prevent FP on install failure

### DIFF
--- a/setup/so-functions
+++ b/setup/so-functions
@@ -233,7 +233,7 @@ check_service_status() {
 
 	local service_name=$1
 	echo "Checking service $service_name status" >> "$setup_log" 2>&1
-	systemctl status $service_name >> "$setup_log" 2>&1
+	systemctl status $service_name > /dev/null 2>&1
 	local status=$?
 	#true if there is an issue with the service false if it is running properly
 	if [ $status -gt 0 ]; then


### PR DESCRIPTION
Aug 14 15:59:21 securityonion salt-minion[3858]: [ERROR   ] The Salt Master has cached the public key for this node, this salt minion will wait for 10 seconds before attempting to re-authenticate.

This could be present in the output from systemctl status salt-minion and trigger FP.