### PR TITLE
Detect cloud install on forced imdsv2 instances

### DIFF
--- a/setup/so-functions
+++ b/setup/so-functions
@@ -1124,7 +1124,16 @@ create_repo() {
 
 detect_cloud() {
   echo "Testing if setup is running on a cloud instance..." | tee -a "$setup_log"
-  if ( curl --fail -s -m 5 http://169.254.169.254/latest/meta-data/instance-id > /dev/null ) || ( dmidecode -s bios-vendor | grep -q Google > /dev/null) || [ -f /var/log/waagent.log ]; then export is_cloud="true"; fi
+  if ( curl --fail -s -m 5 http://169.254.169.254/latest/meta-data/instance-id > /dev/null ) || \
+     ( curl --fail -s -m 5 -H "X-aws-ec2-metadata-token: $(curl -s -X PUT 'http://169.254.169.254/latest/api/token' -H 'X-aws-ec2-metadata-token-ttl-seconds: 30')" http://169.254.169.254/latest/meta-data/instance-id > /dev/null) || \
+     (dmidecode -s bios-vendor | grep -q Google > /dev/null) || \
+     [ -f /var/log/waagent.log ]; then 
+
+    echo "Detected a cloud installation." | tee -a "$setup_log"
+    export is_cloud="true"
+  else
+    echo "This does not appear to be a cloud installation." | tee -a "$setup_log"
+  fi
 }
 
 detect_os() {


### PR DESCRIPTION
Ensure that cloud is detected on AWS instances with IMDSv2 enabled with forced token requirements.

See https://github.com/Security-Onion-Solutions/securityonion/pull/10181 by @juju4.