### PR TITLE
Add logger stanza to suppress ES deprecation warning messages

### DIFF
--- a/salt/elasticsearch/defaults.yaml
+++ b/salt/elasticsearch/defaults.yaml
@@ -58,6 +58,10 @@ elasticsearch:
           max_clause_count: 1500
       id_field_data:
         enabled: false
+    logger:
+      org:
+        elasticsearch:
+          deprecation: ERROR
 
 
 


### PR DESCRIPTION
Add logger stanza to suppress deprecation warning messages for now due to current system index access warning messages flooding the ES log