### PR TITLE
Use correct syntax for tar to drop directory structure

### DIFF
--- a/salt/common/tools/sbin/soup
+++ b/salt/common/tools/sbin/soup
@@ -289,7 +289,7 @@ generate_and_clean_tarballs() {
   local new_version
   new_version=$(cat $UPDATE_DIR/VERSION)
   [ -d /opt/so/repo ] || mkdir -p /opt/so/repo
-  tar -czf "/opt/so/repo/$new_version.tar.gz" "$UPDATE_DIR"
+  tar -czf "/opt/so/repo/$new_version.tar.gz" -C "$UPDATE_DIR" .
   find "/opt/so/repo" -type f -not -name "$new_version.tar.gz" -exec rm -rf {} \;
 }
 

--- a/setup/so-functions
+++ b/setup/so-functions
@@ -1426,7 +1426,7 @@ generate_passwords(){
 
 generate_repo_tarball() {
 	mkdir /opt/so/repo
-	tar -czf /opt/so/repo/"$SOVERSION".tar.gz ../.
+	tar -czf /opt/so/repo/"$SOVERSION".tar.gz -C "$(pwd)/.." .
 }
 
 generate_sensor_vars() {


### PR DESCRIPTION
Fix manually tested to ensure folder structure is as expected.