### PR TITLE
Fix/salt ca ssl

### DIFF
--- a/salt/ssl/init.sls
+++ b/salt/ssl/init.sls
@@ -8,7 +8,7 @@
 {% set CUSTOM_FLEET_HOSTNAME = salt['pillar.get']('global:fleet_custom_hostname', None) %}
 
 {% if grains.id.split('_')|last in ['manager', 'eval', 'standalone', 'import'] %}
-    {% set trusttheca_text = salt['cmd.shell']('cat /etc/pki/ca.crt')|replace('\n', '') %}
+    {% set trusttheca_text = salt['cp.get_file_str']('/etc/pki/ca.crt')|replace('\n', '') %}
     {% set ca_server = grains.id %}
 {% else %}
     {% set x509dict = salt['mine.get']('*', 'x509.get_pem_entries') %}

--- a/salt/ssl/init.sls
+++ b/salt/ssl/init.sls
@@ -8,7 +8,7 @@
 {% set CUSTOM_FLEET_HOSTNAME = salt['pillar.get']('global:fleet_custom_hostname', None) %}
 
 {% if grains.id.split('_')|last in ['manager', 'eval', 'standalone', 'import'] %}
-    {% set trusttheca_text =  salt['mine.get'](grains.id, 'x509.get_pem_entries')[grains.id]['/etc/pki/ca.crt']|replace('\n', '') %}
+    {% set trusttheca_text = salt['cmd.shell']('cat /etc/pki/ca.crt')|replace('\n','') %}
     {% set ca_server = grains.id %}
 {% else %}
     {% set x509dict =  salt['mine.get']('*', 'x509.get_pem_entries') %}

--- a/salt/ssl/init.sls
+++ b/salt/ssl/init.sls
@@ -8,10 +8,10 @@
 {% set CUSTOM_FLEET_HOSTNAME = salt['pillar.get']('global:fleet_custom_hostname', None) %}
 
 {% if grains.id.split('_')|last in ['manager', 'eval', 'standalone', 'import'] %}
-    {% set trusttheca_text = salt['cmd.shell']('cat /etc/pki/ca.crt')|replace('\n','') %}
+    {% set trusttheca_text = salt['cmd.shell']('cat /etc/pki/ca.crt')|replace('\n', '') %}
     {% set ca_server = grains.id %}
 {% else %}
-    {% set x509dict =  salt['mine.get']('*', 'x509.get_pem_entries') %}
+    {% set x509dict = salt['mine.get']('*', 'x509.get_pem_entries') %}
     {% for host in x509dict %}
       {% if 'manager' in host.split('_')|last or host.split('_')|last == 'standalone' %}
         {% do global_ca_text.append(x509dict[host].get('/etc/pki/ca.crt')|replace('\n', '')) %}


### PR DESCRIPTION
### Summary
Installations running manager services (import, eval, standalone, manager, etc.) can get into a corner case where the `ssl` state can't retrieve the CA cert from the salt mine. We need to ensure both the `ca` and `ssl` states succeed so that services start properly.

### References
https://github.com/Security-Onion-Solutions/securityonion/issues/1291
https://www.reddit.com/r/securityonion/comments/imxn4i/20_most_docker_containers_errored_out/
https://groups.google.com/u/1/g/security-onion/c/pv49smUzVI0

### Reproducing The Issue

1. Perform a single node installation (import, eval, standalone, etc.). 
2. Rename the salt mine file:
`sudo mv /var/cache/salt/master/minions/*/mine.p /var/cache/salt/master/minions/*/mine.p.orig`
3. Run `sudo salt-call state.highstate`.
4. This should fail as shown in the reddit thread above.

### Root Cause
The current code uses the `ca` state to write the CA cert to the salt mine so that it can be retrieved by other nodes in the `ssl` state. In a single node installation, we always call the `ca` state before the `ssl` state, so how could this fail?

From https://docs.saltstack.com/en/latest/topics/jinja/index.html:
```
Jinja is evaluated before YAML, which means it is evaluated before the States are run.
```

Since jinja is evaluated before the States are run, we can get into a corner case where salt is evaluating the jinja in `ssl/init.sls` and attempts to `mine.get` a value which has not yet been set by the `ca` state. 

### Proposed Solution
This corner case happens on installations where the CA is on the local system, so we really don't need the mine to get the CA cert. Instead, we can simply read `/etc/pki/ca.crt` directly from the filesystem.

### Testing
You can test as shown in the `Reproducing The Issue` section above. With the new code in place, Salt should now be able to complete the `highstate` and repopulate the mine properly so that other nodes can read from the mine.