### PR TITLE
Update node.cfg

### DIFF
--- a/salt/zeek/files/node.cfg
+++ b/salt/zeek/files/node.cfg
@@ -32,7 +32,7 @@ lb_procs={{ salt['pillar.get']('sensor:zeek_lbprocs', '1') }}
 lb_procs={{ salt['pillar.get']('sensor:zeek_pins')|length }}
   {%- endif %}
   {%- if salt['pillar.get']('sensor:zeek_pins') %}
-pin_cpus={{ salt['pillar.get']('sensor:zeek_pins')|join(", ") }}
+pin_cpus={{ salt['pillar.get']('sensor:zeek_pins') }}
   {%- endif %}
 af_packet_fanout_id=23
 af_packet_fanout_mode=AF_Packet::FANOUT_HASH

--- a/salt/zeek/files/node.cfg
+++ b/salt/zeek/files/node.cfg
@@ -28,8 +28,6 @@ interface=af_packet::{{ interface }}
 lb_method=custom
   {%- if salt['pillar.get']('sensor:zeek_lbprocs') %}
 lb_procs={{ salt['pillar.get']('sensor:zeek_lbprocs', '1') }}
-    {%- else %}
-lb_procs={{ salt['pillar.get']('sensor:zeek_pins')|length }}
   {%- endif %}
   {%- if salt['pillar.get']('sensor:zeek_pins') %}
 pin_cpus={{ salt['pillar.get']('sensor:zeek_pins') }}


### PR DESCRIPTION
pin_cpus={{ salt['pillar.get']('sensor:zeek_pins')|join(", ") }} -- the "join(", ") adds extra spaces in the node.cfg file if setting zeek_pins in the minion salt files. 

The syntax is incorrect as every characters gets the extra spacing, the following are examples of the effect:
"zeek_pins: 12"  == "pin_cpus=1, 2, "
"zeek_pins: 1, 2" == "pin_cpus="1, ,,  , 2, "

This is really off for double-digit cpus cores:
"zeek_pins: 10111213" == "pin_cpus: 1, 0, 1, 1, 1, 2, 1, 3, "
"zeek_pins: 10, 11, 12, 13" == "pin_cpus: 1, 0, ,, , 1, 1, ,,  , 1, 2, ,,  , 1, 3, "

Removing the extra join allow the CPU pinning to be successfully set in the salt files with "zeek_pins: 1, 2, 3"