### PR TITLE
fix for #1725, grafana queries use non_negative_ variants

### DIFF
--- a/salt/grafana/dashboards/eval/eval.json
+++ b/salt/grafana/dashboards/eval/eval.json
@@ -3565,7 +3565,7 @@
       "aliasColors": {
         "InBound": "#629E51",
         "OutBound": "#5195CE",
-        "net.derivative": "#1F78C1"
+        "net.non_negative_derivative": "#1F78C1"
       },
       "bars": false,
       "dashLength": 10,
@@ -3636,7 +3636,7 @@
           "measurement": "net",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT 8 * derivative(mean(\"bytes_recv\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
+          "query": "SELECT 8 * non_negative_derivative(mean(\"bytes_recv\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -3656,7 +3656,7 @@
                 "params": [
                   "1s"
                 ],
-                "type": "derivative"
+                "type": "non_negative_derivative"
               },
               {
                 "params": [
@@ -4036,7 +4036,7 @@
               },
               {
                 "params": [],
-                "type": "difference"
+                "type": "non_negative_difference"
               }
             ]
           ],
@@ -4084,7 +4084,7 @@
               },
               {
                 "params": [],
-                "type": "difference"
+                "type": "non_negative_difference"
               }
             ]
           ],
@@ -4143,7 +4143,7 @@
       "aliasColors": {
         "InBound": "#629E51",
         "OutBound": "#5195CE",
-        "net.derivative": "#1F78C1"
+        "net.non_negative_derivative": "#1F78C1"
       },
       "bars": false,
       "dashLength": 10,
