### PR TITLE
so-status should ignore commented entries in so-status.conf

### DIFF
--- a/salt/common/tools/sbin/so-status
+++ b/salt/common/tools/sbin/so-status
@@ -96,6 +96,8 @@ def check_container_status(options, console):
   container_list = []
   expected_file = open(EXPECTED_CONTAINERS_FILE, "r")
   for container in expected_file:
+    if container.startswith('#'):
+      continue
     container = container.strip()
     exists = False
     details = { "Name": container, "Status": "missing", "Details": ""}


### PR DESCRIPTION
Import mode comments out so-steno, so-suricata, and so-zeek in so-status.conf, so so-status should ignore these lines.