### PR TITLE
Fix/so elastic clear

### DIFF
--- a/salt/common/tools/sbin/so-elastic-clear
+++ b/salt/common/tools/sbin/so-elastic-clear
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-{%- set MANAGERIP = salt['pillar.get']('global:managerip', '') -%}
+{%- set NODEIP = salt['pillar.get']('elasticsearch:mainip', '') -%}
 . /usr/sbin/so-common
 
 SKIP=0
@@ -50,7 +50,7 @@ done
 if [ $SKIP -ne 1 ]; then
         # List indices
         echo 
-        curl {{ MANAGERIP }}:9200/_cat/indices?v
+        curl {{ NODEIP }}:9200/_cat/indices?v
         echo
         # Inform user we are about to delete all data
         echo
@@ -89,10 +89,10 @@ fi
 # Delete data
 echo "Deleting data..."
 
-INDXS=$(curl -s -XGET {{ MANAGERIP }}:9200/_cat/indices?v | egrep 'logstash|elastalert|so-' | awk '{ print $3 }')
+INDXS=$(curl -s -XGET {{ NODEIP }}:9200/_cat/indices?v | egrep 'logstash|elastalert|so-' | awk '{ print $3 }')
 for INDX in ${INDXS}
 do
-    curl -XDELETE "{{ MANAGERIP }}:9200/${INDX}" > /dev/null 2>&1
+    curl -XDELETE "{{ NODEIP }}:9200/${INDX}" > /dev/null 2>&1
 done
 
 #Start Logstash/Filebeat

--- a/salt/filebeat/init.sls
+++ b/salt/filebeat/init.sls
@@ -44,6 +44,12 @@ filebeatpkidir:
     - user: 939
     - group: 939
     - makedirs: True
+fileregistrydir:
+  file.directory:
+    - name: /opt/so/conf/filebeat/registry
+    - user: 939
+    - group: 939
+    - makedirs: True
 # This needs to be owned by root
 filebeatconfsync:
   file.managed:
@@ -69,6 +75,7 @@ so-filebeat:
       - /nsm/wazuh/logs/archives:/wazuh/archives:ro
       - /opt/so/conf/filebeat/etc/pki/filebeat.crt:/usr/share/filebeat/filebeat.crt:ro
       - /opt/so/conf/filebeat/etc/pki/filebeat.key:/usr/share/filebeat/filebeat.key:ro
+      - /opt/so/conf/filebeat/registry:/usr/share/filebeat/data/registry:rw
       - /etc/ssl/certs/intca.crt:/usr/share/filebeat/intraca.crt:ro
     - port_bindings:
         - 0.0.0.0:514:514/udp


### PR DESCRIPTION
- Make Filebeat registry file(s) persistent, so as not to re-read old data
- Ensure `so-elastic-clear` can work on search nodes