### PR TITLE
Fix Error: SO elasticsearch ingest failed to convert 'winlog.event_data.SubjectUserName' to 'user.name'

### DIFF
--- a/salt/elasticsearch/files/ingest/win.eventlogs
+++ b/salt/elasticsearch/files/ingest/win.eventlogs
@@ -6,7 +6,7 @@
     { "set":           { "if": "ctx.winlog?.computer_name != null",   "field": "observer.name", "value": "{{winlog.computer_name}}", "override": true }  },
     { "set":           { "field": "event.code", "value": "{{winlog.event_id}}", "override": true }  },  
     { "set":           { "field": "event.category", "value": "host", "override": true }  },   
-    { "rename": 	   { "field": "winlog.event_data.SubjectUserName", 			  "target_field": "user.name",		"ignore_missing": true 	} },
+    { "rename": 	   { "field": "winlog.event_data.SubjectUserName", 			  "target_field": "user.name",		"ignore_failure": true,   "ignore_missing": true 	} },
     { "rename": 	   { "field": "winlog.event_data.User", 			            "target_field": "user.name",		"ignore_missing": true 	} }
   ]
 }


### PR DESCRIPTION
For some event ids (for example 4688), the field 'SubjectUserName' already been converted to 'user.name' in winlogbeat JS processor.
Therefore, elasticsearch ingest pipeline win.eventlog throws [user.name] already exists error.

Here is part of winlogbeat-security.js:
<img width="709" alt="Screen Shot 2020-11-24 at 16 30 17" src="https://user-images.githubusercontent.com/74374518/100114835-83611e80-2e7a-11eb-973f-98e3d2c616ed.png">
<img width="730" alt="Screen Shot 2020-11-24 at 16 31 36" src="https://user-images.githubusercontent.com/74374518/100114873-8e1bb380-2e7a-11eb-9a08-2cbe5726ea70.png">

[winlogbeat-security.js](https://github.com/elastic/beats/blob/master/x-pack/winlogbeat/module/security/config/winlogbeat-security.js)

Ignore failure for winlog.event_data.SubjectUserName rename processor, to rename SubjectUserName only when needed.