### PR TITLE
so-status runs some code before checking for root privileges

### DIFF
--- a/salt/common/tools/sbin/so-status
+++ b/salt/common/tools/sbin/so-status
@@ -28,6 +28,11 @@ cat <<HELP_USAGE
 HELP_USAGE
 }
 
+if ! [ "$(id -u)" = 0 ]; then
+   echo "${0}: This command must be run as root"
+   exit 1
+fi
+
 # Constants
 QUIET=false
 EXITCODE=0
@@ -293,11 +298,6 @@ is_tty() {
 }
 
 # {% endraw %}
-
-if ! [ "$(id -u)" = 0 ]; then
-   echo "${0}: This command must be run as root"
-   exit 1
-fi
 
 while getopts ':hq' OPTION; do
   case "$OPTION" in


### PR DESCRIPTION
Fixes #9270. so-status doesn't check for root privileges before running some of the code (constant declarations). Not only does this waste a couple of seconds, it also outputs unhelpful error messages. This PR moves the privilege check to the top of the file.

Before PR:
```
[user@hostname ~]$ so-status
[ERROR   ] Could not cache minion ID: [Errno 13] Permission denied: '/etc/salt/minion_id'
[WARNING ] Failed to open log file, do you have permission to write to /var/log/salt/minion?
Cannot write to process directory. Do you have permissions to write to /var/cache/salt/minion/proc/20221202190926865812 ?
sort: cannot read: /opt/so/conf/so-status/so-status.conf: Permission denied
/usr/sbin/so-status: This command must be run as root
```

After PR:
```
[user@hostname ~]$ so-status
/usr/sbin/so-status: This command must be run as root
```

The output when run as root is unaffected.