### PR TITLE
add subjectAltName to filebeat.crt

### DIFF
--- a/salt/ssl/init.sls
+++ b/salt/ssl/init.sls
@@ -517,6 +517,7 @@ conf_filebeat_crt:
     - signing_policy: filebeat
     - public_key: /opt/so/conf/filebeat/etc/pki/filebeat.key
     - CN: {{ COMMONNAME }}
+    - subjectAltName: DNS:{{ HOSTNAME }}, IP:{{ MAINIP }}
     - days_remaining: 0
     - days_valid: 820
     - backup: True


### PR DESCRIPTION
IP SAN is required for Endgame integration w/Logstash when DNS resolution is unavailable