### PR TITLE
Allow downgrades in docker_install

### DIFF
--- a/setup/so-functions
+++ b/setup/so-functions
@@ -1223,12 +1223,12 @@ docker_install() {
 		if [ $OSVER == "bionic" ]; then
 		        service docker stop
 			apt -y purge docker-ce docker-ce-cli docker-ce-rootless-extras
-			retry 50 10 "apt-get -y install docker-ce=5:20.10.5~3-0~ubuntu-bionic docker-ce-cli=5:20.10.5~3-0~ubuntu-bionic docker-ce-rootless-extras=5:20.10.5~3-0~ubuntu-bionic python3-docker" >> "$setup_log" 2>&1 || exit 1
+			retry 50 10 "apt-get -y install --allow-downgrades docker-ce=5:20.10.5~3-0~ubuntu-bionic docker-ce-cli=5:20.10.5~3-0~ubuntu-bionic docker-ce-rootless-extras=5:20.10.5~3-0~ubuntu-bionic python3-docker" >> "$setup_log" 2>&1 || exit 1
 	        apt-mark hold docker-ce docker-ce-cli docker-ce-rootless-extras
 		elif [ $OSVER == "focal" ]; then
 		        service docker stop
 			apt -y purge docker-ce docker-ce-cli docker-ce-rootless-extras
-			retry 50 10 "apt-get -y install docker-ce=5:20.10.8~3-0~ubuntu-focal docker-ce-cli=5:20.10.8~3-0~ubuntu-focal docker-ce-rootless-extras=5:20.10.8~3-0~ubuntu-focal python3-docker" >> "$setup_log" 2>&1 || exit 1
+			retry 50 10 "apt-get -y install --allow-downgrades docker-ce=5:20.10.8~3-0~ubuntu-focal docker-ce-cli=5:20.10.8~3-0~ubuntu-focal docker-ce-rootless-extras=5:20.10.8~3-0~ubuntu-focal python3-docker" >> "$setup_log" 2>&1 || exit 1
                         apt-mark hold docker-ce docker-ce-cli docker-ce-rootless-extras		
 		fi
 	fi


### PR DESCRIPTION
When running the installer again on a new node, it tries to pull the docker packages but since the installer ran again before, the install command fails on Ubuntu 18.04 stating that the `--allow-downgrades` is not specified in the command. This change adds that to circumvent the issue.