### PR TITLE
fix for Windows events via osquery

### DIFF
--- a/salt/elasticsearch/files/ingest/osquery.query_result
+++ b/salt/elasticsearch/files/ingest/osquery.query_result
@@ -6,7 +6,7 @@
     { "gsub":        { "field": "message2.columns.data",                              "pattern": "\\\\xC2\\\\xAE",             "replacement": "", "ignore_missing": true  } },
     { "rename":      { "if": "ctx.message2.columns?.eventid != null", "field": "message2.columns",  "target_field": "winlog",       "ignore_missing": true  } },
     { "json":        { "field": "winlog.data",                              "target_field": "temp",             "ignore_failure": true  } },
-    { "rename":      { "field": "temp.Data",               "target_field": "winlog.event_data",       "ignore_missing": true  } },   
+    { "rename":      { "field": "temp.EventData",               "target_field": "winlog.event_data",       "ignore_missing": true  } },   
     { "rename":      { "field": "winlog.source",               "target_field": "winlog.channel",       "ignore_missing": true  } },    
     { "rename":      { "field": "winlog.eventid",               "target_field": "winlog.event_id",       "ignore_missing": true  } },   
     { "pipeline":      { "if": "ctx.winlog?.channel == 'Microsoft-Windows-Sysmon/Operational'",   "name": "sysmon"  }  },


### PR DESCRIPTION
This change was required to properly let Windows events flow through their specific pipelines. Otherwise, the `temp` field stays around and gets ingested in ES and never gets processed.