### PR TITLE
Add initial support for EQL queries for Elastalert

### DIFF
--- a/salt/elastalert/defaults.yaml
+++ b/salt/elastalert/defaults.yaml
@@ -13,6 +13,7 @@ elastalert:
     es_port: 9200
     es_conn_timeout: 55
     max_query_size: 5000
+    eql: true
     use_ssl: true
     verify_certs: false
     writeback_index: elastalert_status

--- a/salt/elastalert/map.jinja
+++ b/salt/elastalert/map.jinja
@@ -8,7 +8,7 @@
 {% set elastalert_pillar = salt['pillar.get']('elastalert:config', {}) %}
 
 
-{% do ELASTALERTDEFAULTS.elastalert.config.update({'es_host': GLOBALS.manager}) %}
+{% do ELASTALERTDEFAULTS.elastalert.config.update({'es_hosts': 'https://' + GLOBALS.manager + ':' + ELASTALERTDEFAULTS.elastalert.config.es_port|string}) %}
 {% do ELASTALERTDEFAULTS.elastalert.config.update({'es_username': pillar.elasticsearch.auth.users.so_elastic_user.user}) %}
 {% do ELASTALERTDEFAULTS.elastalert.config.update({'es_password': pillar.elasticsearch.auth.users.so_elastic_user.pass}) %}
 


### PR DESCRIPTION
- Updates `es_host` to `es_hosts` and changes the format of the host string to include the scheme and Elasticsearch port
- Adds option to use EQL 