### PR TITLE
Run so-kibana-space-defaults when upgrading to 2.3.140

### DIFF
--- a/salt/common/tools/sbin/soup
+++ b/salt/common/tools/sbin/soup
@@ -537,6 +537,7 @@ post_to_2.3.140() {
   echo "Post Processing for 2.3.140"
   FORCE_SYNC=true so-user sync
   so-kibana-restart
+  so-kibana-space-defaults
   POSTVERSION=2.3.140
 }
 


### PR DESCRIPTION
Run so-kibana-space-defaults to re-establish the default enabled features since the Fleet feature name changed.