### PR TITLE
Avoid changing _index for imported logs

### DIFF
--- a/salt/elasticsearch/files/ingest/zeek.dns
+++ b/salt/elasticsearch/files/ingest/zeek.dns
@@ -23,7 +23,7 @@
     { "rename": 	{ "field": "message2.TTLs", 		"target_field": "dns.ttls",			"ignore_missing": true 	} },
     { "rename": 	{ "field": "message2.rejected", 	"target_field": "dns.query.rejected",		"ignore_missing": true 	} },
     { "script": 	{ "lang": "painless", "source": "ctx.dns.query.length = ctx.dns.query.name.length()",	"ignore_failure": true  } },
-    { "set":            { "field": "_index",        "value": "so-zeek_dns", "override": true           } },
+    { "set":      { "if": "ctx._index == 'so-zeek'", "field": "_index",      "value": "so-zeek_dns", "override": true   } },
     { "pipeline": { "if": "ctx.dns.query?.name != null && ctx.dns.query.name.contains('.')", "name": "dns.tld" } },
     { "pipeline":       { "name": "zeek.common"											} }
   ]


### PR DESCRIPTION
Tested and verified that live DNS traffic goes to `so-zeek_dns`:
![image](https://user-images.githubusercontent.com/1659467/155850721-302db32d-78a1-436b-99be-e1334c89ab01.png)

and imported DNS traffic goes to `so-import`:
![image](https://user-images.githubusercontent.com/1659467/155850701-86b1f5ab-6a5a-40fe-9a51-a421ba6e848f.png)
