### PR TITLE
Add `--force` flag to idstools-rulecat under so-rule-update

### DIFF
--- a/salt/common/tools/sbin/so-rule-update
+++ b/salt/common/tools/sbin/so-rule-update
@@ -10,4 +10,4 @@ got_root() {
 }
 
 got_root
-docker exec so-idstools /bin/bash -c "cd /opt/so/idstools/etc && idstools-rulecat $1"
+docker exec so-idstools /bin/bash -c "cd /opt/so/idstools/etc && idstools-rulecat --force $1"


### PR DESCRIPTION
This forces idstools to pull from the url each time, which prevents it from clearing all.rules if idstools-rulecat is run twice within 15 minutes by any method (either restarting the container or running so-rule-update)