### PR TITLE
Shorten timeout when looking for the Elastic Host

### DIFF
--- a/salt/elasticsearch/files/so-elasticsearch-pipelines
+++ b/salt/elasticsearch/files/so-elasticsearch-pipelines
@@ -26,8 +26,8 @@ ELASTICSEARCH_INGEST_PIPELINES="/opt/so/conf/elasticsearch/ingest/"
 echo -n "Waiting for ElasticSearch..."
 COUNT=0
 ELASTICSEARCH_CONNECTED="no"
-while [[ "$COUNT" -le 240 ]]; do
-    {{ ELASTICCURL }} -k --output /dev/null --silent --head --fail -L https://"$ELASTICSEARCH_HOST":"$ELASTICSEARCH_PORT"
+while [[ "$COUNT" -le 10 ]]; do
+    {{ ELASTICCURL }} -k --connection-timeout 60 --output /dev/null --silent --head --fail -L https://"$ELASTICSEARCH_HOST":"$ELASTICSEARCH_PORT"
 	if [ $? -eq 0 ]; then
 		ELASTICSEARCH_CONNECTED="yes"
 		echo "connected!"


### PR DESCRIPTION
Shorten timeout when curling the Elastic Manager from 4 hours( `240 * 60`) to 10 minutes.


[1] Reduce curl attempts from 240 to 10.
 
[2] The default timeout for the curl command can range from 60 to 120 seconds. Hard code this value instead of relying on the OS to make this determination for us.