### PR TITLE
Fix cloud sniffing interface configuration

### DIFF
--- a/salt/common/tools/sbin/so-common
+++ b/salt/common/tools/sbin/so-common
@@ -54,33 +54,37 @@ add_interface_bond0() {
 			ethtool -K "$BNIC" $i off &>/dev/null
 		fi
 	done
-	# Check if the bond slave connection has already been created
-	nmcli -f name,uuid -p con | grep -q "bond0-slave-$BNIC"
-	local found_int=$?
 
-	if [[ $found_int != 0 ]]; then
-		# Create the slave interface and assign it to the bond
-		nmcli con add type ethernet ifname "$BNIC" con-name "bond0-slave-$BNIC" master bond0 -- \
-			ethernet.mtu "$MTU" \
-			connection.autoconnect "yes"
-	else
-		local int_uuid
-		int_uuid=$(nmcli -f name,uuid -p con | sed -n "s/bond0-slave-$BNIC //p" | tr -d ' ')
+        if ! [[ is_cloud ]]; then
+	  # Check if the bond slave connection has already been created
+	  nmcli -f name,uuid -p con | grep -q "bond0-slave-$BNIC"
+	  local found_int=$?
 
-		nmcli con mod "$int_uuid" \
-			ethernet.mtu "$MTU" \
-			connection.autoconnect "yes"
-	fi
+	  if [[ $found_int != 0 ]]; then
+		  # Create the slave interface and assign it to the bond
+		  nmcli con add type ethernet ifname "$BNIC" con-name "bond0-slave-$BNIC" master bond0 -- \
+			  ethernet.mtu "$MTU" \
+			  connection.autoconnect "yes"
+	  else
+		  local int_uuid
+		  int_uuid=$(nmcli -f name,uuid -p con | sed -n "s/bond0-slave-$BNIC //p" | tr -d ' ')
+
+		  nmcli con mod "$int_uuid" \
+			  ethernet.mtu "$MTU" \
+			  connection.autoconnect "yes"
+	  fi
+        fi
 
 	ip link set dev "$BNIC" arp off multicast off allmulticast off promisc on
-			
-	# Bring the slave interface up
-	if [[ $verbose == true ]]; then
-		nmcli con up "bond0-slave-$BNIC"
-	else
-		nmcli con up "bond0-slave-$BNIC" &>/dev/null
+
+        if ! [[ is_cloud ]]; then
+	  # Bring the slave interface up
+	  if [[ $verbose == true ]]; then
+		  nmcli con up "bond0-slave-$BNIC"
+	  else
+		  nmcli con up "bond0-slave-$BNIC" &>/dev/null
+	  fi
 	fi
-	 
 	if [ "$nic_error" != 0 ]; then
 		return "$nic_error"
 	fi

--- a/salt/common/tools/sbin/so-common
+++ b/salt/common/tools/sbin/so-common
@@ -55,7 +55,7 @@ add_interface_bond0() {
 		fi
 	done
 
-        if ! [[ is_cloud ]]; then
+        if ! [[ $is_cloud ]]; then
 	  # Check if the bond slave connection has already been created
 	  nmcli -f name,uuid -p con | grep -q "bond0-slave-$BNIC"
 	  local found_int=$?
@@ -77,7 +77,7 @@ add_interface_bond0() {
 
 	ip link set dev "$BNIC" arp off multicast off allmulticast off promisc on
 
-        if ! [[ is_cloud ]]; then
+        if ! [[ $is_cloud ]]; then
 	  # Bring the slave interface up
 	  if [[ $verbose == true ]]; then
 		  nmcli con up "bond0-slave-$BNIC"

--- a/setup/so-functions
+++ b/setup/so-functions
@@ -802,9 +802,11 @@ compare_main_nic_ip() {
 configure_network_sensor() {
 	info "Setting up sensor interface"
 
-	if [[ $is_cloud ]]; then 
+	if [[ $is_cloud ]]; then
+                info "Configuring traditional interface settings, since this is a cloud installation..."
 		local nmcli_con_args=( "type" "ethernet" )
 	else 
+                info "Configuring bond interface settings, since this is a not a cloud installation..."
 		local nmcli_con_args=( "type" "bond" "mode" "0" )
 	fi
 
@@ -909,7 +911,7 @@ create_repo() {
 
 detect_cloud() {
   info "Testing if setup is running on a cloud instance..."
-  if ( curl --fail -s -m 5 http://169.254.169.254/latest/meta-data/instance-id > /dev/null ) || ( dmidecode -s bios-vendor | grep -q Google > /dev/null) || [ -f /var/log/waagent.log ]; then export is_cloud="true"; fi
+  if ( curl --fail -s -m 5 http://169.254.169.254/latest/meta-data/instance-id > /dev/null ) || ( dmidecode -s bios-vendor | grep -q Google > /dev/null) || [ -f /var/log/waagent.log ]; then info "Detected a cloud installation..." && export is_cloud="true"; fi
 }
 
 detect_os() {
@@ -1247,11 +1249,12 @@ generate_interface_vars() {
 	export MTU
 
 	# Set interface variable
-	if [[ $is_cloud ]]; then 
+	if [[ $is_cloud ]]; then
 		INTERFACE=${BNICS[0]}
 	else 
 		INTERFACE='bond0'
 	fi
+        info "Interface set to $INTERFACE"
 	export INTERFACE
 }
 

--- a/setup/so-setup
+++ b/setup/so-setup
@@ -566,7 +566,7 @@ if ! [[ -f $install_opt_file ]]; then
 		export NODE_DESCRIPTION=$NODE_DESCRIPTION
 		export MAINIP=$MAINIP
 		export PATCHSCHEDULENAME=$PATCHSCHEDULENAME
-		export INTERFACE="bond0"
+		export INTERFACE=$INTERFACE
 		export CORECOUNT=$lb_procs
 		export LSHOSTNAME=$HOSTNAME
 		export LSHEAP=$LS_HEAP_SIZE


### PR DESCRIPTION
- Add interface configuration information to `sosetup.log`
- Ensure that bond interfaces are not configured for cloud installations