### PR TITLE
Superuser permission check for so-elasticsearch-indices-list

### DIFF
--- a/salt/common/tools/sbin/so-elasticsearch-indices-list
+++ b/salt/common/tools/sbin/so-elasticsearch-indices-list
@@ -18,4 +18,9 @@
 
 . /usr/sbin/so-common
 
+if ! [ "$(id -u)" = 0 ]; then
+   echo "${0}: This command must be run as root"
+   exit 1
+fi
+
 {{ ELASTICCURL }} -s -k -L "https://{{ NODEIP }}:9200/_cat/indices?pretty&v&s=index"

--- a/salt/common/tools/sbin/so-status
+++ b/salt/common/tools/sbin/so-status
@@ -28,6 +28,11 @@ cat <<HELP_USAGE
 HELP_USAGE
 }
 
+if ! [ "$(id -u)" = 0 ]; then
+   echo "${0}: This command must be run as root"
+   exit 1
+fi
+
 # Constants
 QUIET=false
 EXITCODE=0
@@ -293,11 +298,6 @@ is_tty() {
 }
 
 # {% endraw %}
-
-if ! [ "$(id -u)" = 0 ]; then
-   echo "${0}: This command must be run as root"
-   exit 1
-fi
 
 while getopts ':hq' OPTION; do
   case "$OPTION" in

--- a/salt/common/tools/sbin/so-status
+++ b/salt/common/tools/sbin/so-status
@@ -28,11 +28,6 @@ cat <<HELP_USAGE
 HELP_USAGE
 }
 
-if ! [ "$(id -u)" = 0 ]; then
-   echo "${0}: This command must be run as root"
-   exit 1
-fi
-
 # Constants
 QUIET=false
 EXITCODE=0
@@ -298,6 +293,11 @@ is_tty() {
 }
 
 # {% endraw %}
+
+if ! [ "$(id -u)" = 0 ]; then
+   echo "${0}: This command must be run as root"
+   exit 1
+fi
 
 while getopts ':hq' OPTION; do
   case "$OPTION" in


### PR DESCRIPTION
The `curl.config` specified by `so-elasticsearch-indices-list` is only accessible with root permissions. If cURL is unable to access said file then it'll try to do the request without it and fail, spitting out vague error messages in the process. My PR fixes this by adding a simple superuser check before the request is run. Fixes #9461