### PR TITLE
fix for rendering error on soc.json if >0 search node

### DIFF
--- a/salt/soc/files/soc/soc.json
+++ b/salt/soc/files/soc/soc.json
@@ -33,7 +33,7 @@
         {%- if salt['pillar.get']('nodestab', {}) %}
         "remoteHostUrls": [
         {%- for SN, SNDATA in salt['pillar.get']('nodestab', {}).items() %}
-        "https://{{ SN.split('_')|first }}:9200"{{ "," if not loop.last }}
+        "https://{{ SN.split('_')|first }}:9200"{{ "," if not loop.last else ""}}
         {%- endfor %}
         ],
         {%- endif %}


### PR DESCRIPTION
Fails rendering if you have more than one search node. The last node will trigger the `loop.last`, but there's no `else` so jinja doesn't know what to do with itself.