### PR TITLE
Specify outputs for Elasticsearch and Kibana for Eval and Import Mode

### DIFF
--- a/salt/filebeat/etc/filebeat.yml
+++ b/salt/filebeat/etc/filebeat.yml
@@ -449,6 +449,12 @@ output.elasticsearch:
     - index: "so-logscan"
       when.contains:
         module: "logscan"
+    - index: "so-elasticsearch-%{+YYYY.MM.dd}"
+      when.contains:
+        event.module: "elasticsearch"
+    - index: "so-kibana-%{+YYYY.MM.dd}"
+      when.contains:
+        event.module: "kibana"
   
 setup.template.enabled: false
   {%- else %}


### PR DESCRIPTION
Add outputs for Elasticsearch and Kibana for Eval/Import Mode, since Logstash is not used in Eval Mode or Import Mode. Otherwise, logs from these inputs end up in a filebeat-prefixed index.