### PR TITLE
Fix so-rule apply - manually tested

### DIFF
--- a/salt/common/tools/sbin/so-rule
+++ b/salt/common/tools/sbin/so-rule
@@ -37,11 +37,9 @@ def print_err(string: str):
 
 
 def check_apply(args: dict, prompt: bool = True):
-  cmd_arr = ['salt-call', 'state.apply', 'idstools', 'queue=True']
-
   if args.apply:
-    print('Configuration updated. Applying idstools state...')
-    return subprocess.run(cmd_arr)
+    print('Configuration updated. Applying changes:')
+    return apply()
   else:
     if prompt:
       message = 'Configuration updated. Would you like to apply your changes now? (y/N) '
@@ -51,10 +49,22 @@ def check_apply(args: dict, prompt: bool = True):
       if answer.lower() in [ 'n', '' ]:
         return 0
       else:
-        print('Applying idstools state...')
-        return subprocess.run(cmd_arr)
+        print('Applying changes:')
+        return apply()
     else:
       return 0
+
+
+def apply():
+  salt_cmd = ['salt-call', 'state.apply', '-l', 'quiet', 'idstools.sync_files', 'queue=True']
+  update_cmd = ['so-rule-update']
+  print('Syncing config files...')
+  cmd = subprocess.run(salt_cmd, stdout=subprocess.DEVNULL)
+  if cmd.returncode == 0:
+    print('Updating rules...')
+    return subprocess.run(update_cmd).returncode
+  else:
+    return cmd.returncode
 
 
 def find_minion_pillar() -> str:
@@ -442,10 +452,7 @@ def main():
         modify.print_help()
     sys.exit(0)
   
-  if isinstance(exit_code, subprocess.CompletedProcess):
-    sys.exit(exit_code.returncode)
-  else:
-    sys.exit(exit_code)
+  sys.exit(exit_code)
 
 
 if __name__ == '__main__':

--- a/salt/idstools/init.sls
+++ b/salt/idstools/init.sls
@@ -19,13 +19,12 @@
 {% set IMAGEREPO = salt['pillar.get']('global:imagerepo') %}
 {% set MANAGER = salt['grains.get']('master') %}
 {% set ENGINE = salt['pillar.get']('global:mdengine', '') %}
+{% set proxy = salt['pillar.get']('manager:proxy') %}
+
+include:
+  - idstools.sync_files
+
 # IDSTools Setup
-idstoolsdir:
-  file.directory:
-    - name: /opt/so/conf/idstools/etc
-    - user: 939
-    - group: 939
-    - makedirs: True
 
 idstoolslogdir:
   file.directory:
@@ -34,37 +33,12 @@ idstoolslogdir:
     - group: 939
     - makedirs: True
 
-idstoolsetcsync:
-  file.recurse:
-    - name: /opt/so/conf/idstools/etc
-    - source: salt://idstools/etc
-    - user: 939
-    - group: 939
-    - template: jinja
-
 so-ruleupdatecron:
   cron.present:
     - name: /usr/sbin/so-rule-update > /opt/so/log/idstools/download.log 2>&1
     - user: root
     - minute: '1'
     - hour: '7'
-
-rulesdir:
-  file.directory:
-    - name: /opt/so/rules/nids
-    - user: 939
-    - group: 939
-    - makedirs: True
-
-# Don't show changes because all.rules can be large
-synclocalnidsrules:
-  file.recurse:
-    - name: /opt/so/rules/nids/
-    - source: salt://idstools/
-    - user: 939
-    - group: 939
-    - show_changes: False
-    - include_pat: 'E@.rules'
 
 so-idstools:
   docker_container.running:

--- a/salt/idstools/sync_files.sls
+++ b/salt/idstools/sync_files.sls
@@ -1,0 +1,46 @@
+# Copyright 2014,2015,2016,2017,2018 Security Onion Solutions, LLC
+
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+idstoolsetcsync:
+  file.recurse:
+    - name: /opt/so/conf/idstools/etc
+    - source: salt://idstools/etc
+    - user: 939
+    - group: 939
+    - template: jinja
+
+idstoolsdir:
+  file.directory:
+    - name: /opt/so/conf/idstools/etc
+    - user: 939
+    - group: 939
+    - makedirs: True
+
+rulesdir:
+  file.directory:
+    - name: /opt/so/rules/nids
+    - user: 939
+    - group: 939
+    - makedirs: True
+
+# Don't show changes because all.rules can be large
+synclocalnidsrules:
+  file.recurse:
+    - name: /opt/so/rules/nids/
+    - source: salt://idstools/
+    - user: 939
+    - group: 939
+    - show_changes: False
+    - include_pat: 'E@.rules'

--- a/salt/idstools/sync_files.sls
+++ b/salt/idstools/sync_files.sls
@@ -13,6 +13,13 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+idstoolsdir:
+  file.directory:
+    - name: /opt/so/conf/idstools/etc
+    - user: 939
+    - group: 939
+    - makedirs: True
+
 idstoolsetcsync:
   file.recurse:
     - name: /opt/so/conf/idstools/etc
@@ -20,13 +27,6 @@ idstoolsetcsync:
     - user: 939
     - group: 939
     - template: jinja
-
-idstoolsdir:
-  file.directory:
-    - name: /opt/so/conf/idstools/etc
-    - user: 939
-    - group: 939
-    - makedirs: True
 
 rulesdir:
   file.directory:


### PR DESCRIPTION
Break out the file management portion of the idstools state into a sub-state since that's the only part of the state so-rule needs to apply.

Then, change the apply function to apply that state and run so-rule-update.

Closes #3289 