### PR TITLE
Remove tty flag for docker, omit sourcing common

### DIFF
--- a/salt/common/tools/sbin/so-redis-count
+++ b/salt/common/tools/sbin/so-redis-count
@@ -15,6 +15,4 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-. /usr/sbin/so-common
-
-docker exec -it so-redis redis-cli llen logstash:unparsed
+docker exec -i so-redis redis-cli llen logstash:unparsed


### PR DESCRIPTION
Having the '-t' flag present for docker exec allocates a tty.  This prevents running the command on all cluster members from the salt master via a command such as

> salt '*' cmd.run 'so-redis-count'

In addition, there are no dependencies on any definitions in so-common.  There is no need to source the file.  In fact, doing so adds the "must be root" dependency, which, if the user is a member of the docker group, is not true for this command.  The error when trying to run docker exec from a user that is not a member of the docker group is obviously enough a permissions error that a user should know to rerun as root.