### PR TITLE
powershell fields is unsearchable

### DIFF
--- a/salt/elasticsearch/templates/so/so-common-template.json
+++ b/salt/elasticsearch/templates/so/so-common-template.json
@@ -540,7 +540,11 @@
 	"zeek":{
           "type":"object",
           "dynamic": true
-        }
+        },
+	"powershell":{
+	  "type":"object",
+	  "dynamic": true
+	}
      }
   }
 }


### PR DESCRIPTION
powershell fields did not work and was unindexed
and because of that you couldn't search on this fields

events ID's: 400, 403, 600, 800, 4103, 4104, 4105, 4106 etc.
had powershell. fields that defined as unindexed and were not included in the index pattern
It caused the fields to be unsearchable

Doc with powershell fields for example:
{
"_index" : "so-beats-2021.06.22",
"_type" : "_doc",
"_id" : "iPseM3oBcHOnuak1d6OP",
"_score" : 1.0,
"_source" : {
"process" : {
"args" : [
"""C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe""",
"-ExecutionPolicy",
"Unrestricted",
"-Noninteractive",
"-NoProfile",
"-NoLogo",
"-File",
"""C:\Program""",
"""Files\Microsoft""",
"Dependency",
"""Agent\plugins\AzureMetadata.ps1"""
],
"args_count" : 11,
"title" : "ConsoleHost",
"entity_id" : "2a4e0f3e-28d0-43ad-be01-419844fe9716",
"command_line" : """C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe -ExecutionPolicy Unrestricted -Noninteractive -NoProfile -NoLogo -File C:\Program Files\Microsoft Dependency Agent\plugins\AzureMetadata.ps1"""
},
"agent" : {
"hostname" : "Airgap-SO-Solo",
"name" : "Airgap-SO-Solo",
"id" : "5ce9a7b4-8f55-4ecd-9cf5-0f380fc3a215",
"type" : "winlogbeat",
"ephemeral_id" : "53b21be9-7be2-46e9-8e33-ed3ec77fdfa7",
"version" : "7.13.2"
},
"winlog" : {
"computer_name" : "Airgap-SO-Solo",
"record_id" : 7907,
"event_id" : "400",
"task" : "Engine Lifecycle",
"keywords" : [
"Classic"
],
"channel" : "Windows PowerShell",
"api" : "wineventlog",
"provider_name" : "PowerShell",
"opcode" : "Info"
},
"log" : {
"level" : "information"
},
"message" : """Engine state is changed from None to Available.

Details:
NewEngineState=Available
PreviousEngineState=None

SequenceNumber=13

HostName=ConsoleHost
HostVersion=5.1.19041.906
HostId=2a4e0f3e-28d0-43ad-be01-419844fe9716
HostApplication=C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe -ExecutionPolicy Unrestricted -Noninteractive -NoProfile -NoLogo -File C:\Program Files\Microsoft Dependency Agent\plugins\AzureMetadata.ps1
EngineVersion=5.1.19041.906
RunspaceId=426b8da0-a32a-48d5-9727-6087294fdbc8
PipelineId=
CommandName=
CommandType=
ScriptName=
CommandPath=
CommandLine=""",
"tags" : [
"beat-ext",
"beats_input_codec_plain_applied"
],
"cloud" : {
"instance" : {
"name" : "Airgap-SO-Solo",
"id" : "5771c1a0-dcab-4901-9894-a5dcfc5956be"
},
"provider" : "azure",
"service" : {
"name" : "Virtual Machines"
},
"machine" : {
"type" : "Standard_D8s_v3"
},
"region" : "SwitzerlandNorth",
"account" : { }
},
"observer" : {
"name" : "Airgap-SO-Solo"
},
"@timestamp" : "2021-06-22T09:43:00.331Z",
"ecs" : {
"version" : "1.9.0"
},
"powershell" : {
"process" : {
"executable_version" : "5.1.19041.906"
},
"engine" : {
"previous_state" : "None",
"new_state" : "Available",
"version" : "5.1.19041.906"
},
"runspace_id" : "426b8da0-a32a-48d5-9727-6087294fdbc8"
},
"host" : {
"hostname" : "Airgap-SO-Solo",
"os" : {
"build" : "19042.985",
"kernel" : "10.0.19041.985 (WinBuild.160101.0800)",
"name" : "Windows 10 Pro",
"family" : "windows",
"type" : "windows",
"version" : "10.0",
"platform" : "windows"
},
"ip" : [
"fe80::545a:d4:d904:5d9e",
"10.6.0.6",
"fe80::9999:740f:8766:ba9a",
"192.168.56.1"
],
"name" : "Airgap-SO-Solo",
"id" : "d3644997-39e6-4804-9248-c12158784c99",
"mac" : [
"00:22:48:12:f9:fd",
"0a:00:27:00:00:05"
],
"architecture" : "x86_64"
},
"@Version" : "1",
"event" : {
"sequence" : 13,
"code" : "400",
"provider" : "PowerShell",
"kind" : "event",
"created" : "2021-06-22T09:43:00.567Z",
"module" : "powershell",
"action" : "Engine Lifecycle",
"type" : [
"start"
],
"category" : "host",
"dataset" : "windows powershell"
}
}
}

as you can see the powershell object field doesn't mapped in the so-common-template