### PR TITLE
Elastic Agent .security subfield additions

### DIFF
--- a/salt/elasticsearch/defaults.yaml
+++ b/salt/elasticsearch/defaults.yaml
@@ -60,6 +60,380 @@ elasticsearch:
         elasticsearch:
           deprecation: ERROR
   index_settings:
+    so-logs-elastic_agent.apm_server:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-elastic_agent.apm_server-*"
+        template:
+          settings:
+            index:
+              mapping:
+                total_fields:
+                  limit: 5000
+              sort:
+                field: "@timestamp"
+                order: desc
+          mappings:
+            _meta:
+              package:
+                name: elastic_agent
+              managed_by: fleet
+              managed: true
+        composed_of:
+          - "so-logs-elastic_agent.apm_server@package"
+          - "so-logs-elastic_agent.apm_server@custom"
+          - ".fleet_globals-1"
+          - ".fleet_agent_id_verification-1"
+        priority: 500
+        _meta:
+          package:
+            name: elastic_agent
+          managed_by: fleet
+          managed: true
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-elastic_agent.auditbeat:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-elastic_agent.auditbeat-*"
+        template:
+          settings:
+            index:
+              mapping:
+                total_fields:
+                  limit: 5000
+              sort:
+                field: "@timestamp"
+                order: desc
+          mappings:
+            _meta:
+              package:
+                name: elastic_agent
+              managed_by: fleet
+              managed: true
+        composed_of:
+          - "so-logs-elastic_agent.auditbeat@package"
+          - "so-logs-elastic_agent.auditbeat@custom"
+          - ".fleet_globals-1"
+          - ".fleet_agent_id_verification-1"
+        priority: 500
+        _meta:
+          package:
+            name: elastic_agent
+          managed_by: fleet
+          managed: true
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-elastic_agent.cloudbeat:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-elastic_agent.cloudbeat-*"
+        template:
+          settings:
+            index:
+              mapping:
+                total_fields:
+                  limit: 5000
+              sort:
+                field: "@timestamp"
+                order: desc
+          mappings:
+            _meta:
+              package:
+                name: elastic_agent
+              managed_by: fleet
+              managed: true
+        composed_of:
+          - "so-logs-elastic_agent.cloudbeat@package"
+          - "so-logs-elastic_agent.cloudbeat@custom"
+          - ".fleet_globals-1"
+          - ".fleet_agent_id_verification-1"
+        priority: 500
+        _meta:
+          package:
+            name: elastic_agent
+          managed_by: fleet
+          managed: true
+        data_stream:
+          hidden: false
+          allow_custom_routing: false    
+    so-logs-elastic_agent.endpoint_security:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-elastic_agent.endpoint_security-*"
+        template:
+          settings:
+            index:
+              mapping:
+                total_fields:
+                  limit: 5000
+              sort:
+                field: "@timestamp"
+                order: desc
+          mappings:
+            _meta:
+              package:
+                name: elastic_agent
+              managed_by: fleet
+              managed: true
+        composed_of:
+          - "so-logs-elastic_agent.endpoint_security@package"
+          - "so-logs-elastic_agent.endpoint_security@custom"
+          - ".fleet_globals-1"
+          - ".fleet_agent_id_verification-1"
+        priority: 500
+        _meta:
+          package:
+            name: elastic_agent
+          managed_by: fleet
+          managed: true
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-elastic_agent.filebeat:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-elastic_agent.filebeat-*"
+        template:
+          settings:
+            index:
+              mapping:
+                total_fields:
+                  limit: 5000
+              sort:
+                field: "@timestamp"
+                order: desc
+          mappings:
+            _meta:
+              package:
+                name: elastic_agent
+              managed_by: fleet
+              managed: true
+        composed_of:
+          - "so-logs-elastic_agent.filebeat@package"
+          - "so-logs-elastic_agent.filebeat@custom"
+          - ".fleet_globals-1"
+          - ".fleet_agent_id_verification-1"
+        priority: 500
+        _meta:
+          package:
+            name: elastic_agent
+          managed_by: fleet
+          managed: true
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-elastic_agent.fleet_server:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-elastic_agent.fleet_server-*"
+        template:
+          settings:
+            index:
+              mapping:
+                total_fields:
+                  limit: 5000
+              sort:
+                field: "@timestamp"
+                order: desc
+          mappings:
+            _meta:
+              package:
+                name: elastic_agent
+              managed_by: fleet
+              managed: true
+        composed_of:
+          - "so-logs-elastic_agent.fleet_server@package"
+          - "so-logs-elastic_agent.fleet_server@custom"
+          - ".fleet_globals-1"
+          - ".fleet_agent_id_verification-1"
+        priority: 500
+        _meta:
+          package:
+            name: elastic_agent
+          managed_by: fleet
+          managed: true
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-elastic_agent.heartbeat:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-elastic_agent.heartbeat-*"
+        template:
+          settings:
+            index:
+              mapping:
+                total_fields:
+                  limit: 5000
+              sort:
+                field: "@timestamp"
+                order: desc
+          mappings:
+            _meta:
+              package:
+                name: elastic_agent
+              managed_by: fleet
+              managed: true
+        composed_of:
+          - "so-logs-elastic_agent.heartbeat@package"
+          - "so-logs-elastic_agent.heartbeat@custom"
+          - ".fleet_globals-1"
+          - ".fleet_agent_id_verification-1"
+        priority: 500
+        _meta:
+          package:
+            name: elastic_agent
+          managed_by: fleet
+          managed: true
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-elastic_agent:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-elastic_agent-*"
+        template:
+          settings:
+            index:
+              mapping:
+                total_fields:
+                  limit: 5000
+              sort:
+                field: "@timestamp"
+                order: desc
+          mappings:
+            _meta:
+              package:
+                name: elastic_agent
+              managed_by: fleet
+              managed: true
+        composed_of:
+          - "so-logs-elastic_agent@package"
+          - "so-logs-elastic_agent@custom"
+          - ".fleet_globals-1"
+          - ".fleet_agent_id_verification-1"
+        priority: 500
+        _meta:
+          package:
+            name: elastic_agent
+          managed_by: fleet
+          managed: true
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-elastic_agent.metricbeat:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-elastic_agent.metricbeat-*"
+        template:
+          settings:
+            index:
+              mapping:
+                total_fields:
+                  limit: 5000
+              sort:
+                field: "@timestamp"
+                order: desc
+          mappings:
+            _meta:
+              package:
+                name: elastic_agent
+              managed_by: fleet
+              managed: true
+        composed_of:
+          - "so-logs-elastic_agent.metricbeat@package"
+          - "so-logs-elastic_agent.metricbeat@custom"
+          - ".fleet_globals-1"
+          - ".fleet_agent_id_verification-1"
+        priority: 500
+        _meta:
+          package:
+            name: elastic_agent
+          managed_by: fleet
+          managed: true
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-elastic_agent.osquerybeat:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-elastic_agent.osquerybeat-*"
+        template:
+          settings:
+            index:
+              mapping:
+                total_fields:
+                  limit: 5000
+              sort:
+                field: "@timestamp"
+                order: desc
+          mappings:
+            _meta:
+              package:
+                name: elastic_agent
+              managed_by: fleet
+              managed: true
+        composed_of:
+          - "so-logs-elastic_agent.osquerybeat@package"
+          - "so-logs-elastic_agent.osquerybeat@custom"
+          - ".fleet_globals-1"
+          - ".fleet_agent_id_verification-1"
+        priority: 500
+        _meta:
+          package:
+            name: elastic_agent
+          managed_by: fleet
+          managed: true
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-elastic_agent.packetbeat:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-elastic_agent.packetbeat-*"
+        template:
+          settings:
+            index:
+              mapping:
+                total_fields:
+                  limit: 5000
+              sort:
+                field: "@timestamp"
+                order: desc
+          mappings:
+            _meta:
+              package:
+                name: elastic_agent
+              managed_by: fleet
+              managed: true
+        composed_of:
+          - "so-logs-elastic_agent.packetbeat@package"
+          - "so-logs-elastic_agent.packetbeat@custom"
+          - ".fleet_globals-1"
+          - ".fleet_agent_id_verification-1"
+        priority: 500
+        _meta:
+          package:
+            name: elastic_agent
+          managed_by: fleet
+          managed: true
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
     so-aws:
       warm: 7
       close: 30

--- a/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.apm_server@custom.json
+++ b/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.apm_server@custom.json
@@ -1,0 +1,12 @@
+{
+  "template": {
+    "settings": {}
+  },
+  "_meta": {
+    "package": {
+      "name": "elastic_agent"
+    },
+    "managed_by": "fleet",
+    "managed": true
+  }
+}

