### PR TITLE
enh: optimize so-status ANSI control codes

### DIFF
--- a/salt/common/tools/sbin/so-status
+++ b/salt/common/tools/sbin/so-status
@@ -190,9 +190,11 @@ print_line() {
     fi
 
     printf "    $service_name "
+    printf "${state_color}"
     for i in $(seq 0 $(( $columns - $PADDING_CONSTANT - ${#service_name} - ${#service_state} ))); do
-        printf "${state_color}%b\e[0m" "-"
+        printf "-"
     done
+    printf "\e[0m"
     printf " [ "
     printf "${state_color}%b\e[0m" "$service_state"
     printf "%s    \n" " ]"


### PR DESCRIPTION
When running over a slow ssh connection, the amount of ansi control codes slows in so-status can affect the display speed.  This is because the color is changed then restored on each dash connecting a service's name to its status.  On a wide terminal, this increases the amount output by nearly an order of magnitude.  Changing the color before the first dash and restoring it after the last makes this faster.

Example of total characters transferred on a 130-char width terminal:
Before patch:
> ~/git/securityonion/salt/common/tools/sbin# ./so-status|wc
     38     163   39196

After patch:
> ~/git/securityonion/salt/common/tools/sbin# ./so-status|wc
     38     163    4821

Showing a reduction from nearly 40kb to less than 5kb with no change in line or word counts.