### PR TITLE
calculate log_size_limit based on /nsm/elasticsearch

### DIFF
--- a/setup/so-functions
+++ b/setup/so-functions
@@ -1743,6 +1743,9 @@ set_default_log_size() {
 	if [ -d /nsm ]; then
 		disk_dir="/nsm"
 	fi
+	if [ -d /nsm/elasticsearch ]; then
+		disk_dir="/nsm/elasticsearch"
+	fi
 	local disk_size_1k
 	disk_size_1k=$(df $disk_dir | grep -v "^Filesystem" | awk '{print $2}')
 


### PR DESCRIPTION
Extend the directory traversal into /nsm/elasticsearch in case that's a separate mountpoint from /nsm/.  That way, if /nsm/elasticsearch is on its own filesystem, it will calculate the default log_size_limit correctly.

Issue #2995.