### PR TITLE
FEATURE: so-pcap-export can run without needing to be attached to a TTY

### DIFF
--- a/salt/common/tools/sbin/so-pcap-export
+++ b/salt/common/tools/sbin/so-pcap-export
@@ -20,7 +20,7 @@ if [ $# -lt 2 ]; then
   exit 1
 fi
 
-docker exec -it so-sensoroni scripts/stenoquery.sh "$1" -w /nsm/pcapout/$2.pcap
+docker exec -t so-sensoroni scripts/stenoquery.sh "$1" -w /nsm/pcapout/$2.pcap
 
 echo ""
 echo "If successful, the output was written to: /nsm/pcapout/$2.pcap"


### PR DESCRIPTION
so-pcap-export was not able to be run automatically (in my case over a non-interactive SSH session.) This is due to the `-i` flag in the `docker exec ...` command. I see no reason why the interactive flag is needed as the script doesn't rely on TTY functionality.