### PR TITLE
Move Kibana dashboard update from post_to_2.3.90() to post_to_2.3.100()

### DIFF
--- a/salt/common/tools/sbin/soup
+++ b/salt/common/tools/sbin/soup
@@ -442,9 +442,6 @@ post_to_2.3.60() {
 }
 
 post_to_2.3.90() {
-  # Do Kibana dashboard things
-  salt-call state.apply kibana.so_savedobjects_defaults queue=True
-
   # Create FleetDM service account
     FLEET_MANAGER=$(lookup_pillar fleet_manager)
     if [[ "$FLEET_MANAGER" == "True" ]]; then
@@ -468,7 +465,9 @@ post_to_2.3.90() {
 }
 
 post_to_2.3.100() {
-  echo "Post Processing for .100"
+  echo "Post Processing for 2.3.100"
+  echo "Updating Kibana dashboards"
+  salt-call state.apply kibana.so_savedobjects_defaults queue=True
 }
 
 stop_salt_master() {


### PR DESCRIPTION
Updating from 2.3.91 to 2.3.100 was not updating Kibana dashboards. Moved Kibana dashboard update from `post_to_2.3.90()` to `post_to_2.3.100()`.

Tested as follows:
- 2.3.91 IMPORT VM
- 2.3.91 distributed deployment

Verified Kibana dashboards successfully updated.