### PR TITLE
Change priority for Elastic Agent Elasticsearch index templates

### DIFF
--- a/salt/elasticsearch/defaults.yaml
+++ b/salt/elasticsearch/defaults.yaml
@@ -82,7 +82,7 @@ elasticsearch:
           - "so-logs-elastic_agent.apm_server@custom"
           - "so-fleet_globals-1"
           - "so-fleet_agent_id_verification-1"
-        priority: 500
+        priority: 200
         _meta:
           package:
             name: elastic_agent
@@ -116,7 +116,7 @@ elasticsearch:
           - "so-logs-elastic_agent.auditbeat@custom"
           - "so-fleet_globals-1"
           - "so-fleet_agent_id_verification-1"
-        priority: 500
+        priority: 200
         _meta:
           package:
             name: elastic_agent
@@ -150,7 +150,7 @@ elasticsearch:
           - "so-logs-elastic_agent.cloudbeat@custom"
           - "so-fleet_globals-1"
           - "so-fleet_agent_id_verification-1"
-        priority: 500
+        priority: 200
         _meta:
           package:
             name: elastic_agent
@@ -184,7 +184,7 @@ elasticsearch:
           - "so-logs-elastic_agent.endpoint_security@custom"
           - "so-fleet_globals-1"
           - "so-fleet_agent_id_verification-1"
-        priority: 500
+        priority: 200
         _meta:
           package:
             name: elastic_agent
@@ -218,7 +218,7 @@ elasticsearch:
           - "so-logs-elastic_agent.filebeat@custom"
           - "so-fleet_globals-1"
           - "so-fleet_agent_id_verification-1"
-        priority: 500
+        priority: 200
         _meta:
           package:
             name: elastic_agent
@@ -252,7 +252,7 @@ elasticsearch:
           - "so-logs-elastic_agent.fleet_server@custom"
           - "so-fleet_globals-1"
           - "so-fleet_agent_id_verification-1"
-        priority: 500
+        priority: 200
         _meta:
           package:
             name: elastic_agent
@@ -286,7 +286,7 @@ elasticsearch:
           - "so-logs-elastic_agent.heartbeat@custom"
           - "so-fleet_globals-1"
           - "so-fleet_agent_id_verification-1"
-        priority: 500
+        priority: 200
         _meta:
           package:
             name: elastic_agent
@@ -320,7 +320,7 @@ elasticsearch:
           - "so-logs-elastic_agent@custom"
           - "so-fleet_globals-1"
           - "so-fleet_agent_id_verification-1"
-        priority: 500
+        priority: 200
         _meta:
           package:
             name: elastic_agent
@@ -354,7 +354,7 @@ elasticsearch:
           - "so-logs-elastic_agent.metricbeat@custom"
           - "so-fleet_globals-1"
           - "so-fleet_agent_id_verification-1"
-        priority: 500
+        priority: 200
         _meta:
           package:
             name: elastic_agent
@@ -388,7 +388,7 @@ elasticsearch:
           - "so-logs-elastic_agent.osquerybeat@custom"
           - "so-fleet_globals-1"
           - "so-fleet_agent_id_verification-1"
-        priority: 500
+        priority: 200
         _meta:
           package:
             name: elastic_agent
@@ -422,7 +422,7 @@ elasticsearch:
           - "so-logs-elastic_agent.packetbeat@custom"
           - "so-fleet_globals-1"
           - "so-fleet_agent_id_verification-1"
-        priority: 500
+        priority: 200
         _meta:
           package:
             name: elastic_agent


### PR DESCRIPTION
Change priority from 500 to 200 for Elastic Agent index templates to avoid collisions with other templates