### PR TITLE
Pipeline userpass

### DIFF
--- a/salt/common/init.sls
+++ b/salt/common/init.sls
@@ -3,6 +3,12 @@
 
 {% set role = grains.id.split('_') | last %}
 {% from 'elasticsearch/auth.map.jinja' import ELASTICAUTH with context %}
+{% set ES_INCLUDED_NODES = ['so-standalone'] %}
+
+{% if grains.role in ES_INCLUDED_NODES %}
+include:
+  - elasticsearch.auth
+{% %}
 
 # Remove variables.txt from /tmp - This is temp
 rmvariablesfile:
@@ -179,7 +185,10 @@ utilsyncscripts:
     - source: salt://common/tools/sbin
     - defaults:
         ELASTICCURL: {{ ELASTICAUTH.elasticcurl }}
-
+{% if grains.role in ES_INCLUDED_NODES %}
+    - require:
+      - file: elastic_auth_pillar
+{% endif %}
 
 {% if role in ['eval', 'standalone', 'sensor', 'heavynode'] %}
 # Add sensor cleanup

--- a/salt/elasticsearch/auth.map.jinja
+++ b/salt/elasticsearch/auth.map.jinja
@@ -1,7 +1,7 @@
 {% set ELASTICAUTH = salt['pillar.filter_by']({
     True: {
-      'user': salt['pillar.get']('elasticsearch:auth:user'), 
-      'pass': salt['pillar.get']('elasticsearch:auth:pass'), 
+      'user': salt['pillar.get']('elasticsearch:auth:users:so_elastic_user:user'), 
+      'pass': salt['pillar.get']('elasticsearch:auth:users:so_elastic_user:pass'), 
       'elasticcurl':'curl -K /opt/so/conf/elasticsearch/curl.config' },
     False: {'elasticcurl': 'curl'},
 }, pillar='elasticsearch:auth:enabled', default=False) %}

--- a/salt/elasticsearch/auth.sls
+++ b/salt/elasticsearch/auth.sls
@@ -5,8 +5,27 @@ elastic_auth_pillar:
         elasticsearch:
           auth:
             enabled: False
-            user: so_elastic
-            pass: {{ salt['random.get_str'](20) }}
+            users:
+              so_elastic_user:
+                user: so_elastic
+                pass: {{ salt['random.get_str'](20) }}
+              so_kibana_user:
+                user: so_kibana
+                pass: {{ salt['random.get_str'](20) }}
+              so_logstash_user:
+                user: so_logstash
+                pass: {{ salt['random.get_str'](20) }}
+              so_beats_user:
+                user: so_beats
+                pass: {{ salt['random.get_str'](20) }}
+              so_monitor_user:
+                user: so_monitor
+                pass: {{ salt['random.get_str'](20) }}
     # since we are generating a random password, and we don't want that to happen everytime
-    # a highstate runs, we only manage the file if it doesn't exist
-    - unless: ls /opt/so/saltstack/local/pillar/elasticsearch/auth.sls
+    # a highstate runs, we only manage the file each user isn't present in the file. if the
+    # pillar file doesn't exists, then the default vault provided to pillar.get should not
+    # be within the file either, so it should then be created
+    - unless:
+    {% for so_app_user in salt['pillar.get']('elasticsearch:auth:users', {'so_noapp_user': {'user': 'r@NDumu53Rd0NtDOoP'}}) %}
+      - grep {{ so_app_user.user }} /opt/so/saltstack/local/pillar/elasticsearch/auth.sls
+    {% endfor%}

--- a/salt/elasticsearch/init.sls
+++ b/salt/elasticsearch/init.sls
@@ -293,7 +293,7 @@ elastic_curl_config:
   file.managed:
     - name: /opt/so/conf/elasticsearch/curl.config
     - mode: 600
-    - contents: user = "{{ salt['pillar.get']('elasticsearch:auth:user') }}:{{ salt['pillar.get']('elasticsearch:auth:pass') }}"
+    - contents: user = "{{ salt['pillar.get']('elasticsearch:auth:users:so_elastic_user:user') }}:{{ salt['pillar.get']('elasticsearch:auth:users:so_elastic_user:pass') }}"
     - show_changes: False
 
 {% endif %} {# if grains['role'] != 'so-helix' #}

--- a/salt/manager/init.sls
+++ b/salt/manager/init.sls
@@ -20,6 +20,9 @@
 {% set MANAGER = salt['grains.get']('master') %}
 {% set STRELKA_RULES = salt['pillar.get']('strelka:rules', '1') %}
 
+include:
+  - elasticsearch.auth
+
 socore_own_saltstack:
   file.directory:
     - name: /opt/so/saltstack


### PR DESCRIPTION
elasticsearch.auth pillar is now created when manager state runs so that it will be created sooner during setup and not fail later when the common state runs. common state now includes it since it requires that pillar file to exist to manage so-user