### PR TITLE
Adjust Wazuh logging so we don't log alerts to a separate file and so…

### DIFF
--- a/salt/wazuh/files/server/ossec.conf
+++ b/salt/wazuh/files/server/ossec.conf
@@ -7,8 +7,8 @@
 <ossec_config>
   <global>
     <jsonout_output>yes</jsonout_output>
-    <alerts_log>yes</alerts_log>
-    <logall>yes</logall>
+    <alerts_log>no</alerts_log>
+    <logall>no</logall>
     <logall_json>yes</logall_json>
     <email_notification>no</email_notification>
     <smtp_server>smtp.example.wazuh.com</smtp_server>


### PR DESCRIPTION
… we don't write a separate log file for non-JSON for archives