### PR TITLE
FIX: Correctly handle failure to install curl in so-preflight

### DIFF
--- a/setup/so-preflight
+++ b/setup/so-preflight
@@ -169,11 +169,15 @@ __check_url_arr() {
 }
 
 preflight_prereqs() {
+	local ret_code=0
+	
 	if [[ $OS == 'centos' ]]; then
 		: # no-op to match structure of other checks for $OS var
 	else
-		retry 50 10 "apt-get -y install curl" >> "$preflight_log" 2>&1 || exit 1
+		retry 50 10 "apt-get -y install curl" >> "$preflight_log" 2>&1 || ret_code=1
 	fi
+
+	return $ret_code
 }
 
 main() {
@@ -190,6 +194,7 @@ main() {
 	else
 		echo "$intro_str" | tee "$preflight_log"
 	fi
+
 	check_default_repos &&\
 	preflight_prereqs &&\
 	check_new_repos &&\


### PR DESCRIPTION
Use ret_code in prereq function to return failures