--- a/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.apm_server@package.json
+++ b/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.apm_server@package.json
@@ -1,7 +1,7 @@
 {
   "template": {
     "settings": {
-      "analysis": {
+    "analysis": {
         "analyzer": {
           "es_security_analyzer": {
             "type": "custom",
@@ -100,24 +100,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "image": {
               "properties": {
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -138,22 +126,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 },
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -172,24 +148,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "machine": {
               "properties": {
                 "type": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -210,12 +174,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 }
               }
             },
@@ -228,24 +186,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "account": {
               "properties": {
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -270,12 +216,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 }
               }
             },
@@ -288,22 +228,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "id": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -330,12 +258,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             }
           }
         },
@@ -344,12 +266,6 @@
             "level": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -383,24 +299,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "os": {
               "properties": {
                 "build": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -417,22 +321,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 },
                 "codename": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -444,6 +336,10 @@
                   "ignore_above": 1024,
                   "type": "keyword",
                   "fields": {
+
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"},
                     "text": {
                       "type": "text"
                     }
@@ -452,12 +348,6 @@
                 "family": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -474,22 +364,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 },
                 "platform": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -502,12 +380,6 @@
             "domain": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -530,22 +402,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "id": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -562,12 +422,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "mac": {
               "ignore_above": 1024,
@@ -578,22 +432,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "architecture": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -614,12 +456,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "id": {
               "ignore_above": 1024,
@@ -630,22 +466,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "version": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {

--- a/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.apm_server@package.json
+++ b/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.apm_server@package.json
@@ -1,0 +1,681 @@
+{
+  "template": {
+    "settings": {
+      "analysis": {
+        "analyzer": {
+          "es_security_analyzer": {
+            "type": "custom",
+            "char_filter": [
+              "whitespace_no_way"
+            ],
+            "filter": [
+              "lowercase",
+              "trim"
+            ],
+            "tokenizer": "keyword"
+          }
+        },
+        "char_filter": {
+          "whitespace_no_way": {
+            "type": "pattern_replace",
+            "pattern": "(\\s)+",
+            "replacement": "$1"
+          }
+        },
+        "filter": {
+          "path_hierarchy_pattern_filter": {
+            "type": "pattern_capture",
+            "preserve_original": true,
+            "patterns": [
+              "((?:[^\\\\]*\\\\)*)(.*)",
+              "((?:[^/]*/)*)(.*)"
+            ]
+          }
+        },
+        "tokenizer": {
+            "path_tokenizer": {
+              "type": "path_hierarchy",
+              "delimiter": "\\"
+            }
+          }
+        },
+      "index": {
+        "lifecycle": {
+          "name": "logs"
+        },
+        "codec": "best_compression",
+        "mapping": {
+          "total_fields": {
+            "limit": "10000"
+          }
+        },
+        "query": {
+          "default_field": [
+            "cloud.account.id",
+            "cloud.availability_zone",
+            "cloud.instance.id",
+            "cloud.instance.name",
+            "cloud.machine.type",
+            "cloud.provider",
+            "cloud.region",
+            "cloud.project.id",
+            "cloud.image.id",
+            "container.id",
+            "container.image.name",
+            "container.name",
+            "host.architecture",
+            "host.domain",
+            "host.hostname",
+            "host.id",
+            "host.mac",
+            "host.name",
+            "host.os.family",
+            "host.os.kernel",
+            "host.os.name",
+            "host.os.platform",
+            "host.os.version",
+            "host.os.build",
+            "host.os.codename",
+            "host.type",
+            "log.level",
+            "message",
+            "elastic_agent.id",
+            "elastic_agent.process",
+            "elastic_agent.version"
+          ]
+        }
+      }
+    },
+    "mappings": {
+      "dynamic": false,
+      "properties": {
+        "cloud": {
+          "properties": {
+            "availability_zone": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "image": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "instance": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "provider": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "machine": {
+              "properties": {
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "project": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "region": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "account": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            }
+          }
+        },
+        "container": {
+          "properties": {
+            "image": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "labels": {
+              "type": "object"
+            }
+          }
+        },
+        "@timestamp": {
+          "type": "date"
+        },
+        "ecs": {
+          "properties": {
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            }
+          }
+        },
+        "log": {
+          "properties": {
+            "level": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            }
+          }
+        },
+        "data_stream": {
+          "properties": {
+            "namespace": {
+              "type": "constant_keyword"
+            },
+            "type": {
+              "type": "constant_keyword"
+            },
+            "dataset": {
+              "type": "constant_keyword"
+            }
+          }
+        },
+        "host": {
+          "properties": {
+            "hostname": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "os": {
+              "properties": {
+                "build": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "kernel": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "codename": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword",
+                  "fields": {
+                    "text": {
+                      "type": "text"
+                    }
+                  }
+                },
+                "family": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "platform": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "ip": {
+              "type": "ip"
+            },
+            "containerized": {
+              "type": "boolean"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "mac": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "architecture": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            }
+          }
+        },
+        "elastic_agent": {
+          "properties": {
+            "process": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "snapshot": {
+              "type": "boolean"
+            }
+          }
+        },
+        "event": {
+          "properties": {
+            "dataset": {
+              "type": "constant_keyword"
+            }
+          }
+        },
+        "message": {
+          "type": "text"
+        }
+      }
+    }
+  },
+  "_meta": {
+    "package": {
+      "name": "elastic_agent"
+    },
+    "managed_by": "fleet",
+    "managed": true
+  }
+}

--- a/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.auditbeat@custom.json
+++ b/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.auditbeat@custom.json
@@ -1,0 +1,12 @@
+{
+  "template": {
+    "settings": {}
+  },
+  "_meta": {
+    "package": {
+      "name": "elastic_agent"
+    },
+    "managed_by": "fleet",
+    "managed": true
+  }
+}

--- a/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.auditbeat@package.json
+++ b/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.auditbeat@package.json
@@ -1,7 +1,7 @@
 {
   "template": {
     "settings": {
-      "analysis": {
+    "analysis": {
         "analyzer": {
           "es_security_analyzer": {
             "type": "custom",
@@ -100,24 +100,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "image": {
               "properties": {
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -138,22 +126,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 },
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -172,24 +148,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "machine": {
               "properties": {
                 "type": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -210,12 +174,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 }
               }
             },
@@ -228,24 +186,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "account": {
               "properties": {
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -270,12 +216,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 }
               }
             },
@@ -288,22 +228,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "id": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -330,12 +258,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             }
           }
         },
@@ -344,12 +266,6 @@
             "level": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -383,24 +299,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "os": {
               "properties": {
                 "build": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -417,22 +321,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 },
                 "codename": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -444,6 +336,10 @@
                   "ignore_above": 1024,
                   "type": "keyword",
                   "fields": {
+
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"},
                     "text": {
                       "type": "text"
                     }
@@ -452,12 +348,6 @@
                 "family": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -474,22 +364,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 },
                 "platform": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -502,12 +380,6 @@
             "domain": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -530,22 +402,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "id": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -562,12 +422,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "mac": {
               "ignore_above": 1024,
@@ -578,22 +432,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "architecture": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -614,12 +456,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "id": {
               "ignore_above": 1024,
@@ -630,22 +466,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "version": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {

--- a/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.auditbeat@package.json
+++ b/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.auditbeat@package.json
@@ -1,0 +1,681 @@
+{
+  "template": {
+    "settings": {
+      "analysis": {
+        "analyzer": {
+          "es_security_analyzer": {
+            "type": "custom",
+            "char_filter": [
+              "whitespace_no_way"
+            ],
+            "filter": [
+              "lowercase",
+              "trim"
+            ],
+            "tokenizer": "keyword"
+          }
+        },
+        "char_filter": {
+          "whitespace_no_way": {
+            "type": "pattern_replace",
+            "pattern": "(\\s)+",
+            "replacement": "$1"
+          }
+        },
+        "filter": {
+          "path_hierarchy_pattern_filter": {
+            "type": "pattern_capture",
+            "preserve_original": true,
+            "patterns": [
+              "((?:[^\\\\]*\\\\)*)(.*)",
+              "((?:[^/]*/)*)(.*)"
+            ]
+          }
+        },
+        "tokenizer": {
+            "path_tokenizer": {
+              "type": "path_hierarchy",
+              "delimiter": "\\"
+            }
+          }
+        },
+      "index": {
+        "lifecycle": {
+          "name": "logs"
+        },
+        "codec": "best_compression",
+        "mapping": {
+          "total_fields": {
+            "limit": "10000"
+          }
+        },
+        "query": {
+          "default_field": [
+            "cloud.account.id",
+            "cloud.availability_zone",
+            "cloud.instance.id",
+            "cloud.instance.name",
+            "cloud.machine.type",
+            "cloud.provider",
+            "cloud.region",
+            "cloud.project.id",
+            "cloud.image.id",
+            "container.id",
+            "container.image.name",
+            "container.name",
+            "host.architecture",
+            "host.domain",
+            "host.hostname",
+            "host.id",
+            "host.mac",
+            "host.name",
+            "host.os.family",
+            "host.os.kernel",
+            "host.os.name",
+            "host.os.platform",
+            "host.os.version",
+            "host.os.build",
+            "host.os.codename",
+            "host.type",
+            "log.level",
+            "message",
+            "elastic_agent.id",
+            "elastic_agent.process",
+            "elastic_agent.version"
+          ]
+        }
+      }
+    },
+    "mappings": {
+      "dynamic": false,
+      "properties": {
+        "cloud": {
+          "properties": {
+            "availability_zone": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "image": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "instance": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "provider": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "machine": {
+              "properties": {
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "project": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "region": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "account": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            }
+          }
+        },
+        "container": {
+          "properties": {
+            "image": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "labels": {
+              "type": "object"
+            }
+          }
+        },
+        "@timestamp": {
+          "type": "date"
+        },
+        "ecs": {
+          "properties": {
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            }
+          }
+        },
+        "log": {
+          "properties": {
+            "level": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            }
+          }
+        },
+        "data_stream": {
+          "properties": {
+            "namespace": {
+              "type": "constant_keyword"
+            },
+            "type": {
+              "type": "constant_keyword"
+            },
+            "dataset": {
+              "type": "constant_keyword"
+            }
+          }
+        },
+        "host": {
+          "properties": {
+            "hostname": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "os": {
+              "properties": {
+                "build": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "kernel": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "codename": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword",
+                  "fields": {
+                    "text": {
+                      "type": "text"
+                    }
+                  }
+                },
+                "family": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "platform": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "ip": {
+              "type": "ip"
+            },
+            "containerized": {
+              "type": "boolean"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "mac": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "architecture": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            }
+          }
+        },
+        "elastic_agent": {
+          "properties": {
+            "process": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "snapshot": {
+              "type": "boolean"
+            }
+          }
+        },
+        "event": {
+          "properties": {
+            "dataset": {
+              "type": "constant_keyword"
+            }
+          }
+        },
+        "message": {
+          "type": "text"
+        }
+      }
+    }
+  },
+  "_meta": {
+    "package": {
+      "name": "elastic_agent"
+    },
+    "managed_by": "fleet",
+    "managed": true
+  }
+}

--- a/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.cloudbeat@custom.json
+++ b/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.cloudbeat@custom.json
@@ -1,0 +1,12 @@
+{
+  "template": {
+    "settings": {}
+  },
+  "_meta": {
+    "package": {
+      "name": "elastic_agent"
+    },
+    "managed_by": "fleet",
+    "managed": true
+  }
+}

--- a/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.cloudbeat@package.json
+++ b/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.cloudbeat@package.json
@@ -1,0 +1,692 @@
+{
+  "template": {
+    "settings": {
+      "analysis": {
+        "analyzer": {
+          "es_security_analyzer": {
+            "type": "custom",
+            "char_filter": [
+              "whitespace_no_way"
+            ],
+            "filter": [
+              "lowercase",
+              "trim"
+            ],
+            "tokenizer": "keyword"
+          }
+        },
+        "char_filter": {
+          "whitespace_no_way": {
+            "type": "pattern_replace",
+            "pattern": "(\\s)+",
+            "replacement": "$1"
+          }
+        },
+        "filter": {
+          "path_hierarchy_pattern_filter": {
+            "type": "pattern_capture",
+            "preserve_original": true,
+            "patterns": [
+              "((?:[^\\\\]*\\\\)*)(.*)",
+              "((?:[^/]*/)*)(.*)"
+            ]
+          }
+        },
+        "tokenizer": {
+            "path_tokenizer": {
+              "type": "path_hierarchy",
+              "delimiter": "\\"
+            }
+          }
+        },
+      "index": {
+        "lifecycle": {
+          "name": "logs"
+        },
+        "codec": "best_compression",
+        "mapping": {
+          "total_fields": {
+            "limit": "10000"
+          }
+        },
+        "query": {
+          "default_field": [
+            "cloud.account.id",
+            "cloud.availability_zone",
+            "cloud.instance.id",
+            "cloud.instance.name",
+            "cloud.machine.type",
+            "cloud.provider",
+            "cloud.region",
+            "cloud.project.id",
+            "cloud.image.id",
+            "container.id",
+            "container.image.name",
+            "container.name",
+            "host.architecture",
+            "host.domain",
+            "host.hostname",
+            "host.id",
+            "host.mac",
+            "host.name",
+            "host.os.family",
+            "host.os.kernel",
+            "host.os.name",
+            "host.os.platform",
+            "host.os.version",
+            "host.os.build",
+            "host.os.codename",
+            "host.type",
+            "elastic_agent.id",
+            "elastic_agent.process",
+            "elastic_agent.version"
+          ]
+        }
+      }
+    },
+    "mappings": {
+      "dynamic": false,
+      "properties": {
+        "cloud": {
+          "properties": {
+            "availability_zone": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "image": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "instance": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "provider": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "machine": {
+              "properties": {
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "project": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "region": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "account": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            }
+          }
+        },
+        "container": {
+          "properties": {
+            "image": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "labels": {
+              "type": "object"
+            }
+          }
+        },
+        "@timestamp": {
+          "type": "date"
+        },
+        "ecs": {
+          "properties": {
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            }
+          }
+        },
+        "log": {
+          "properties": {
+            "level": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            }
+          }
+        },
+        "data_stream": {
+          "properties": {
+            "namespace": {
+              "type": "constant_keyword"
+            },
+            "type": {
+              "type": "constant_keyword"
+            },
+            "dataset": {
+              "type": "constant_keyword"
+            }
+          }
+        },
+        "host": {
+          "properties": {
+            "hostname": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "os": {
+              "properties": {
+                "build": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "kernel": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "codename": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword",
+                  "fields": {
+                    "text": {
+                      "type": "text"
+                    }
+                  }
+                },
+                "family": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "platform": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "ip": {
+              "type": "ip"
+            },
+            "containerized": {
+              "type": "boolean"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "mac": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "architecture": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            }
+          }
+        },
+        "elastic_agent": {
+          "properties": {
+            "process": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "snapshot": {
+              "type": "boolean"
+            }
+          }
+        },
+        "event": {
+          "properties": {
+            "dataset": {
+              "type": "constant_keyword"
+            }
+          }
+        },
+        "message": {
+          "ignore_above": 1024,
+          "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+        }
+      }
+    }
+  },
+  "_meta": {
+    "package": {
+      "name": "elastic_agent"
+    },
+    "managed_by": "fleet",
+    "managed": true
+  }
+}

--- a/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.cloudbeat@package.json
+++ b/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.cloudbeat@package.json
@@ -1,7 +1,7 @@
 {
   "template": {
     "settings": {
-      "analysis": {
+"analysis": {
         "analyzer": {
           "es_security_analyzer": {
             "type": "custom",
@@ -98,24 +98,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "image": {
               "properties": {
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -136,22 +124,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 },
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -170,24 +146,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "machine": {
               "properties": {
                 "type": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -208,12 +172,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 }
               }
             },
@@ -226,24 +184,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "account": {
               "properties": {
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -268,12 +214,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 }
               }
             },
@@ -286,22 +226,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "id": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -328,12 +256,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             }
           }
         },
@@ -342,12 +264,6 @@
             "level": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -381,24 +297,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "os": {
               "properties": {
                 "build": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -415,22 +319,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 },
                 "codename": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -442,6 +334,10 @@
                   "ignore_above": 1024,
                   "type": "keyword",
                   "fields": {
+
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"},
                     "text": {
                       "type": "text"
                     }
@@ -450,12 +346,6 @@
                 "family": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -472,22 +362,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 },
                 "platform": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -500,12 +378,6 @@
             "domain": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -528,22 +400,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "id": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -560,12 +420,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "mac": {
               "ignore_above": 1024,
@@ -576,22 +430,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "architecture": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -612,12 +454,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "id": {
               "ignore_above": 1024,
@@ -628,22 +464,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "version": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -666,12 +490,6 @@
         "message": {
           "ignore_above": 1024,
           "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {

--- a/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.endpoint_security@custom.json
+++ b/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.endpoint_security@custom.json
@@ -1,0 +1,12 @@
+{
+  "template": {
+    "settings": {}
+  },
+  "_meta": {
+    "package": {
+      "name": "elastic_agent"
+    },
+    "managed_by": "fleet",
+    "managed": true
+  }
+}

--- a/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.endpoint_security@package.json
+++ b/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.endpoint_security@package.json
@@ -1,0 +1,681 @@
+{
+  "template": {
+    "settings": {
+      "analysis": {
+        "analyzer": {
+          "es_security_analyzer": {
+            "type": "custom",
+            "char_filter": [
+              "whitespace_no_way"
+            ],
+            "filter": [
+              "lowercase",
+              "trim"
+            ],
+            "tokenizer": "keyword"
+          }
+        },
+        "char_filter": {
+          "whitespace_no_way": {
+            "type": "pattern_replace",
+            "pattern": "(\\s)+",
+            "replacement": "$1"
+          }
+        },
+        "filter": {
+          "path_hierarchy_pattern_filter": {
+            "type": "pattern_capture",
+            "preserve_original": true,
+            "patterns": [
+              "((?:[^\\\\]*\\\\)*)(.*)",
+              "((?:[^/]*/)*)(.*)"
+            ]
+          }
+        },
+        "tokenizer": {
+            "path_tokenizer": {
+              "type": "path_hierarchy",
+              "delimiter": "\\"
+            }
+          }
+        },
+      "index": {
+        "lifecycle": {
+          "name": "logs"
+        },
+        "codec": "best_compression",
+        "mapping": {
+          "total_fields": {
+            "limit": "10000"
+          }
+        },
+        "query": {
+          "default_field": [
+            "cloud.account.id",
+            "cloud.availability_zone",
+            "cloud.instance.id",
+            "cloud.instance.name",
+            "cloud.machine.type",
+            "cloud.provider",
+            "cloud.region",
+            "cloud.project.id",
+            "cloud.image.id",
+            "container.id",
+            "container.image.name",
+            "container.name",
+            "host.architecture",
+            "host.domain",
+            "host.hostname",
+            "host.id",
+            "host.mac",
+            "host.name",
+            "host.os.family",
+            "host.os.kernel",
+            "host.os.name",
+            "host.os.platform",
+            "host.os.version",
+            "host.os.build",
+            "host.os.codename",
+            "host.type",
+            "log.level",
+            "message",
+            "elastic_agent.id",
+            "elastic_agent.process",
+            "elastic_agent.version"
+          ]
+        }
+      }
+    },
+    "mappings": {
+      "dynamic": false,
+      "properties": {
+        "cloud": {
+          "properties": {
+            "availability_zone": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "image": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "instance": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "provider": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "machine": {
+              "properties": {
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "project": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "region": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "account": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            }
+          }
+        },
+        "container": {
+          "properties": {
+            "image": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "labels": {
+              "type": "object"
+            }
+          }
+        },
+        "@timestamp": {
+          "type": "date"
+        },
+        "ecs": {
+          "properties": {
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            }
+          }
+        },
+        "log": {
+          "properties": {
+            "level": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            }
+          }
+        },
+        "data_stream": {
+          "properties": {
+            "namespace": {
+              "type": "constant_keyword"
+            },
+            "type": {
+              "type": "constant_keyword"
+            },
+            "dataset": {
+              "type": "constant_keyword"
+            }
+          }
+        },
+        "host": {
+          "properties": {
+            "hostname": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "os": {
+              "properties": {
+                "build": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "kernel": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "codename": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword",
+                  "fields": {
+                    "text": {
+                      "type": "text"
+                    }
+                  }
+                },
+                "family": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "platform": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "ip": {
+              "type": "ip"
+            },
+            "containerized": {
+              "type": "boolean"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "mac": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "architecture": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            }
+          }
+        },
+        "elastic_agent": {
+          "properties": {
+            "process": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "snapshot": {
+              "type": "boolean"
+            }
+          }
+        },
+        "event": {
+          "properties": {
+            "dataset": {
+              "type": "constant_keyword"
+            }
+          }
+        },
+        "message": {
+          "type": "text"
+        }
+      }
+    }
+  },
+  "_meta": {
+    "package": {
+      "name": "elastic_agent"
+    },
+    "managed_by": "fleet",
+    "managed": true
+  }
+}

--- a/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.endpoint_security@package.json
+++ b/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.endpoint_security@package.json
@@ -1,7 +1,7 @@
 {
   "template": {
     "settings": {
-      "analysis": {
+"analysis": {
         "analyzer": {
           "es_security_analyzer": {
             "type": "custom",
@@ -100,24 +100,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "image": {
               "properties": {
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -138,22 +126,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 },
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -172,24 +148,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "machine": {
               "properties": {
                 "type": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -210,12 +174,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 }
               }
             },
@@ -228,24 +186,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "account": {
               "properties": {
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -270,12 +216,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 }
               }
             },
@@ -288,22 +228,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "id": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -330,12 +258,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             }
           }
         },
@@ -344,12 +266,6 @@
             "level": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -383,24 +299,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "os": {
               "properties": {
                 "build": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -417,22 +321,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 },
                 "codename": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -444,6 +336,10 @@
                   "ignore_above": 1024,
                   "type": "keyword",
                   "fields": {
+
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"},
                     "text": {
                       "type": "text"
                     }
@@ -452,12 +348,6 @@
                 "family": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -474,22 +364,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 },
                 "platform": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -502,12 +380,6 @@
             "domain": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -530,22 +402,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "id": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -562,12 +422,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "mac": {
               "ignore_above": 1024,
@@ -578,22 +432,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "architecture": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -614,12 +456,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "id": {
               "ignore_above": 1024,
@@ -630,22 +466,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "version": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {

--- a/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.filebeat@custom.json
+++ b/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.filebeat@custom.json
@@ -1,0 +1,12 @@
+{
+  "template": {
+    "settings": {}
+  },
+  "_meta": {
+    "package": {
+      "name": "elastic_agent"
+    },
+    "managed_by": "fleet",
+    "managed": true
+  }
+}

--- a/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.filebeat@package.json
+++ b/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.filebeat@package.json
@@ -1,0 +1,681 @@
+{
+  "template": {
+    "settings": {
+      "analysis": {
+        "analyzer": {
+          "es_security_analyzer": {
+            "type": "custom",
+            "char_filter": [
+              "whitespace_no_way"
+            ],
+            "filter": [
+              "lowercase",
+              "trim"
+            ],
+            "tokenizer": "keyword"
+          }
+        },
+        "char_filter": {
+          "whitespace_no_way": {
+            "type": "pattern_replace",
+            "pattern": "(\\s)+",
+            "replacement": "$1"
+          }
+        },
+        "filter": {
+          "path_hierarchy_pattern_filter": {
+            "type": "pattern_capture",
+            "preserve_original": true,
+            "patterns": [
+              "((?:[^\\\\]*\\\\)*)(.*)",
+              "((?:[^/]*/)*)(.*)"
+            ]
+          }
+        },
+        "tokenizer": {
+            "path_tokenizer": {
+              "type": "path_hierarchy",
+              "delimiter": "\\"
+            }
+          }
+        },
+      "index": {
+        "lifecycle": {
+          "name": "logs"
+        },
+        "codec": "best_compression",
+        "mapping": {
+          "total_fields": {
+            "limit": "10000"
+          }
+        },
+        "query": {
+          "default_field": [
+            "cloud.account.id",
+            "cloud.availability_zone",
+            "cloud.instance.id",
+            "cloud.instance.name",
+            "cloud.machine.type",
+            "cloud.provider",
+            "cloud.region",
+            "cloud.project.id",
+            "cloud.image.id",
+            "container.id",
+            "container.image.name",
+            "container.name",
+            "host.architecture",
+            "host.domain",
+            "host.hostname",
+            "host.id",
+            "host.mac",
+            "host.name",
+            "host.os.family",
+            "host.os.kernel",
+            "host.os.name",
+            "host.os.platform",
+            "host.os.version",
+            "host.os.build",
+            "host.os.codename",
+            "host.type",
+            "log.level",
+            "message",
+            "elastic_agent.id",
+            "elastic_agent.process",
+            "elastic_agent.version"
+          ]
+        }
+      }
+    },
+    "mappings": {
+      "dynamic": false,
+      "properties": {
+        "cloud": {
+          "properties": {
+            "availability_zone": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "image": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "instance": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "provider": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "machine": {
+              "properties": {
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "project": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "region": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "account": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            }
+          }
+        },
+        "container": {
+          "properties": {
+            "image": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "labels": {
+              "type": "object"
+            }
+          }
+        },
+        "@timestamp": {
+          "type": "date"
+        },
+        "ecs": {
+          "properties": {
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            }
+          }
+        },
+        "log": {
+          "properties": {
+            "level": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            }
+          }
+        },
+        "data_stream": {
+          "properties": {
+            "namespace": {
+              "type": "constant_keyword"
+            },
+            "type": {
+              "type": "constant_keyword"
+            },
+            "dataset": {
+              "type": "constant_keyword"
+            }
+          }
+        },
+        "host": {
+          "properties": {
+            "hostname": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "os": {
+              "properties": {
+                "build": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "kernel": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "codename": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword",
+                  "fields": {
+                    "text": {
+                      "type": "text"
+                    }
+                  }
+                },
+                "family": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "platform": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "ip": {
+              "type": "ip"
+            },
+            "containerized": {
+              "type": "boolean"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "mac": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "architecture": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            }
+          }
+        },
+        "elastic_agent": {
+          "properties": {
+            "process": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "snapshot": {
+              "type": "boolean"
+            }
+          }
+        },
+        "event": {
+          "properties": {
+            "dataset": {
+              "type": "constant_keyword"
+            }
+          }
+        },
+        "message": {
+          "type": "text"
+        }
+      }
+    }
+  },
+  "_meta": {
+    "package": {
+      "name": "elastic_agent"
+    },
+    "managed_by": "fleet",
+    "managed": true
+  }
+}

--- a/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.filebeat@package.json
+++ b/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.filebeat@package.json
@@ -1,7 +1,7 @@
 {
   "template": {
     "settings": {
-      "analysis": {
+"analysis": {
         "analyzer": {
           "es_security_analyzer": {
             "type": "custom",
@@ -100,24 +100,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "image": {
               "properties": {
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -138,22 +126,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 },
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -172,24 +148,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "machine": {
               "properties": {
                 "type": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -210,12 +174,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 }
               }
             },
@@ -228,24 +186,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "account": {
               "properties": {
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -270,12 +216,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 }
               }
             },
@@ -288,22 +228,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "id": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -330,12 +258,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             }
           }
         },
@@ -344,12 +266,6 @@
             "level": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -383,24 +299,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "os": {
               "properties": {
                 "build": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -417,22 +321,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 },
                 "codename": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -444,6 +336,10 @@
                   "ignore_above": 1024,
                   "type": "keyword",
                   "fields": {
+
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"},
                     "text": {
                       "type": "text"
                     }
@@ -452,12 +348,6 @@
                 "family": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -474,22 +364,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 },
                 "platform": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -502,12 +380,6 @@
             "domain": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -530,22 +402,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "id": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -562,12 +422,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "mac": {
               "ignore_above": 1024,
@@ -578,22 +432,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "architecture": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -614,12 +456,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "id": {
               "ignore_above": 1024,
@@ -630,22 +466,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "version": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {

--- a/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.fleet_server@custom.json
+++ b/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.fleet_server@custom.json
@@ -1,0 +1,12 @@
+{
+  "template": {
+    "settings": {}
+  },
+  "_meta": {
+    "package": {
+      "name": "elastic_agent"
+    },
+    "managed_by": "fleet",
+    "managed": true
+  }
+}

--- a/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.fleet_server@package.json
+++ b/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.fleet_server@package.json
@@ -1,0 +1,681 @@
+{
+  "template": {
+    "settings": {
+      "analysis": {
+        "analyzer": {
+          "es_security_analyzer": {
+            "type": "custom",
+            "char_filter": [
+              "whitespace_no_way"
+            ],
+            "filter": [
+              "lowercase",
+              "trim"
+            ],
+            "tokenizer": "keyword"
+          }
+        },
+        "char_filter": {
+          "whitespace_no_way": {
+            "type": "pattern_replace",
+            "pattern": "(\\s)+",
+            "replacement": "$1"
+          }
+        },
+        "filter": {
+          "path_hierarchy_pattern_filter": {
+            "type": "pattern_capture",
+            "preserve_original": true,
+            "patterns": [
+              "((?:[^\\\\]*\\\\)*)(.*)",
+              "((?:[^/]*/)*)(.*)"
+            ]
+          }
+        },
+        "tokenizer": {
+            "path_tokenizer": {
+              "type": "path_hierarchy",
+              "delimiter": "\\"
+            }
+          }
+        },
+      "index": {
+        "lifecycle": {
+          "name": "logs"
+        },
+        "codec": "best_compression",
+        "mapping": {
+          "total_fields": {
+            "limit": "10000"
+          }
+        },
+        "query": {
+          "default_field": [
+            "cloud.account.id",
+            "cloud.availability_zone",
+            "cloud.instance.id",
+            "cloud.instance.name",
+            "cloud.machine.type",
+            "cloud.provider",
+            "cloud.region",
+            "cloud.project.id",
+            "cloud.image.id",
+            "container.id",
+            "container.image.name",
+            "container.name",
+            "host.architecture",
+            "host.domain",
+            "host.hostname",
+            "host.id",
+            "host.mac",
+            "host.name",
+            "host.os.family",
+            "host.os.kernel",
+            "host.os.name",
+            "host.os.platform",
+            "host.os.version",
+            "host.os.build",
+            "host.os.codename",
+            "host.type",
+            "log.level",
+            "message",
+            "elastic_agent.id",
+            "elastic_agent.process",
+            "elastic_agent.version"
+          ]
+        }
+      }
+    },
+    "mappings": {
+      "dynamic": false,
+      "properties": {
+        "cloud": {
+          "properties": {
+            "availability_zone": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "image": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "instance": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "provider": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "machine": {
+              "properties": {
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "project": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "region": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "account": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            }
+          }
+        },
+        "container": {
+          "properties": {
+            "image": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "labels": {
+              "type": "object"
+            }
+          }
+        },
+        "@timestamp": {
+          "type": "date"
+        },
+        "ecs": {
+          "properties": {
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            }
+          }
+        },
+        "log": {
+          "properties": {
+            "level": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            }
+          }
+        },
+        "data_stream": {
+          "properties": {
+            "namespace": {
+              "type": "constant_keyword"
+            },
+            "type": {
+              "type": "constant_keyword"
+            },
+            "dataset": {
+              "type": "constant_keyword"
+            }
+          }
+        },
+        "host": {
+          "properties": {
+            "hostname": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "os": {
+              "properties": {
+                "build": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "kernel": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "codename": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword",
+                  "fields": {
+                    "text": {
+                      "type": "text"
+                    }
+                  }
+                },
+                "family": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "platform": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "ip": {
+              "type": "ip"
+            },
+            "containerized": {
+              "type": "boolean"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "mac": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "architecture": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            }
+          }
+        },
+        "elastic_agent": {
+          "properties": {
+            "process": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "snapshot": {
+              "type": "boolean"
+            }
+          }
+        },
+        "event": {
+          "properties": {
+            "dataset": {
+              "type": "constant_keyword"
+            }
+          }
+        },
+        "message": {
+          "type": "text"
+        }
+      }
+    }
+  },
+  "_meta": {
+    "package": {
+      "name": "elastic_agent"
+    },
+    "managed_by": "fleet",
+    "managed": true
+  }
+}

--- a/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.fleet_server@package.json
+++ b/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.fleet_server@package.json
@@ -1,7 +1,7 @@
 {
   "template": {
     "settings": {
-      "analysis": {
+"analysis": {
         "analyzer": {
           "es_security_analyzer": {
             "type": "custom",
@@ -100,24 +100,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "image": {
               "properties": {
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -138,22 +126,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 },
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -172,24 +148,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "machine": {
               "properties": {
                 "type": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -210,12 +174,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 }
               }
             },
@@ -228,24 +186,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "account": {
               "properties": {
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -270,12 +216,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 }
               }
             },
@@ -288,22 +228,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "id": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -330,12 +258,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             }
           }
         },
@@ -344,12 +266,6 @@
             "level": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -383,24 +299,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "os": {
               "properties": {
                 "build": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -417,22 +321,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 },
                 "codename": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -444,6 +336,10 @@
                   "ignore_above": 1024,
                   "type": "keyword",
                   "fields": {
+
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"},
                     "text": {
                       "type": "text"
                     }
@@ -452,12 +348,6 @@
                 "family": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -474,22 +364,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 },
                 "platform": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -502,12 +380,6 @@
             "domain": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -530,22 +402,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "id": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -562,12 +422,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "mac": {
               "ignore_above": 1024,
@@ -578,22 +432,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "architecture": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -614,12 +456,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "id": {
               "ignore_above": 1024,
@@ -630,22 +466,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "version": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {

--- a/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.heartbeat@custom.json
+++ b/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.heartbeat@custom.json
@@ -1,0 +1,12 @@
+{
+  "template": {
+    "settings": {}
+  },
+  "_meta": {
+    "package": {
+      "name": "elastic_agent"
+    },
+    "managed_by": "fleet",
+    "managed": true
+  }
+}

--- a/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.heartbeat@package.json
+++ b/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.heartbeat@package.json
@@ -1,0 +1,681 @@
+{
+  "template": {
+    "settings": {
+      "analysis": {
+        "analyzer": {
+          "es_security_analyzer": {
+            "type": "custom",
+            "char_filter": [
+              "whitespace_no_way"
+            ],
+            "filter": [
+              "lowercase",
+              "trim"
+            ],
+            "tokenizer": "keyword"
+          }
+        },
+        "char_filter": {
+          "whitespace_no_way": {
+            "type": "pattern_replace",
+            "pattern": "(\\s)+",
+            "replacement": "$1"
+          }
+        },
+        "filter": {
+          "path_hierarchy_pattern_filter": {
+            "type": "pattern_capture",
+            "preserve_original": true,
+            "patterns": [
+              "((?:[^\\\\]*\\\\)*)(.*)",
+              "((?:[^/]*/)*)(.*)"
+            ]
+          }
+        },
+        "tokenizer": {
+            "path_tokenizer": {
+              "type": "path_hierarchy",
+              "delimiter": "\\"
+            }
+          }
+        },
+      "index": {
+        "lifecycle": {
+          "name": "logs"
+        },
+        "codec": "best_compression",
+        "mapping": {
+          "total_fields": {
+            "limit": "10000"
+          }
+        },
+        "query": {
+          "default_field": [
+            "cloud.account.id",
+            "cloud.availability_zone",
+            "cloud.instance.id",
+            "cloud.instance.name",
+            "cloud.machine.type",
+            "cloud.provider",
+            "cloud.region",
+            "cloud.project.id",
+            "cloud.image.id",
+            "container.id",
+            "container.image.name",
+            "container.name",
+            "host.architecture",
+            "host.domain",
+            "host.hostname",
+            "host.id",
+            "host.mac",
+            "host.name",
+            "host.os.family",
+            "host.os.kernel",
+            "host.os.name",
+            "host.os.platform",
+            "host.os.version",
+            "host.os.build",
+            "host.os.codename",
+            "host.type",
+            "log.level",
+            "message",
+            "elastic_agent.id",
+            "elastic_agent.process",
+            "elastic_agent.version"
+          ]
+        }
+      }
+    },
+    "mappings": {
+      "dynamic": false,
+      "properties": {
+        "cloud": {
+          "properties": {
+            "availability_zone": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "image": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "instance": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "provider": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "machine": {
+              "properties": {
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "project": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "region": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "account": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            }
+          }
+        },
+        "container": {
+          "properties": {
+            "image": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "labels": {
+              "type": "object"
+            }
+          }
+        },
+        "@timestamp": {
+          "type": "date"
+        },
+        "ecs": {
+          "properties": {
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            }
+          }
+        },
+        "log": {
+          "properties": {
+            "level": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            }
+          }
+        },
+        "data_stream": {
+          "properties": {
+            "namespace": {
+              "type": "constant_keyword"
+            },
+            "type": {
+              "type": "constant_keyword"
+            },
+            "dataset": {
+              "type": "constant_keyword"
+            }
+          }
+        },
+        "host": {
+          "properties": {
+            "hostname": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "os": {
+              "properties": {
+                "build": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "kernel": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "codename": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword",
+                  "fields": {
+                    "text": {
+                      "type": "text"
+                    }
+                  }
+                },
+                "family": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "platform": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "ip": {
+              "type": "ip"
+            },
+            "containerized": {
+              "type": "boolean"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "mac": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "architecture": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            }
+          }
+        },
+        "elastic_agent": {
+          "properties": {
+            "process": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "snapshot": {
+              "type": "boolean"
+            }
+          }
+        },
+        "message": {
+          "type": "text"
+        },
+        "event": {
+          "properties": {
+            "dataset": {
+              "type": "constant_keyword"
+            }
+          }
+        }
+      }
+    }
+  },
+  "_meta": {
+    "package": {
+      "name": "elastic_agent"
+    },
+    "managed_by": "fleet",
+    "managed": true
+  }
+}

--- a/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.heartbeat@package.json
+++ b/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.heartbeat@package.json
@@ -1,7 +1,7 @@
 {
   "template": {
     "settings": {
-      "analysis": {
+"analysis": {
         "analyzer": {
           "es_security_analyzer": {
             "type": "custom",
@@ -100,24 +100,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "image": {
               "properties": {
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -138,22 +126,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 },
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -172,24 +148,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "machine": {
               "properties": {
                 "type": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -210,12 +174,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 }
               }
             },
@@ -228,24 +186,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "account": {
               "properties": {
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -270,12 +216,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 }
               }
             },
@@ -288,22 +228,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "id": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -330,12 +258,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             }
           }
         },
@@ -344,12 +266,6 @@
             "level": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -383,24 +299,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "os": {
               "properties": {
                 "build": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -417,22 +321,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 },
                 "codename": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -444,6 +336,10 @@
                   "ignore_above": 1024,
                   "type": "keyword",
                   "fields": {
+
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"},
                     "text": {
                       "type": "text"
                     }
@@ -452,12 +348,6 @@
                 "family": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -474,22 +364,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 },
                 "platform": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -502,12 +380,6 @@
             "domain": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -530,22 +402,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "id": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -562,12 +422,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "mac": {
               "ignore_above": 1024,
@@ -578,22 +432,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "architecture": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -614,12 +456,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "id": {
               "ignore_above": 1024,
@@ -630,22 +466,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "version": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {

--- a/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.metricbeat@custom.json
+++ b/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.metricbeat@custom.json
@@ -1,0 +1,12 @@
+{
+  "template": {
+    "settings": {}
+  },
+  "_meta": {
+    "package": {
+      "name": "elastic_agent"
+    },
+    "managed_by": "fleet",
+    "managed": true
+  }
+}

--- a/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.metricbeat@package.json
+++ b/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.metricbeat@package.json
@@ -1,0 +1,681 @@
+{
+  "template": {
+    "settings": {
+      "analysis": {
+        "analyzer": {
+          "es_security_analyzer": {
+            "type": "custom",
+            "char_filter": [
+              "whitespace_no_way"
+            ],
+            "filter": [
+              "lowercase",
+              "trim"
+            ],
+            "tokenizer": "keyword"
+          }
+        },
+        "char_filter": {
+          "whitespace_no_way": {
+            "type": "pattern_replace",
+            "pattern": "(\\s)+",
+            "replacement": "$1"
+          }
+        },
+        "filter": {
+          "path_hierarchy_pattern_filter": {
+            "type": "pattern_capture",
+            "preserve_original": true,
+            "patterns": [
+              "((?:[^\\\\]*\\\\)*)(.*)",
+              "((?:[^/]*/)*)(.*)"
+            ]
+          }
+        },
+        "tokenizer": {
+            "path_tokenizer": {
+              "type": "path_hierarchy",
+              "delimiter": "\\"
+            }
+          }
+        },
+      "index": {
+        "lifecycle": {
+          "name": "logs"
+        },
+        "codec": "best_compression",
+        "mapping": {
+          "total_fields": {
+            "limit": "10000"
+          }
+        },
+        "query": {
+          "default_field": [
+            "cloud.account.id",
+            "cloud.availability_zone",
+            "cloud.instance.id",
+            "cloud.instance.name",
+            "cloud.machine.type",
+            "cloud.provider",
+            "cloud.region",
+            "cloud.project.id",
+            "cloud.image.id",
+            "container.id",
+            "container.image.name",
+            "container.name",
+            "host.architecture",
+            "host.domain",
+            "host.hostname",
+            "host.id",
+            "host.mac",
+            "host.name",
+            "host.os.family",
+            "host.os.kernel",
+            "host.os.name",
+            "host.os.platform",
+            "host.os.version",
+            "host.os.build",
+            "host.os.codename",
+            "host.type",
+            "log.level",
+            "message",
+            "elastic_agent.id",
+            "elastic_agent.process",
+            "elastic_agent.version"
+          ]
+        }
+      }
+    },
+    "mappings": {
+      "dynamic": false,
+      "properties": {
+        "cloud": {
+          "properties": {
+            "availability_zone": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "image": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "instance": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "provider": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "machine": {
+              "properties": {
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "project": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "region": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "account": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            }
+          }
+        },
+        "container": {
+          "properties": {
+            "image": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "labels": {
+              "type": "object"
+            }
+          }
+        },
+        "@timestamp": {
+          "type": "date"
+        },
+        "ecs": {
+          "properties": {
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            }
+          }
+        },
+        "log": {
+          "properties": {
+            "level": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            }
+          }
+        },
+        "data_stream": {
+          "properties": {
+            "namespace": {
+              "type": "constant_keyword"
+            },
+            "type": {
+              "type": "constant_keyword"
+            },
+            "dataset": {
+              "type": "constant_keyword"
+            }
+          }
+        },
+        "host": {
+          "properties": {
+            "hostname": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "os": {
+              "properties": {
+                "build": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "kernel": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "codename": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword",
+                  "fields": {
+                    "text": {
+                      "type": "text"
+                    }
+                  }
+                },
+                "family": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "platform": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "ip": {
+              "type": "ip"
+            },
+            "containerized": {
+              "type": "boolean"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "mac": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "architecture": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            }
+          }
+        },
+        "elastic_agent": {
+          "properties": {
+            "process": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "snapshot": {
+              "type": "boolean"
+            }
+          }
+        },
+        "event": {
+          "properties": {
+            "dataset": {
+              "type": "constant_keyword"
+            }
+          }
+        },
+        "message": {
+          "type": "text"
+        }
+      }
+    }
+  },
+  "_meta": {
+    "package": {
+      "name": "elastic_agent"
+    },
+    "managed_by": "fleet",
+    "managed": true
+  }
+}

--- a/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.metricbeat@package.json
+++ b/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.metricbeat@package.json
@@ -1,7 +1,7 @@
 {
   "template": {
     "settings": {
-      "analysis": {
+"analysis": {
         "analyzer": {
           "es_security_analyzer": {
             "type": "custom",
@@ -100,24 +100,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "image": {
               "properties": {
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -138,22 +126,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 },
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -172,24 +148,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "machine": {
               "properties": {
                 "type": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -210,12 +174,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 }
               }
             },
@@ -228,24 +186,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "account": {
               "properties": {
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -270,12 +216,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 }
               }
             },
@@ -288,22 +228,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "id": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -330,12 +258,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             }
           }
         },
@@ -344,12 +266,6 @@
             "level": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -383,24 +299,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "os": {
               "properties": {
                 "build": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -417,22 +321,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 },
                 "codename": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -444,6 +336,10 @@
                   "ignore_above": 1024,
                   "type": "keyword",
                   "fields": {
+
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"},
                     "text": {
                       "type": "text"
                     }
@@ -452,12 +348,6 @@
                 "family": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -474,22 +364,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 },
                 "platform": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -502,12 +380,6 @@
             "domain": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -530,22 +402,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "id": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -562,12 +422,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "mac": {
               "ignore_above": 1024,
@@ -578,22 +432,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "architecture": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -614,12 +456,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "id": {
               "ignore_above": 1024,
@@ -630,22 +466,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "version": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {

--- a/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.osquerybeat@custom.json
+++ b/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.osquerybeat@custom.json
@@ -1,0 +1,12 @@
+{
+  "template": {
+    "settings": {}
+  },
+  "_meta": {
+    "package": {
+      "name": "elastic_agent"
+    },
+    "managed_by": "fleet",
+    "managed": true
+  }
+}

--- a/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.osquerybeat@package.json
+++ b/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.osquerybeat@package.json
@@ -1,0 +1,681 @@
+{
+  "template": {
+    "settings": {
+      "analysis": {
+        "analyzer": {
+          "es_security_analyzer": {
+            "type": "custom",
+            "char_filter": [
+              "whitespace_no_way"
+            ],
+            "filter": [
+              "lowercase",
+              "trim"
+            ],
+            "tokenizer": "keyword"
+          }
+        },
+        "char_filter": {
+          "whitespace_no_way": {
+            "type": "pattern_replace",
+            "pattern": "(\\s)+",
+            "replacement": "$1"
+          }
+        },
+        "filter": {
+          "path_hierarchy_pattern_filter": {
+            "type": "pattern_capture",
+            "preserve_original": true,
+            "patterns": [
+              "((?:[^\\\\]*\\\\)*)(.*)",
+              "((?:[^/]*/)*)(.*)"
+            ]
+          }
+        },
+        "tokenizer": {
+            "path_tokenizer": {
+              "type": "path_hierarchy",
+              "delimiter": "\\"
+            }
+          }
+        },
+      "index": {
+        "lifecycle": {
+          "name": "logs"
+        },
+        "codec": "best_compression",
+        "mapping": {
+          "total_fields": {
+            "limit": "10000"
+          }
+        },
+        "query": {
+          "default_field": [
+            "cloud.account.id",
+            "cloud.availability_zone",
+            "cloud.instance.id",
+            "cloud.instance.name",
+            "cloud.machine.type",
+            "cloud.provider",
+            "cloud.region",
+            "cloud.project.id",
+            "cloud.image.id",
+            "container.id",
+            "container.image.name",
+            "container.name",
+            "host.architecture",
+            "host.domain",
+            "host.hostname",
+            "host.id",
+            "host.mac",
+            "host.name",
+            "host.os.family",
+            "host.os.kernel",
+            "host.os.name",
+            "host.os.platform",
+            "host.os.version",
+            "host.os.build",
+            "host.os.codename",
+            "host.type",
+            "log.level",
+            "message",
+            "elastic_agent.id",
+            "elastic_agent.process",
+            "elastic_agent.version"
+          ]
+        }
+      }
+    },
+    "mappings": {
+      "dynamic": false,
+      "properties": {
+        "cloud": {
+          "properties": {
+            "availability_zone": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "image": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "instance": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "provider": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "machine": {
+              "properties": {
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "project": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "region": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "account": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            }
+          }
+        },
+        "container": {
+          "properties": {
+            "image": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "labels": {
+              "type": "object"
+            }
+          }
+        },
+        "@timestamp": {
+          "type": "date"
+        },
+        "ecs": {
+          "properties": {
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            }
+          }
+        },
+        "log": {
+          "properties": {
+            "level": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            }
+          }
+        },
+        "data_stream": {
+          "properties": {
+            "namespace": {
+              "type": "constant_keyword"
+            },
+            "type": {
+              "type": "constant_keyword"
+            },
+            "dataset": {
+              "type": "constant_keyword"
+            }
+          }
+        },
+        "host": {
+          "properties": {
+            "hostname": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "os": {
+              "properties": {
+                "build": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "kernel": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "codename": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword",
+                  "fields": {
+                    "text": {
+                      "type": "text"
+                    }
+                  }
+                },
+                "family": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "platform": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "ip": {
+              "type": "ip"
+            },
+            "containerized": {
+              "type": "boolean"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "mac": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "architecture": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            }
+          }
+        },
+        "elastic_agent": {
+          "properties": {
+            "process": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "snapshot": {
+              "type": "boolean"
+            }
+          }
+        },
+        "event": {
+          "properties": {
+            "dataset": {
+              "type": "constant_keyword"
+            }
+          }
+        },
+        "message": {
+          "type": "text"
+        }
+      }
+    }
+  },
+  "_meta": {
+    "package": {
+      "name": "elastic_agent"
+    },
+    "managed_by": "fleet",
+    "managed": true
+  }
+}

--- a/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.osquerybeat@package.json
+++ b/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.osquerybeat@package.json
@@ -1,7 +1,7 @@
 {
   "template": {
     "settings": {
-      "analysis": {
+"analysis": {
         "analyzer": {
           "es_security_analyzer": {
             "type": "custom",
@@ -100,24 +100,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "image": {
               "properties": {
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -138,22 +126,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 },
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -172,24 +148,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "machine": {
               "properties": {
                 "type": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -210,12 +174,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 }
               }
             },
@@ -228,24 +186,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "account": {
               "properties": {
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -270,12 +216,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 }
               }
             },
@@ -288,22 +228,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "id": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -330,12 +258,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             }
           }
         },
@@ -344,12 +266,6 @@
             "level": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -383,24 +299,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "os": {
               "properties": {
                 "build": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -417,22 +321,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 },
                 "codename": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -444,6 +336,10 @@
                   "ignore_above": 1024,
                   "type": "keyword",
                   "fields": {
+
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"},
                     "text": {
                       "type": "text"
                     }
@@ -452,12 +348,6 @@
                 "family": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -474,22 +364,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 },
                 "platform": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -502,12 +380,6 @@
             "domain": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -530,22 +402,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "id": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -562,12 +422,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "mac": {
               "ignore_above": 1024,
@@ -578,22 +432,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "architecture": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -614,12 +456,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "id": {
               "ignore_above": 1024,
@@ -630,22 +466,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "version": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {

--- a/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.packetbeat@custom.json
+++ b/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.packetbeat@custom.json
@@ -1,0 +1,12 @@
+{
+  "template": {
+    "settings": {}
+  },
+  "_meta": {
+    "package": {
+      "name": "elastic_agent"
+    },
+    "managed_by": "fleet",
+    "managed": true
+  }
+}

--- a/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.packetbeat@package.json
+++ b/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.packetbeat@package.json
@@ -1,0 +1,674 @@
+{
+  "template": {
+    "settings": {
+      "analysis": {
+        "analyzer": {
+          "es_security_analyzer": {
+            "type": "custom",
+            "char_filter": [
+              "whitespace_no_way"
+            ],
+            "filter": [
+              "lowercase",
+              "trim"
+            ],
+            "tokenizer": "keyword"
+          }
+        },
+        "char_filter": {
+          "whitespace_no_way": {
+            "type": "pattern_replace",
+            "pattern": "(\\s)+",
+            "replacement": "$1"
+          }
+        },
+        "filter": {
+          "path_hierarchy_pattern_filter": {
+            "type": "pattern_capture",
+            "preserve_original": true,
+            "patterns": [
+              "((?:[^\\\\]*\\\\)*)(.*)",
+              "((?:[^/]*/)*)(.*)"
+            ]
+          }
+        },
+        "tokenizer": {
+            "path_tokenizer": {
+              "type": "path_hierarchy",
+              "delimiter": "\\"
+            }
+          }
+        },
+      "index": {
+        "lifecycle": {
+          "name": "logs"
+        },
+        "codec": "best_compression",
+        "mapping": {
+          "total_fields": {
+            "limit": "10000"
+          }
+        },
+        "query": {
+          "default_field": [
+            "cloud.account.id",
+            "cloud.availability_zone",
+            "cloud.instance.id",
+            "cloud.instance.name",
+            "cloud.machine.type",
+            "cloud.provider",
+            "cloud.region",
+            "cloud.project.id",
+            "cloud.image.id",
+            "container.id",
+            "container.image.name",
+            "container.name",
+            "host.architecture",
+            "host.domain",
+            "host.hostname",
+            "host.id",
+            "host.mac",
+            "host.name",
+            "host.os.family",
+            "host.os.kernel",
+            "host.os.name",
+            "host.os.platform",
+            "host.os.version",
+            "host.os.build",
+            "host.os.codename",
+            "host.type",
+            "log.level",
+            "message",
+            "elastic_agent.id",
+            "elastic_agent.process",
+            "elastic_agent.version"
+          ]
+        }
+      }
+    },
+    "mappings": {
+      "dynamic": false,
+      "properties": {
+        "cloud": {
+          "properties": {
+            "availability_zone": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "image": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "instance": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "provider": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "machine": {
+              "properties": {
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "project": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "region": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "account": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            }
+          }
+        },
+        "container": {
+          "properties": {
+            "image": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "labels": {
+              "type": "object"
+            }
+          }
+        },
+        "@timestamp": {
+          "type": "date"
+        },
+        "ecs": {
+          "properties": {
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            }
+          }
+        },
+        "log": {
+          "properties": {
+            "level": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            }
+          }
+        },
+        "data_stream": {
+          "properties": {
+            "namespace": {
+              "type": "constant_keyword"
+            },
+            "type": {
+              "type": "constant_keyword"
+            },
+            "dataset": {
+              "type": "constant_keyword"
+            }
+          }
+        },
+        "host": {
+          "properties": {
+            "hostname": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "os": {
+              "properties": {
+                "build": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "kernel": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "codename": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword",
+                  "fields": {
+                    "text": {
+                      "type": "text"
+                    }
+                  }
+                },
+                "family": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "platform": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "ip": {
+              "type": "ip"
+            },
+            "containerized": {
+              "type": "boolean"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "mac": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "architecture": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            }
+          }
+        },
+        "elastic_agent": {
+          "properties": {
+            "process": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "snapshot": {
+              "type": "boolean"
+            }
+          }
+        },
+        "message": {
+          "type": "text"
+        }
+      }
+    }
+  },
+  "_meta": {
+    "package": {
+      "name": "elastic_agent"
+    },
+    "managed_by": "fleet",
+    "managed": true
+  }
+}

--- a/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.packetbeat@package.json
+++ b/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent.packetbeat@package.json
@@ -1,7 +1,7 @@
 {
   "template": {
     "settings": {
-      "analysis": {
+"analysis": {
         "analyzer": {
           "es_security_analyzer": {
             "type": "custom",
@@ -100,24 +100,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "image": {
               "properties": {
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -138,22 +126,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 },
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -172,24 +148,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "machine": {
               "properties": {
                 "type": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -210,12 +174,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 }
               }
             },
@@ -228,24 +186,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "account": {
               "properties": {
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -270,12 +216,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 }
               }
             },
@@ -288,22 +228,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "id": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -330,12 +258,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             }
           }
         },
@@ -344,12 +266,6 @@
             "level": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -383,24 +299,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "os": {
               "properties": {
                 "build": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -417,22 +321,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 },
                 "codename": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -444,6 +336,10 @@
                   "ignore_above": 1024,
                   "type": "keyword",
                   "fields": {
+
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"},
                     "text": {
                       "type": "text"
                     }
@@ -452,12 +348,6 @@
                 "family": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -474,22 +364,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 },
                 "platform": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -502,12 +380,6 @@
             "domain": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -530,22 +402,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "id": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -562,12 +422,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "mac": {
               "ignore_above": 1024,
@@ -578,22 +432,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "architecture": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -614,12 +456,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "id": {
               "ignore_above": 1024,
@@ -630,22 +466,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "version": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {

--- a/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent@custom.json
+++ b/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent@custom.json
@@ -1,0 +1,12 @@
+{
+  "template": {
+    "settings": {}
+  },
+  "_meta": {
+    "package": {
+      "name": "elastic_agent"
+    },
+    "managed_by": "fleet",
+    "managed": true
+  }
+}

--- a/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent@package.json
+++ b/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent@package.json
@@ -1,7 +1,7 @@
 {
   "template": {
     "settings": {
-      "analysis": {
+ "analysis": {
         "analyzer": {
           "es_security_analyzer": {
             "type": "custom",
@@ -39,7 +39,7 @@
             }
           }
         },
-      "index": {
+     "index": {
         "lifecycle": {
           "name": "logs"
         },
@@ -100,24 +100,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "image": {
               "properties": {
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -138,22 +126,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 },
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -172,24 +148,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "machine": {
               "properties": {
                 "type": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -210,12 +174,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 }
               }
             },
@@ -228,24 +186,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "account": {
               "properties": {
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -270,12 +216,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 }
               }
             },
@@ -288,22 +228,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "id": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -330,12 +258,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             }
           }
         },
@@ -344,12 +266,6 @@
             "level": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -383,24 +299,12 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "os": {
               "properties": {
                 "build": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -417,22 +321,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 },
                 "codename": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -444,6 +336,10 @@
                   "ignore_above": 1024,
                   "type": "keyword",
                   "fields": {
+
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"},
                     "text": {
                       "type": "text"
                     }
@@ -452,12 +348,6 @@
                 "family": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -474,22 +364,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
                 },
                 "platform": {
                   "ignore_above": 1024,
                   "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -502,12 +380,6 @@
             "domain": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -530,22 +402,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "id": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -562,12 +422,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "mac": {
               "ignore_above": 1024,
@@ -578,22 +432,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "architecture": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {
@@ -614,12 +456,6 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "id": {
               "ignore_above": 1024,
@@ -630,22 +466,10 @@
 "type": "text",
 "analyzer": "es_security_analyzer"}
 }
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
             },
             "version": {
               "ignore_above": 1024,
               "type": "keyword"
-,
-"fields": {
-"security": {
-"type": "text",
-"analyzer": "es_security_analyzer"}
-}
 ,
 "fields": {
 "security": {

--- a/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent@package.json
+++ b/salt/elasticsearch/templates/component/elastic-agent/logs-elastic_agent@package.json
@@ -1,0 +1,681 @@
+{
+  "template": {
+    "settings": {
+      "analysis": {
+        "analyzer": {
+          "es_security_analyzer": {
+            "type": "custom",
+            "char_filter": [
+              "whitespace_no_way"
+            ],
+            "filter": [
+              "lowercase",
+              "trim"
+            ],
+            "tokenizer": "keyword"
+          }
+        },
+        "char_filter": {
+          "whitespace_no_way": {
+            "type": "pattern_replace",
+            "pattern": "(\\s)+",
+            "replacement": "$1"
+          }
+        },
+        "filter": {
+          "path_hierarchy_pattern_filter": {
+            "type": "pattern_capture",
+            "preserve_original": true,
+            "patterns": [
+              "((?:[^\\\\]*\\\\)*)(.*)",
+              "((?:[^/]*/)*)(.*)"
+            ]
+          }
+        },
+        "tokenizer": {
+            "path_tokenizer": {
+              "type": "path_hierarchy",
+              "delimiter": "\\"
+            }
+          }
+        },
+      "index": {
+        "lifecycle": {
+          "name": "logs"
+        },
+        "codec": "best_compression",
+        "mapping": {
+          "total_fields": {
+            "limit": "10000"
+          }
+        },
+        "query": {
+          "default_field": [
+            "cloud.account.id",
+            "cloud.availability_zone",
+            "cloud.instance.id",
+            "cloud.instance.name",
+            "cloud.machine.type",
+            "cloud.provider",
+            "cloud.region",
+            "cloud.project.id",
+            "cloud.image.id",
+            "container.id",
+            "container.image.name",
+            "container.name",
+            "host.architecture",
+            "host.domain",
+            "host.hostname",
+            "host.id",
+            "host.mac",
+            "host.name",
+            "host.os.family",
+            "host.os.kernel",
+            "host.os.name",
+            "host.os.platform",
+            "host.os.version",
+            "host.os.build",
+            "host.os.codename",
+            "host.type",
+            "log.level",
+            "message",
+            "elastic_agent.id",
+            "elastic_agent.process",
+            "elastic_agent.version"
+          ]
+        }
+      }
+    },
+    "mappings": {
+      "dynamic": false,
+      "properties": {
+        "cloud": {
+          "properties": {
+            "availability_zone": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "image": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "instance": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "provider": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "machine": {
+              "properties": {
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "project": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "region": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "account": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            }
+          }
+        },
+        "container": {
+          "properties": {
+            "image": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "labels": {
+              "type": "object"
+            }
+          }
+        },
+        "@timestamp": {
+          "type": "date"
+        },
+        "ecs": {
+          "properties": {
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            }
+          }
+        },
+        "log": {
+          "properties": {
+            "level": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            }
+          }
+        },
+        "data_stream": {
+          "properties": {
+            "namespace": {
+              "type": "constant_keyword"
+            },
+            "type": {
+              "type": "constant_keyword"
+            },
+            "dataset": {
+              "type": "constant_keyword"
+            }
+          }
+        },
+        "host": {
+          "properties": {
+            "hostname": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "os": {
+              "properties": {
+                "build": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "kernel": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "codename": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword",
+                  "fields": {
+                    "text": {
+                      "type": "text"
+                    }
+                  }
+                },
+                "family": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                },
+                "platform": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+                }
+              }
+            },
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "ip": {
+              "type": "ip"
+            },
+            "containerized": {
+              "type": "boolean"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "mac": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "architecture": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            }
+          }
+        },
+        "elastic_agent": {
+          "properties": {
+            "process": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+,
+"fields": {
+"security": {
+"type": "text",
+"analyzer": "es_security_analyzer"}
+}
+            },
+            "snapshot": {
+              "type": "boolean"
+            }
+          }
+        },
+        "event": {
+          "properties": {
+            "dataset": {
+              "type": "constant_keyword"
+            }
+          }
+        },
+        "message": {
+          "type": "text"
+        }
+      }
+    }
+  },
+  "_meta": {
+    "package": {
+      "name": "elastic_agent"
+    },
+    "managed_by": "fleet",
+    "managed": true
+  }
+}

--- a/salt/elasticsearch/tools/sbin/so-elasticsearch-templates-load
+++ b/salt/elasticsearch/tools/sbin/so-elasticsearch-templates-load
@@ -1,9 +1,7 @@
 #!/bin/bash
 # Copyright Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
-# or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at 
-# https://securityonion.net/license; you may not use this file except in compliance with the
-# Elastic License 2.0.
-
+# or more contributor license agreements. Licensed under the Elastic License 2.0; you may not use
+# this file except in compliance with the Elastic License 2.0.
 
 
 {%- set mainint = salt['pillar.get']('host:mainint') %}
@@ -43,6 +41,11 @@ cd ${ELASTICSEARCH_TEMPLATES}/component/ecs
 
 echo "Loading ECS component templates..."
 for i in *; do TEMPLATE=$(echo $i | cut -d '.' -f1); echo "$TEMPLATE-mappings"; so-elasticsearch-query _component_template/$TEMPLATE-mappings -d@$i -XPUT 2>/dev/null; echo; done
+
+cd ${ELASTICSEARCH_TEMPLATES}/component/elastic-agent
+
+echo "Loading Elastic Agent component templates..."
+for i in *; do TEMPLATE=${i::-5}; echo "so-$TEMPLATE"; so-elasticsearch-query _component_template/so-$TEMPLATE -d@$i -XPUT 2>/dev/null; echo; done
 
 # Load SO-specific component templates
 cd ${ELASTICSEARCH_TEMPLATES}/component/so


### PR DESCRIPTION
- Adds Elastic agent component templates and index templates to be managed by Security Onion, so that we can implement the required customizations for the `.security` subfield.