### PR TITLE
Parsing of RITA Logs

### DIFF
--- a/pillar/logstash/search.sls
+++ b/pillar/logstash/search.sls
@@ -13,4 +13,5 @@ logstash:
         - so/9600_output_ossec.conf.jinja
         - so/9700_output_strelka.conf.jinja
         - so/9800_output_logscan.conf.jinja
+        - so/9801_output_rita.conf.jinja
         - so/9900_output_endgame.conf.jinja

--- a/salt/elasticsearch/files/ingest/rita.beacon
+++ b/salt/elasticsearch/files/ingest/rita.beacon
@@ -1,0 +1,127 @@
+{
+  "description": "RITA Beacons",
+  "processors": [
+    {
+      "set": {
+        "field": "_index",
+        "value": "so-rita",
+        "override": true
+      }
+    },
+    {
+      "csv": {
+        "field": "message",
+        "target_fields": [
+          "beacon.score",
+          "source.ip",
+          "destination.ip",
+          "network.connections",
+          "network.average_bytes",
+          "beacon.interval.range",
+          "beacon.size.range",
+          "beacon.interval.top",
+          "beacon.size.top",
+          "beacon.interval.top_count",
+          "beacon.size.top_count",
+          "beacon.interval.skew",
+          "beacon.size.skew",
+          "beacon.interval.dispersion",
+          "beacon.size.dispersion",
+          "network.bytes"
+        ]
+      }
+    },
+    {
+      "convert": {
+        "field": "beacon.score",
+        "type": "float"
+      }
+    },
+    {
+      "convert": {
+        "field": "network.connections",
+        "type": "integer"
+      }
+    },
+    {
+      "convert": {
+        "field": "network.average_bytes",
+        "type": "integer"
+      }
+    },
+    {
+      "convert": {
+        "field": "beacon.interval.range",
+        "type": "integer"
+      }
+    },
+    {
+      "convert": {
+        "field": "beacon.size.range",
+        "type": "integer"
+      }
+    },
+    {
+      "convert": {
+        "field": "beacon.interval.top",
+        "type": "integer"
+      }
+    },
+    {
+      "convert": {
+        "field": "beacon.size.top",
+        "type": "integer"
+      }
+    },
+    {
+      "convert": {
+        "field": "beacon.interval.top_count",
+        "type": "integer"
+      }
+    },
+    {
+      "convert": {
+        "field": "beacon.size.top_count",
+        "type": "integer"
+      }
+    },
+    {
+      "convert": {
+        "field": "beacon.interval.skew",
+        "type": "float"
+      }
+    },
+    {
+      "convert": {
+        "field": "beacon.size.skew",
+        "type": "float"
+      }
+    },
+    {
+      "convert": {
+        "field": "beacon.interval.dispersion",
+        "type": "integer"
+      }
+    },
+    {
+      "convert": {
+        "field": "beacon.size.dispersion",
+        "type": "integer"
+      }
+    },
+    {
+      "convert": {
+        "field": "network.bytes",
+        "type": "integer"
+      }
+    },
+    { "set":         { "if": "ctx.beacon?.score == 1", "field": "dataset",        "value": "alert", "override": true }},
+    { "set":         { "if": "ctx.beacon?.score == 1", "field": "rule.name",        "value": "Potential C2 Beacon Activity", "override": true }},
+    { "set":         { "if": "ctx.beacon?.score == 1", "field": "event.severity",        "value": 3, "override": true }},
+    {
+      "pipeline": {
+        "name": "common"
+      }
+    }
+  ]
+}

--- a/salt/elasticsearch/files/ingest/rita.connection
+++ b/salt/elasticsearch/files/ingest/rita.connection
@@ -1,0 +1,36 @@
+{
+  "description": "RITA Connections",
+  "processors": [
+    {
+      "set": {
+        "field": "_index",
+        "value": "so-rita",
+        "override": true
+      }
+    },
+    {
+      "dissect": {
+        "field": "message",
+        "pattern": "%{source.ip},%{destination.ip},%{network.port}:%{network.protocol}:%{network.service},%{connection.duration},%{connection.state}"
+      }
+    },
+    {
+      "convert": {
+        "field": "connection.duration",
+        "type": "float"
+      }
+    },
+    {
+      "set": {
+        "field": "event.duration",
+        "value": "{{ connection.duration }}",
+        "override": true
+      }
+    },
+    {
+      "pipeline": {
+        "name": "common"
+      }
+    }
+  ]
+}

--- a/salt/elasticsearch/files/ingest/rita.dns
+++ b/salt/elasticsearch/files/ingest/rita.dns
@@ -1,0 +1,39 @@
+{
+  "description": "RITA DNS",
+  "processors": [
+    {
+      "set": {
+        "field": "_index",
+        "value": "so-rita",
+        "override": true
+      }
+    },
+    {
+      "csv": {
+        "field": "message",
+        "target_fields": [
+          "dns.question.name",
+          "dns.question.subdomain_count",
+          "dns.question.count"
+        ]
+      }
+    },
+    {
+      "convert": {
+        "field": "dns.question.subdomain_count",
+        "type": "integer"
+      }
+    },
+    {
+      "convert": {
+        "field": "dns.question.count",
+        "type": "integer"
+      }
+    },
+    {
+      "pipeline": {
+        "name": "common"
+      }
+    }
+  ]
+}

--- a/salt/filebeat/etc/filebeat.yml
+++ b/salt/filebeat/etc/filebeat.yml
@@ -10,6 +10,7 @@
 {%- set ZEEKVER = salt['pillar.get']('global:mdengine', 'COMMUNITY') %}
 {%- set WAZUHENABLED = salt['pillar.get']('global:wazuh', '0') %}
 {%- set STRELKAENABLED = salt['pillar.get']('strelka:enabled', '0') %}
