### PR TITLE
make sure that each post_to_* function sets POSTVERSION at end

### DIFF
--- a/salt/common/tools/sbin/soup
+++ b/salt/common/tools/sbin/soup
@@ -468,6 +468,7 @@ post_to_2.3.90() {
 
 post_to_2.3.100() {
   echo "Post Processing for 2.3.100"
+  POSTVERSION=2.3.100
 }
 
 post_to_2.3.110() {
@@ -475,6 +476,7 @@ post_to_2.3.110() {
   echo "Updating Kibana dashboards"
   salt-call state.apply kibana.so_savedobjects_defaults queue=True
   so-playbook-sigma-refresh >> /root/soup_playbook_sigma_refresh.log 2>&1 &
+  POSTVERSION=2.3.110
 }
 
 stop_salt_master() {


### PR DESCRIPTION
soup was not running `post_to_2.3.110` because `post_to_2.3.100` wasn't updating `POSTVERSION` to `2.3.100`. This has been tested and works properly with this fix:
![image](https://user-images.githubusercontent.com/1659467/155796200-e9846aaa-5434-460e-9d22-e901fd901ce3.png)
