### PR TITLE
Add Strelka YARA matches as alerts

### DIFF
--- a/salt/elasticsearch/files/ingest/strelka.file
+++ b/salt/elasticsearch/files/ingest/strelka.file
@@ -6,7 +6,8 @@
     { "rename":         { "field": "message2.scan",        "target_field": "scan",          "ignore_missing": true  } },
     { "rename":         { "field": "message2.request",        "target_field": "request",          "ignore_missing": true  } },
     { "rename":         { "field": "scan.hash",        "target_field": "hash",          "ignore_missing": true  } },
-    { "grok":           { "field": "request.attributes.filename",       "patterns": ["-%{WORD:log.id.fuid}-"] } },
+
+    { "grok":           { "if": "ctx.request.attributes.filename != null",   "field": "request.attributes.filename",       "patterns": ["-%{WORD:log.id.fuid}-"], "ignore_failure": true } },
     { "foreach":
       {
         "if": "ctx.scan?.exiftool?.keys !=null",
@@ -19,8 +20,29 @@
           }
       }
     },
+    { "foreach":
+      {
+        "if": "ctx.scan?.yara?.meta !=null",
+          "field": "scan.yara.meta",
+          "processor":{
+            "set": {
+              "field": "rule.{{_ingest._value.identifier}}",
+              "value": "{{_ingest._value.value}}"
+            }
+          }
+      }
+    },
+    { "set":         { "if": "ctx.scan.yara.matches != null", "field": "rule.name",        "value": "{{scan.yara.matches.0}}" }},
+    { "set":         { "if": "ctx.scan.yara.matches != null", "field": "dataset",        "value": "alert", "override": true }},
+    { "rename":         { "field": "scan.hash",        "target_field": "",          "ignore_missing": true  } },
+    { "set":         { "if": "ctx.rule.name != null && ctx.rule.score == null",   "field": "event.severity", "value": 3, "override": true }  },
+    { "convert" : { "if": "ctx.rule.score != null", "field" : "rule.score","type": "integer"}},
+    { "set":         { "if": "ctx.rule.score != null && ctx.rule.score >= 0 && ctx.rule.score <= 49",   "field": "event.severity", "value": 1, "override": true }  },
+    { "set":         { "if": "ctx.rule.score != null && ctx.rule.score >= 50 && ctx.rule.score <=69",   "field": "event.severity", "value": 2, "override": true }  },
+    { "set":         { "if": "ctx.rule != null && ctx.rule.score >= 70 && ctx.rule.score <=89",   "field": "event.severity", "value": 3, "override": true }  },
+    { "set":         { "if": "ctx.rule != null && ctx.rule.score >= 90",   "field": "event.severity", "value": 4, "override": true }  },
     { "set":         { "field": "observer.name",        "value": "{{agent.name}}" }},
-    { "remove":         { "field": ["host", "path", "message", "scan.exiftool.keys"],                                         "ignore_missing": true  } },
+    { "remove":         { "field": ["host", "path", "message", "scan.exiftool.keys", "scan.yara.meta"],                                         "ignore_missing": true  } },
     { "pipeline":       { "name": "common"                                                                                   } }
   ]
 }

--- a/salt/elasticsearch/templates/so/so-common-template.json
+++ b/salt/elasticsearch/templates/so/so-common-template.json
@@ -353,6 +353,9 @@
           "type":"object",
           "dynamic":true,
           "properties":{
+            "score":{
+              "type":"long"
+            },
             "uuid":{
               "type":"keyword"
             }


### PR DESCRIPTION
- Files analyzed by Strelka with a valid YARA rule match will be considered `event.dataset:alert`
- If a `score` is provided in the YARA rule, the severity will be based off of it -- otherwise, the alert will have an `event.severity: 3`, (and `event.severity_label: high`) by default.