### PR TITLE
prevent salt warning about file mode

### DIFF
--- a/salt/suricata/init.sls
+++ b/salt/suricata/init.sls
@@ -184,7 +184,7 @@ so-suricata-eve-clean:
     - name: /usr/sbin/so-suricata-eve-clean
     - user: root
     - group: root
-    - file_mode: 755
+    - mode: 755
     - template: jinja
     - source: salt://suricata/cron/so-suricata-eve-clean
 


### PR DESCRIPTION
The 'file_mode' argument will be ignored.  Please use 'mode' instead to set file permissions.