### PR TITLE
fix 5-second sleep

### DIFF
--- a/salt/common/tools/sbin/so-playbook-reset
+++ b/salt/common/tools/sbin/so-playbook-reset
@@ -22,5 +22,5 @@ salt-call state.apply playbook.db_init,playbook,playbook.automation_user_create
 /usr/sbin/so-soctopus-restart
 
 echo "Importing Plays - this will take some time...."
-wait 5
+sleep 5
 /usr/sbin/so-playbook-ruleupdate


### PR DESCRIPTION
Using wait here instead of sleep tries to wait until pid 5 exits, but instead generates the error:
> /usr/sbin/so-playbook-reset: line 25: wait: pid 5 is not a child of this shell
What you meant to use was sleep.