### PR TITLE
Disable ecat_arp_info by default in so-zeek-logs and so-whiptail

### DIFF
--- a/salt/common/tools/sbin/so-zeek-logs
+++ b/salt/common/tools/sbin/so-zeek-logs
@@ -61,7 +61,7 @@ whiptail_manager_adv_service_zeeklogs() {
   "dnp3_control" "" ON \
   "dnp3_objects" "" ON \
   "ecat_aoe_info" "" ON \
-  "ecat_arp_info" "" ON \
+  "ecat_arp_info" "" OFF \
   "ecat_coe_info" "" ON \
   "ecat_dev_info" "" ON \
   "ecat_foe_info" "" ON \

--- a/setup/so-whiptail
+++ b/setup/so-whiptail
@@ -1331,7 +1331,7 @@ whiptail_manager_adv_service_zeeklogs() {
 	"dnp3_control" "" ON \
 	"dnp3_objects" "" ON \
         "ecat_aoe_info" "" ON \
-        "ecat_arp_info" "" ON \
+        "ecat_arp_info" "" OFF \
         "ecat_coe_info" "" ON \
         "ecat_dev_info" "" ON \
         "ecat_foe_info" "" ON \


### PR DESCRIPTION
ecat_arp_info is not specific to ecat and records all arp traffic.