### PR TITLE
Detect cloud install on forced imdsv2 instances

### DIFF
--- a/setup/so-functions
+++ b/setup/so-functions
@@ -919,7 +919,15 @@ create_repo() {
 
 detect_cloud() {
   info "Testing if setup is running on a cloud instance..."
-  if ( curl --fail -s -m 5 http://169.254.169.254/latest/meta-data/instance-id > /dev/null ) || ( dmidecode -s bios-vendor | grep -q Google > /dev/null) || [ -f /var/log/waagent.log ]; then info "Detected a cloud installation..." && export is_cloud="true"; fi
+  if ( curl --fail -s -m 5 http://169.254.169.254/latest/meta-data/instance-id > /dev/null ) || \
+     ( curl --fail -s -m 5 -H "X-aws-ec2-metadata-token: $(curl -s -X PUT 'http://169.254.169.254/latest/api/token' -H 'X-aws-ec2-metadata-token-ttl-seconds: 30')" http://169.254.169.254/latest/meta-data/instance-id > /dev/null) || \
+     (dmidecode -s bios-vendor | grep -q Google > /dev/null) || \
+     [ -f /var/log/waagent.log ]; then 
+
+    info "Detected a cloud installation..." && export is_cloud="true"; 
+  else
+    info "This does not appear to be a cloud installation."
+  fi
 }
 
 detect_os() {


### PR DESCRIPTION
Ensure that cloud is detected on AWS instances with IMDSv2 enabled with forced token requirements.

See #10181 by @juju4.