### PR TITLE
Update TALOS rules snapshot version

### DIFF
--- a/salt/idstools/etc/rulecat.conf
+++ b/salt/idstools/etc/rulecat.conf
@@ -31,7 +31,7 @@
   {%- elif RULESET == 'ETPRO' %}
 --etpro={{ OINKCODE }}
   {%- elif RULESET == 'TALOS' %}
---url=https://www.snort.org/rules/snortrules-snapshot-2983.tar.gz?oinkcode={{ OINKCODE }}
+--url=https://www.snort.org/rules/snortrules-snapshot-29200.tar.gz?oinkcode={{ OINKCODE }}
   {%- endif %}
 {%- endif %}
 {%- if URLS != None %}


### PR DESCRIPTION
Snort v2.9.83 is very old and Cisco may discontinue building rules snapshots for it at any time.  v2.9.200 is now the most current version, so should be supported for a longer period going forward.