### PR TITLE
Exclude Zeek's reporter.log from being picked up by Elastic Agent

### DIFF
--- a/salt/elasticfleet/files/integrations/grid-nodes/zeek-logs.json
+++ b/salt/elasticfleet/files/integrations/grid-nodes/zeek-logs.json
@@ -20,7 +20,7 @@
             "data_stream.dataset": "zeek",
             "tags": [],
             "processors": "- dissect:\n    tokenizer: \"/nsm/zeek/logs/current/%{pipeline}.log\"\n    field: \"log.file.path\"\n    trim_chars: \".log\"\n    target_prefix: \"\"\n- script:\n      lang: javascript\n      source: >\n        function process(event) {\n          var pl = event.Get(\"pipeline\");\n          event.Put(\"@metadata.pipeline\", \"zeek.\" + pl);\n        }\n- add_fields:\n    target: event\n    fields:\n      category: network\n      module: zeek\n- add_tags:\n    tags: \"ics\"\n    when:\n      regexp:\n        pipeline: \"^bacnet*|^bsap*|^cip*|^cotp*|^dnp3*|^ecat*|^enip*|^modbus*|^opcua*|^profinet*|^s7comm*\"",
-            "custom": "exclude_files: [\"broker|capture_loss|ecat_arp_info|known_hosts|known_services|loaded_scripts|ntp|packet_filter|stats|stderr|stdout.log$\"]\n"
+            "custom": "exclude_files: [\"broker|capture_loss|ecat_arp_info|known_hosts|known_services|loaded_scripts|ntp|packet_filter|reporter|stats|stderr|stdout.log$\"]\n"
           }
         }
       }


### PR DESCRIPTION
This issue/fix is related to the following issue: https://github.com/Security-Onion-Solutions/securityonion/issues/10291