### PR TITLE
FIX: surilogcompress cron job not running

### DIFF
--- a/salt/suricata/init.sls
+++ b/salt/suricata/init.sls
@@ -36,12 +36,12 @@ suricatagroup:
     - name: suricata
     - gid: 940
 
-# Add ES user
+# Add Suricata user
 suricata:
   user.present:
     - uid: 940
     - gid: 940
-    - home: /opt/so/conf/suricata
+    - home: /nsm/suricata
     - createhome: False
 
 suridir:


### PR DESCRIPTION
The suricata user was originally created with `/opt/so/conf/suricata` as its home directory. I think at some point we changed permissions on `/opt/so/conf` and at that point the `surilogcompress` cron job stopped working. Changing the home directory to `/nsm/suricata` works on all of my PROD systems (including Ubuntu and CentOS).

For more information, please see https://github.com/Security-Onion-Solutions/securityonion/issues/7133.