### PR TITLE
featreq: remove tty flag in redis-count script

### DIFF
--- a/salt/common/tools/sbin/so-redis-count
+++ b/salt/common/tools/sbin/so-redis-count
@@ -17,4 +17,4 @@
 
 . /usr/sbin/so-common
 
-docker exec -it so-redis redis-cli llen logstash:unparsed
+docker exec so-redis redis-cli llen logstash:unparsed


### PR DESCRIPTION
Calling so-redis-count just calls to docker exec and returns a number.  No interaction (stdin) or tty is required.  Specifically, having the -t option prevents running via salt using a command such as:

> salt '*' cmd.run 'so-redis-count'