### PR TITLE
Prevent unnecessary processes in Import Mode

### DIFF
--- a/salt/pcap/map.jinja
+++ b/salt/pcap/map.jinja
@@ -4,12 +4,8 @@
 # don't start the docker container if it is an import node or disabled via pillar
 {% if grains.id.split('_')|last == 'import' or ENABLED is sameas false %}
   {% do STENOOPTIONS.update({'start': False}) %}
-{% else %}
-  {% do STENOOPTIONS.update({'start': True}) %}
-{% endif %}
-
-{% if ENABLED is sameas false %}
   {% do STENOOPTIONS.update({'status': 'absent'}) %}
 {% else %}
+  {% do STENOOPTIONS.update({'start': True}) %}
   {% do STENOOPTIONS.update({'status': 'running'}) %}
 {% endif %}

--- a/salt/suricata/map.jinja
+++ b/salt/suricata/map.jinja
@@ -4,12 +4,8 @@
 # don't start the docker container if it is an import node or disabled via pillar
 {% if grains.id.split('_')|last == 'import' or ENABLED is sameas false %}
   {% do SURICATAOPTIONS.update({'start': False}) %}
-{% else %}
-  {% do SURICATAOPTIONS.update({'start': True}) %}
-{% endif %}
-
-{% if ENABLED is sameas false %}
   {% do SURICATAOPTIONS.update({'status': 'absent'}) %}
 {% else %}
+  {% do SURICATAOPTIONS.update({'start': True}) %}
   {% do SURICATAOPTIONS.update({'status': 'running'}) %}
 {% endif %}

--- a/salt/zeek/config.map.jinja
+++ b/salt/zeek/config.map.jinja
@@ -11,13 +11,9 @@
 {% if grains.id.split('_')|last == 'import' or not ENABLED %}
   {% do ZEEKOPTIONS.update({'start': False}) %}
   {% do ZEEKOPTIONS.update({'pl_cron_state': 'absent'}) %}
+  {% do ZEEKOPTIONS.update({'status': 'absent'}) %}
 {% else %}
   {% do ZEEKOPTIONS.update({'start': True}) %}
   {% do ZEEKOPTIONS.update({'pl_cron_state': 'present'}) %}
-{% endif %}
-
-{% if not ENABLED %}
-  {% do ZEEKOPTIONS.update({'status': 'absent'}) %}
-{% else %}
   {% do ZEEKOPTIONS.update({'status': 'running'}) %}
 {% endif %}


### PR DESCRIPTION
In Import Mode, we need pcap, suricata, and zeek to be enabled but not actually run live sniffing processes.

This has been tested in Import, Eval, and Standalone modes and works as expected.