### PR TITLE
soup: check_local_mods include deletes

### DIFF
--- a/salt/common/tools/sbin/soup
+++ b/salt/common/tools/sbin/soup
@@ -212,7 +212,7 @@ check_local_mods() {
     if [[ -f $default_file ]]; then
       file_diff=$(diff "$default_file" "$local_file" )
       if [[ ! " ${local_ignore_arr[*]} " =~ " ${local_file} " ]]; then
-        if [[ $(echo "$file_diff" | grep -c "^<") -gt 0 ]]; then
+        if [[ $(echo "$file_diff" | grep -Ec "^[<>]") -gt 0 ]]; then
           local_mod_arr+=( "$local_file" )
         fi
       fi


### PR DESCRIPTION
Checking for diff lines starting with less-than only finds additions.  This PR has grep check for less-than and greater-than, which identifies both additions and deletions when checking differences between default and local salt files while updating with soup.