### PR TITLE
Run `check_network_manager_conf()` later in setup

### DIFF
--- a/setup/so-functions
+++ b/setup/so-functions
@@ -1849,8 +1849,6 @@ minio_generate_keys() {
 network_init() {
 	disable_ipv6
 	set_hostname
-	echo "Verifying all network devices are managed by Network Manager" >> "$setup_log" 2>&1
-	check_network_manager_conf
 	if [[ "$setup_type" == 'iso' ]]; then
 		set_management_interface
 	fi

--- a/setup/so-setup
+++ b/setup/so-setup
@@ -443,6 +443,8 @@ if [[ $is_helix ]]; then
 fi
 
 if [[ $is_helix || $is_sensor ]]; then
+	echo "Verifying all network devices are managed by Network Manager that should be" >> "$setup_log" 2>&1
+	check_network_manager_conf
 	set_network_dev_status_list
 	whiptail_sensor_nics
 fi


### PR DESCRIPTION
The directory was being overwritten when network-manager was installed later