### PR TITLE
Telegraf should monitor all mount points

### DIFF
--- a/salt/telegraf/etc/telegraf.conf
+++ b/salt/telegraf/etc/telegraf.conf
@@ -113,7 +113,7 @@
 [[inputs.disk]]
   ## By default stats will be gathered for all mount points.
   ## Set mount_points will restrict the stats to only the specified mount points.
-  mount_points = ["/", "/host/nsm"]
+  #mount_points = ["/", "/host/nsm"]
 
   ## Ignore mount points by filesystem type.
   #ignore_fs = ["tmpfs", "devtmpfs", "devfs", "overlay", "aufs", "squashfs"]


### PR DESCRIPTION
There's little advantage to filtering to just `/` and `/nsm`. This also avoids a filtering issue where the `/nsm` and `/host/nsm` are unaligned.