### PR TITLE
Fix typos in ssh_warning

### DIFF
--- a/setup/so-setup
+++ b/setup/so-setup
@@ -1015,7 +1015,7 @@ else
 
 	echo "Post-installation steps have completed. Awaiting user input to clean up installer." >> $setup_log 2>&1
 	whiptail_setup_complete
-	[[ $setup_type != 'iso' ]] && whitpail_ssh_warning
+	[[ $setup_type != 'iso' ]] && whiptail_ssh_warning
 fi
 
 install_cleanup >> "$setup_log" 2>&1

--- a/setup/so-whiptail
+++ b/setup/so-whiptail
@@ -1813,7 +1813,7 @@ whitpail_ssh_warning() {
 	local msg
 
 	read -r -d '' msg <<- EOM
-	NOTE: You will recceive a warning upon SSH reconnect that the host key has changed.
+	NOTE: You will receive a warning upon SSH reconnect that the host key has changed.
 
 	This is expected due to hardening of the OpenSSH server config.
 	

--- a/setup/so-whiptail
+++ b/setup/so-whiptail
@@ -1807,7 +1807,7 @@ whiptail_ssh_key_copy_notice() {
 	whiptail_check_exitstatus $exitstatus
 }
 
-whitpail_ssh_warning() {
+whiptail_ssh_warning() {
 	[ -n "$TESTING" ] && return
 
 	local msg


### PR DESCRIPTION
Rename `whitpail_ssh_warning` to `whiptail_ssh_warning` and change `recceive` to `receive`.