+{%- set RITAENABLED = salt['pillar.get']('rita:enabled', False) -%}
 {%- set FLEETMANAGER = salt['pillar.get']('global:fleet_manager', False) -%}
 {%- set FLEETNODE = salt['pillar.get']('global:fleet_node', False) -%}
 {%- set FBMEMEVENTS = salt['pillar.get']('filebeat:mem_events', 2048) -%}
@@ -262,6 +263,54 @@ filebeat.inputs:
   clean_removed: false
   close_removed: false
 
+{%- endif %}
+
+{%- if RITAENABLED %}
+- type: filestream
+  paths:
+    - /nsm/rita/beacons.csv
+  exclude_lines: ['^Score', '^Source', '^Domain']
+  fields:
+    module: rita
+    dataset: beacon
+    category: network
+  processors:
+  - drop_fields:
+      fields: ["source", "prospector", "input", "offset", "beat"]
+  fields_under_root: true
+  pipeline: "rita.beacon"
+  index: "so-rita"
+
+- type: filestream
+  paths:
+    - //nsm/rita/logs/long-connections.csv
+    - /nsm/rita/logs/open-connections.csv
+  exclude_lines: ['^Source']
+  fields:
+    module: rita
+    dataset: connection
+    category: network
+  processors:
+  - drop_fields:
+      fields: ["source", "prospector", "input", "offset", "beat"]
+  fields_under_root: true
+  pipeline: "rita.connection"
+  index: "so-rita"
+
+- type: filestream
+  paths:
+    - /nsm/rita/exploded-dns.csv
+  exclude_lines: ['^Domain']
+  fields:
+    module: rita
+    dataset: dns
+    category: network
+  processors:
+  - drop_fields:
+      fields: ["source", "prospector", "input", "offset", "beat"]
+  fields_under_root: true
+  pipeline: "rita.dns"
+  index: "so-rita"
 {%- endif %}
 
 {%- if grains['role'] in ['so-eval', 'so-standalone', 'so-manager',  'so-managersearch', 'so-import'] %}

--- a/salt/filebeat/etc/filebeat.yml
+++ b/salt/filebeat/etc/filebeat.yml
@@ -283,8 +283,8 @@ filebeat.inputs:
 
 - type: filestream
   paths:
-    - /nsm/rita/logs/long-connections.csv
-    - /nsm/rita/logs/open-connections.csv
+    - /nsm/rita/long-connections.csv
+    - /nsm/rita/open-connections.csv
   exclude_lines: ['^Source']
   fields:
     module: rita

--- a/salt/filebeat/etc/filebeat.yml
+++ b/salt/filebeat/etc/filebeat.yml
@@ -283,7 +283,7 @@ filebeat.inputs:
 
 - type: filestream
   paths:
-    - //nsm/rita/logs/long-connections.csv
+    - /nsm/rita/logs/long-connections.csv
     - /nsm/rita/logs/open-connections.csv
   exclude_lines: ['^Source']
   fields:

--- a/salt/filebeat/etc/filebeat.yml
+++ b/salt/filebeat/etc/filebeat.yml
@@ -269,7 +269,7 @@ filebeat.inputs:
 - type: filestream
   paths:
     - /nsm/rita/beacons.csv
-  exclude_lines: ['^Score', '^Source', '^Domain']
+  exclude_lines: ['^Score', '^Source', '^Domain', '^No results']
   fields:
     module: rita
     dataset: beacon
@@ -285,7 +285,7 @@ filebeat.inputs:
   paths:
     - /nsm/rita/long-connections.csv
     - /nsm/rita/open-connections.csv
-  exclude_lines: ['^Source']
+  exclude_lines: ['^Source', '^No results']
   fields:
     module: rita
     dataset: connection
@@ -300,7 +300,7 @@ filebeat.inputs:
 - type: filestream
   paths:
     - /nsm/rita/exploded-dns.csv
-  exclude_lines: ['^Domain']
+  exclude_lines: ['^Domain', '^No results']
   fields:
     module: rita
     dataset: dns

--- a/salt/logstash/pipelines/config/so/9801_output_rita.conf.jinja
+++ b/salt/logstash/pipelines/config/so/9801_output_rita.conf.jinja
@@ -1,0 +1,22 @@
+{%- if grains['role'] == 'so-eval' -%}
+{%- set ES = salt['pillar.get']('manager:mainip', '') -%}
+{%- else %}
+{%- set ES = salt['pillar.get']('elasticsearch:mainip', '') -%}
+{%- endif %}
+{%- set ES_USER = salt['pillar.get']('elasticsearch:auth:users:so_elastic_user:user', '') %}
+{%- set ES_PASS = salt['pillar.get']('elasticsearch:auth:users:so_elastic_user:pass', '') %}
+output {
+  if [module] =~ "rita" and "import" not in [tags] {
+    elasticsearch {
+      pipeline => "%{module}.%{dataset}"
+      hosts => "{{ ES }}"
+{% if salt['pillar.get']('elasticsearch:auth:enabled') is sameas true %}
+      user => "{{ ES_USER }}"
+      password => "{{ ES_PASS }}"
+{% endif %}
+      index => "so-rita"
+      ssl => true
+      ssl_certificate_verification => false
+    }
+  }
+}


### PR DESCRIPTION
- beacons.csv
- exploded-dns.csv
- long-connections.csv

Disabled by default.  Enabled with:

`rita:enabled:True` in pillar.