### PR TITLE
Increase printf padding by 1

### DIFF
--- a/salt/common/tools/sbin/so-status
+++ b/salt/common/tools/sbin/so-status
@@ -131,7 +131,7 @@ print_line() {
     local columns=$(tput cols)
     local state_color="\e[0m"
 
-    local PADDING_CONSTANT=14
+    local PADDING_CONSTANT=15
 
     if [[ $service_state = "$ERROR_STRING" ]] || [[ $service_state = "$MISSING_STRING" ]]; then
         state_color="\e[1;31m"


### PR DESCRIPTION
Adding one character of padding prevents each status line from wrapping right before its LF, thus giving single-spaced output rather than double-spaced.  (final LF in patch added by github editor)

Before:
Checking container statuses

    so-aptcacherng ------------------------------------------- [ OK ] 
   
    so-cortex ------------------------------------------------ [ OK ]    

    so-curator ----------------------------------------------- [ OK ]   
....

After:
Checking container statuses

    so-aptcacherng ------------------------------------------ [ OK ]    
    so-cortex ----------------------------------------------- [ OK ]    
    so-curator ---------------------------------------------- [ OK ]
....