### PR TITLE
safe load yaml config in so-firewall

### DIFF
--- a/salt/common/tools/sbin/so-firewall
+++ b/salt/common/tools/sbin/so-firewall
@@ -71,7 +71,7 @@ def checkApplyOption(options):
 
 def loadYaml(filename):
   file = open(filename, "r")
-  return yaml.safe_load(file.read())
+  return yaml.safe_load(file.read()) 
 
 def writeYaml(filename, content):
   file = open(filename, "w")

--- a/salt/common/tools/sbin/so-firewall
+++ b/salt/common/tools/sbin/so-firewall
@@ -71,7 +71,7 @@ def checkApplyOption(options):
 
 def loadYaml(filename):
   file = open(filename, "r")
-  return yaml.load(file.read())
+  return yaml.safe_load(file.read())
 
 def writeYaml(filename, content):
   file = open(filename, "w")


### PR DESCRIPTION
When testing #5601, I noticed there was an unsafe yaml load warning flagging in so-firewall. After checking for other references for `yaml.load()` I noticed there were none but there were a few `yaml.safe_load()` calls. 

This simply changes `yaml.load` to `yaml.safe_load` in salt/common/tools/sbin/so-firewall.