@@ -4214,7 +4214,7 @@
           "measurement": "net",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT 8 * derivative(mean(\"bytes_recv\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
+          "query": "SELECT 8 * non_negative_derivative(mean(\"bytes_recv\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -4234,7 +4234,7 @@
                 "params": [
                   "1s"
                 ],
-                "type": "derivative"
+                "type": "non_negative_derivative"
               },
               {
                 "params": [
@@ -4278,7 +4278,7 @@
           "measurement": "net",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT 8 * derivative(mean(\"bytes_sent\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
+          "query": "SELECT 8 * non_negative_derivative(mean(\"bytes_sent\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
           "rawQuery": false,
           "refId": "B",
           "resultFormat": "time_series",
@@ -4298,7 +4298,7 @@
                 "params": [
                   "1s"
                 ],
-                "type": "derivative"
+                "type": "non_negative_derivative"
               },
               {
                 "params": [

--- a/salt/grafana/dashboards/manager/manager.json
+++ b/salt/grafana/dashboards/manager/manager.json
@@ -1795,7 +1795,7 @@
       "aliasColors": {
         "InBound": "#629E51",
         "OutBound": "#5195CE",
-        "net.derivative": "#1F78C1"
+        "net.non_negative_derivative": "#1F78C1"
       },
       "bars": false,
       "dashLength": 10,
@@ -1860,7 +1860,7 @@
           "measurement": "net",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT 8 * derivative(mean(\"bytes_recv\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
+          "query": "SELECT 8 * non_negative_derivative(mean(\"bytes_recv\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -1880,7 +1880,7 @@
                 "params": [
                   "1s"
                 ],
-                "type": "derivative"
+                "type": "non_negative_derivative"
               },
               {
                 "params": [
@@ -1924,7 +1924,7 @@
           "measurement": "net",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT 8 * derivative(mean(\"bytes_sent\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
+          "query": "SELECT 8 * non_negative_derivative(mean(\"bytes_sent\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
           "rawQuery": false,
           "refId": "B",
           "resultFormat": "time_series",
@@ -1944,7 +1944,7 @@
                 "params": [
                   "1s"
                 ],
-                "type": "derivative"
+                "type": "non_negative_derivative"
               },
               {
                 "params": [
@@ -2459,7 +2459,7 @@
       "aliasColors": {
         "InBound": "#629E51",
         "OutBound": "#5195CE",
-        "net.derivative": "#1F78C1"
+        "net.non_negative_derivative": "#1F78C1"
       },
       "bars": false,
       "dashLength": 10,
@@ -2524,7 +2524,7 @@
           "measurement": "docker_container_net",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT 8 * derivative(mean(\"bytes_recv\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
+          "query": "SELECT 8 * non_negative_derivative(mean(\"bytes_recv\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -2544,7 +2544,7 @@
                 "params": [
                   "1s"
                 ],
-                "type": "derivative"
+                "type": "non_negative_derivative"
               },
               {
                 "params": [
@@ -2588,7 +2588,7 @@
           "measurement": "docker_container_net",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT 8 * derivative(mean(\"bytes_sent\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
+          "query": "SELECT 8 * non_negative_derivative(mean(\"bytes_sent\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
           "rawQuery": false,
           "refId": "B",
           "resultFormat": "time_series",
@@ -2608,7 +2608,7 @@
                 "params": [
                   "1s"
                 ],
-                "type": "derivative"
+                "type": "non_negative_derivative"
               },
               {
                 "params": [
@@ -3168,7 +3168,7 @@
       "aliasColors": {
         "InBound": "#629E51",
         "OutBound": "#5195CE",
-        "net.derivative": "#1F78C1"
+        "net.non_negative_derivative": "#1F78C1"
       },
       "bars": false,
       "dashLength": 10,
@@ -3233,7 +3233,7 @@
           "measurement": "docker_container_net",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT 8 * derivative(mean(\"bytes_recv\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
+          "query": "SELECT 8 * non_negative_derivative(mean(\"bytes_recv\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -3253,7 +3253,7 @@
                 "params": [
                   "1s"
                 ],
-                "type": "derivative"
+                "type": "non_negative_derivative"
               },
               {
                 "params": [
@@ -3297,7 +3297,7 @@
           "measurement": "docker_container_net",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT 8 * derivative(mean(\"bytes_sent\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
+          "query": "SELECT 8 * non_negative_derivative(mean(\"bytes_sent\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
           "rawQuery": false,
           "refId": "B",
           "resultFormat": "time_series",
@@ -3317,7 +3317,7 @@
                 "params": [
                   "1s"
                 ],
-                "type": "derivative"
+                "type": "non_negative_derivative"
               },
               {
                 "params": [
@@ -3463,7 +3463,7 @@
               },
               {
                 "params": [],
-                "type": "difference"
+                "type": "non_negative_difference"
               }
             ]
           ],
@@ -3510,7 +3510,7 @@
               },
               {
                 "params": [],
-                "type": "difference"
+                "type": "non_negative_difference"
               }
             ]
           ],
@@ -3700,7 +3700,7 @@
       "aliasColors": {
         "InBound": "#629E51",
         "OutBound": "#5195CE",
-        "net.derivative": "#1F78C1"
+        "net.non_negative_derivative": "#1F78C1"
       },
       "bars": false,
       "dashLength": 10,
@@ -3765,7 +3765,7 @@
           "measurement": "docker_container_net",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT 8 * derivative(mean(\"bytes_recv\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
+          "query": "SELECT 8 * non_negative_derivative(mean(\"bytes_recv\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -3785,7 +3785,7 @@
                 "params": [
                   "1s"
                 ],
-                "type": "derivative"
+                "type": "non_negative_derivative"
               },
               {
                 "params": [
@@ -3829,7 +3829,7 @@
           "measurement": "docker_container_net",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT 8 * derivative(mean(\"bytes_sent\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
+          "query": "SELECT 8 * non_negative_derivative(mean(\"bytes_sent\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
           "rawQuery": false,
           "refId": "B",
           "resultFormat": "time_series",
@@ -3849,7 +3849,7 @@
                 "params": [
                   "1s"
                 ],
-                "type": "derivative"
+                "type": "non_negative_derivative"
               },
               {
                 "params": [

--- a/salt/grafana/dashboards/managersearch/managersearch.json
+++ b/salt/grafana/dashboards/managersearch/managersearch.json
@@ -1799,7 +1799,7 @@
         "aliasColors": {
           "InBound": "#629E51",
           "OutBound": "#5195CE",
-          "net.derivative": "#1F78C1"
+          "net.non_negative_derivative": "#1F78C1"
         },
         "bars": false,
         "dashLength": 10,
@@ -1864,7 +1864,7 @@
             "measurement": "net",
             "orderByTime": "ASC",
             "policy": "default",
-            "query": "SELECT 8 * derivative(mean(\"bytes_recv\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
+            "query": "SELECT 8 * non_negative_derivative(mean(\"bytes_recv\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
             "rawQuery": false,
             "refId": "A",
             "resultFormat": "time_series",
@@ -1884,7 +1884,7 @@
                   "params": [
                     "1s"
                   ],
-                  "type": "derivative"
+                  "type": "non_negative_derivative"
                 },
                 {
                   "params": [
@@ -1928,7 +1928,7 @@
             "measurement": "net",
             "orderByTime": "ASC",
             "policy": "default",
-            "query": "SELECT 8 * derivative(mean(\"bytes_sent\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
+            "query": "SELECT 8 * non_negative_derivative(mean(\"bytes_sent\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
             "rawQuery": false,
             "refId": "B",
             "resultFormat": "time_series",
@@ -1948,7 +1948,7 @@
                   "params": [
                     "1s"
                   ],
-                  "type": "derivative"
+                  "type": "non_negative_derivative"
                 },
                 {
                   "params": [
@@ -2546,7 +2546,7 @@
         "aliasColors": {
           "InBound": "#629E51",
           "OutBound": "#5195CE",
-          "net.derivative": "#1F78C1"
+          "net.non_negative_derivative": "#1F78C1"
         },
         "bars": false,
         "dashLength": 10,
@@ -2611,7 +2611,7 @@
             "measurement": "docker_container_net",
             "orderByTime": "ASC",
             "policy": "default",
-            "query": "SELECT 8 * derivative(mean(\"bytes_recv\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
+            "query": "SELECT 8 * non_negative_derivative(mean(\"bytes_recv\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
             "rawQuery": false,
             "refId": "A",
             "resultFormat": "time_series",
@@ -2631,7 +2631,7 @@
                   "params": [
                     "1s"
                   ],
-                  "type": "derivative"
+                  "type": "non_negative_derivative"
                 },
                 {
                   "params": [
@@ -2675,7 +2675,7 @@
             "measurement": "docker_container_net",
             "orderByTime": "ASC",
             "policy": "default",
-            "query": "SELECT 8 * derivative(mean(\"bytes_sent\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
+            "query": "SELECT 8 * non_negative_derivative(mean(\"bytes_sent\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
             "rawQuery": false,
             "refId": "B",
             "resultFormat": "time_series",
@@ -2695,7 +2695,7 @@
                   "params": [
                     "1s"
                   ],
-                  "type": "derivative"
+                  "type": "non_negative_derivative"
                 },
                 {
                   "params": [
@@ -3299,7 +3299,7 @@
             "measurement": "docker_container_net",
             "orderByTime": "ASC",
             "policy": "default",
-            "query": "SELECT derivative(mean(\"rx_bytes\"), 1s)  *8 FROM \"docker_container_net\" WHERE (\"host\" = '{{ SERVERNAME }}' AND \"container_name\" = 'so-influxdb') AND $timeFilter GROUP BY time($__interval) fill(null)",
+            "query": "SELECT non_negative_derivative(mean(\"rx_bytes\"), 1s)  *8 FROM \"docker_container_net\" WHERE (\"host\" = '{{ SERVERNAME }}' AND \"container_name\" = 'so-influxdb') AND $timeFilter GROUP BY time($__interval) fill(null)",
             "rawQuery": false,
             "refId": "A",
             "resultFormat": "time_series",
@@ -3319,7 +3319,7 @@
                   "params": [
                     "1s"
                   ],
-                  "type": "derivative"
+                  "type": "non_negative_derivative"
                 },
                 {
                   "params": [
@@ -3380,7 +3380,7 @@
                   "params": [
                     "1s"
                   ],
-                  "type": "derivative"
+                  "type": "non_negative_derivative"
                 },
                 {
                   "params": [
@@ -3785,7 +3785,7 @@
                   "params": [
                     "1s"
                   ],
-                  "type": "derivative"
+                  "type": "non_negative_derivative"
                 },
                 {
                   "params": [
@@ -3846,7 +3846,7 @@
                   "params": [
                     "1s"
                   ],
-                  "type": "derivative"
+                  "type": "non_negative_derivative"
                 },
                 {
                   "params": [
@@ -4164,7 +4164,7 @@
                 },
                 {
                   "params": [],
-                  "type": "difference"
+                  "type": "non_negative_difference"
                 }
               ]
             ],
@@ -4211,7 +4211,7 @@
                 },
                 {
                   "params": [],
-                  "type": "difference"
+                  "type": "non_negative_difference"
                 }
               ]
             ],

--- a/salt/grafana/dashboards/search_nodes/searchnode.json
+++ b/salt/grafana/dashboards/search_nodes/searchnode.json
@@ -2135,7 +2135,7 @@
               },
               {
                 "params": [],
-                "type": "difference"
+                "type": "non_negative_difference"
               }
             ]
           ],
@@ -2182,7 +2182,7 @@
               },
               {
                 "params": [],
-                "type": "difference"
+                "type": "non_negative_difference"
               }
             ]
           ],
@@ -2781,7 +2781,7 @@
       "aliasColors": {
         "InBound": "#629E51",
         "OutBound": "#5195CE",
-        "net.derivative": "#1F78C1"
+        "net.non_negative_derivative": "#1F78C1"
       },
       "bars": false,
       "dashLength": 10,
@@ -2846,7 +2846,7 @@
           "measurement": "net",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT 8 * derivative(mean(\"bytes_recv\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
+          "query": "SELECT 8 * non_negative_derivative(mean(\"bytes_recv\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -2866,7 +2866,7 @@
                 "params": [
                   "1s"
                 ],
-                "type": "derivative"
+                "type": "non_negative_derivative"
               },
               {
                 "params": [
@@ -2910,7 +2910,7 @@
           "measurement": "net",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT 8 * derivative(mean(\"bytes_sent\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
+          "query": "SELECT 8 * non_negative_derivative(mean(\"bytes_sent\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
           "rawQuery": false,
           "refId": "B",
           "resultFormat": "time_series",
@@ -2930,7 +2930,7 @@
                 "params": [
                   "1s"
                 ],
-                "type": "derivative"
+                "type": "non_negative_derivative"
               },
               {
                 "params": [
@@ -3353,7 +3353,7 @@
       "aliasColors": {
         "InBound": "#629E51",
         "OutBound": "#5195CE",
-        "net.derivative": "#1F78C1"
+        "net.non_negative_derivative": "#1F78C1"
       },
       "bars": false,
       "dashLength": 10,
@@ -3418,7 +3418,7 @@
           "measurement": "docker_container_net",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT 8 * derivative(mean(\"bytes_recv\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
+          "query": "SELECT 8 * non_negative_derivative(mean(\"bytes_recv\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -3438,7 +3438,7 @@
                 "params": [
                   "1s"
                 ],
-                "type": "derivative"
+                "type": "non_negative_derivative"
               },
               {
                 "params": [
@@ -3482,7 +3482,7 @@
           "measurement": "docker_container_net",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT 8 * derivative(mean(\"bytes_sent\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
+          "query": "SELECT 8 * non_negative_derivative(mean(\"bytes_sent\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
           "rawQuery": false,
           "refId": "B",
           "resultFormat": "time_series",
@@ -3502,7 +3502,7 @@
                 "params": [
                   "1s"
                 ],
-                "type": "derivative"
+                "type": "non_negative_derivative"
               },
               {
                 "params": [

--- a/salt/grafana/dashboards/sensor_nodes/sensor.json
+++ b/salt/grafana/dashboards/sensor_nodes/sensor.json
@@ -2729,7 +2729,7 @@
       "aliasColors": {
         "InBound": "#629E51",
         "OutBound": "#5195CE",
-        "net.derivative": "#1F78C1"
+        "net.non_negative_derivative": "#1F78C1"
       },
       "bars": false,
       "dashLength": 10,
@@ -2800,7 +2800,7 @@
           "measurement": "net",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT 8 * derivative(mean(\"bytes_recv\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
+          "query": "SELECT 8 * non_negative_derivative(mean(\"bytes_recv\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -2820,7 +2820,7 @@
                 "params": [
                   "1s"
                 ],
-                "type": "derivative"
+                "type": "non_negative_derivative"
               },
               {
                 "params": [
@@ -2864,7 +2864,7 @@
           "measurement": "net",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT 8 * derivative(mean(\"bytes_sent\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
+          "query": "SELECT 8 * non_negative_derivative(mean(\"bytes_sent\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
           "rawQuery": false,
           "refId": "B",
           "resultFormat": "time_series",
@@ -2884,7 +2884,7 @@
                 "params": [
                   "1s"
                 ],
-                "type": "derivative"
+                "type": "non_negative_derivative"
               },
               {
                 "params": [
@@ -3311,7 +3311,7 @@
               },
               {
                 "params": [],
-                "type": "difference"
+                "type": "non_negative_difference"
               }
             ]
           ],
@@ -3359,7 +3359,7 @@
               },
               {
                 "params": [],
-                "type": "difference"
+                "type": "non_negative_difference"
               }
             ]
           ],
@@ -3418,7 +3418,7 @@
       "aliasColors": {
         "InBound": "#629E51",
         "OutBound": "#5195CE",
-        "net.derivative": "#1F78C1"
+        "net.non_negative_derivative": "#1F78C1"
       },
       "bars": false,
       "dashLength": 10,
@@ -3489,7 +3489,7 @@
           "measurement": "net",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT 8 * derivative(mean(\"bytes_recv\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
+          "query": "SELECT 8 * non_negative_derivative(mean(\"bytes_recv\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -3509,7 +3509,7 @@
                 "params": [
                   "1s"
                 ],
-                "type": "derivative"
+                "type": "non_negative_derivative"
               },
               {
                 "params": [
@@ -4085,7 +4085,7 @@
       "aliasColors": {
         "InBound": "#629E51",
         "OutBound": "#5195CE",
-        "net.derivative": "#1F78C1"
+        "net.non_negative_derivative": "#1F78C1"
       },
       "bars": false,
       "dashLength": 10,
@@ -4156,7 +4156,7 @@
           "measurement": "docker_container_net",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT 8 * derivative(mean(\"bytes_recv\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
+          "query": "SELECT 8 * non_negative_derivative(mean(\"bytes_recv\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -4176,7 +4176,7 @@
                 "params": [
                   "1s"
                 ],
-                "type": "derivative"
+                "type": "non_negative_derivative"
               },
               {
                 "params": [
@@ -4220,7 +4220,7 @@
           "measurement": "docker_container_net",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT 8 * derivative(mean(\"bytes_sent\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
+          "query": "SELECT 8 * non_negative_derivative(mean(\"bytes_sent\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
           "rawQuery": false,
           "refId": "B",
           "resultFormat": "time_series",
@@ -4240,7 +4240,7 @@
                 "params": [
                   "1s"
                 ],
-                "type": "derivative"
+                "type": "non_negative_derivative"
               },
               {
                 "params": [

--- a/salt/grafana/dashboards/standalone/standalone.json
+++ b/salt/grafana/dashboards/standalone/standalone.json
@@ -2010,7 +2010,7 @@
       "aliasColors": {
         "InBound": "#629E51",
         "OutBound": "#5195CE",
-        "net.derivative": "#1F78C1"
+        "net.non_negative_derivative": "#1F78C1"
       },
       "bars": false,
       "dashLength": 10,
@@ -2081,7 +2081,7 @@
           "measurement": "net",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT 8 * derivative(mean(\"bytes_recv\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
+          "query": "SELECT 8 * non_negative_derivative(mean(\"bytes_recv\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -2101,7 +2101,7 @@
                 "params": [
                   "1s"
                 ],
-                "type": "derivative"
+                "type": "non_negative_derivative"
               },
               {
                 "params": [
@@ -2145,7 +2145,7 @@
           "measurement": "net",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT 8 * derivative(mean(\"bytes_sent\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
+          "query": "SELECT 8 * non_negative_derivative(mean(\"bytes_sent\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
           "rawQuery": false,
           "refId": "B",
           "resultFormat": "time_series",
@@ -2165,7 +2165,7 @@
                 "params": [
                   "1s"
                 ],
-                "type": "derivative"
+                "type": "non_negative_derivative"
               },
               {
                 "params": [
@@ -2794,7 +2794,7 @@
       "aliasColors": {
         "InBound": "#629E51",
         "OutBound": "#5195CE",
-        "net.derivative": "#1F78C1"
+        "net.non_negative_derivative": "#1F78C1"
       },
       "bars": false,
       "dashLength": 10,
@@ -2865,7 +2865,7 @@
           "measurement": "net",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT 8 * derivative(mean(\"bytes_recv\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
+          "query": "SELECT 8 * non_negative_derivative(mean(\"bytes_recv\"),1s) FROM \"net\" WHERE \"host\" = 'JumpHost' AND \"interface\" = 'eth0' AND $timeFilter GROUP BY time($interval) fill(null)",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -2885,7 +2885,7 @@
                 "params": [
                   "1s"
                 ],
-                "type": "derivative"
+                "type": "non_negative_derivative"
               },
               {
                 "params": [
@@ -3466,7 +3466,7 @@
                 "params": [
                   "1s"
                 ],
-                "type": "derivative"
+                "type": "non_negative_derivative"
               },
               {
                 "params": [
@@ -3527,7 +3527,7 @@
                 "params": [
                   "1s"
                 ],
-                "type": "derivative"
+                "type": "non_negative_derivative"
               },
               {
                 "params": [
@@ -4102,7 +4102,7 @@
                 "params": [
                   "1s"
                 ],
-                "type": "derivative"
+                "type": "non_negative_derivative"
               },
               {
                 "params": [
@@ -4163,7 +4163,7 @@
                 "params": [
                   "1s"
                 ],
-                "type": "derivative"
+                "type": "non_negative_derivative"
               },
               {
                 "params": [
@@ -4854,7 +4854,7 @@
                 "params": [
                   "1s"
                 ],
-                "type": "derivative"
+                "type": "non_negative_derivative"
               },
               {
                 "params": [
@@ -4915,7 +4915,7 @@
                 "params": [
                   "1s"
                 ],
-                "type": "derivative"
+                "type": "non_negative_derivative"
               },
               {
                 "params": [
@@ -5202,7 +5202,7 @@
               },
               {
                 "params": [],
-                "type": "difference"
+                "type": "non_negative_difference"
               }
             ]
           ],
@@ -5250,7 +5250,7 @@
               },
               {
                 "params": [],
-                "type": "difference"
+                "type": "non_negative_difference"
               }
             ]
           ],


### PR DESCRIPTION
This will allow the graphs to stay sane when components restart and reset counters.