### PR TITLE
Bugfix/so-scripts

### DIFF
--- a/salt/common/tools/sbin/so-features-enable
+++ b/salt/common/tools/sbin/so-features-enable
@@ -51,7 +51,7 @@ manager_check() {
 }
 
 manager_check
-VERSION=$(grep soversion $local_salt_dir/pillar/global.sls | cut -d':' -f2|sed 's/ //g')
+VERSION=$(grep soversion $local_salt_dir/pillar/global.sls | cut -d':' -f2|sed 's/ //g' | sed "s/'//g")
 # Modify global.sls to enable Features
 sed -i 's/features: False/features: True/' $local_salt_dir/pillar/global.sls
 SUFFIX="-features"

--- a/salt/common/tools/sbin/so-firewall
+++ b/salt/common/tools/sbin/so-firewall
@@ -116,7 +116,7 @@ def addhostgroup(args):
     print('Missing host group name argument', file=sys.stderr)
     showUsage(args)
 
-  name = args[1]
+  name = args[0]
   content = loadYaml(hostgroupsFilename)
   if name in content['firewall']['hostgroups']:
     print('Already exists', file=sys.stderr)


### PR DESCRIPTION
Hi,

two small bugfixes for two so-scripts that i noticed the last days:

**so-features-enable**

In my latest install of Security Onion 2.3 the version variable in global.sls was set to '2.3.0' (including single quotes). Because of that the script tries to download the images, e.g. so-logstash:'2.3.0'-features. This dont work. In order to get this to work I added a second `sed` to remove these single quotes.

**so-firewall**

In line 115 the script expects an args array with length of 1 and checks this. But in line 119 the script tries to get args[1] which is position 2 of the array. This needs to be changed to args[0] for position 1. The next function addportgroup works the same but is doing this right.

Kind regards
Lukas