### PR TITLE
Allow an additional kratos endpoint through

### DIFF
--- a/salt/nginx/etc/nginx.conf
+++ b/salt/nginx/etc/nginx.conf
@@ -59,7 +59,7 @@ http {
 			proxy_set_header      X-Forwarded-For $proxy_add_x_forwarded_for;
 			proxy_set_header      Proxy "";
 			proxy_set_header      X-Forwarded-Proto $scheme;
-		} 
+		}
 	}
 
 	server {
@@ -95,7 +95,7 @@ http {
 			autoindex_localtime on;
 		}
 	}
-	
+
 	server {
 		listen       443 ssl http2;
 		server_name  {{ GLOBALS.url_base }};
@@ -160,7 +160,7 @@ http {
 			proxy_set_header      X-Forwarded-Proto $scheme;
 		}
 
-		location ~ ^/auth/.*?(whoami|logout|settings|webauthn.js) {
+		location ~ ^/auth/.*?(whoami|logout|settings|errors|webauthn.js) {
 			rewrite               /auth/(.*) /$1 break;
 			proxy_pass            http://{{ GLOBALS.manager }}:4433;
 			proxy_read_timeout    90;
@@ -204,7 +204,7 @@ http {
 			proxy_set_header      X-Forwarded-For $proxy_add_x_forwarded_for;
 			proxy_set_header      Proxy "";
 			proxy_set_header      X-Forwarded-Proto $scheme;
-		} 
+		}
 
 		location /repo/ {
 			allow all;
@@ -215,7 +215,7 @@ http {
 			autoindex_format html;
 			autoindex_localtime on;
 		}
-		
+
 		location /influxdb/ {
 			auth_request          /auth/sessions/whoami;
 			rewrite               /influxdb/api/(.*) /api/$1 break;
@@ -242,7 +242,7 @@ http {
 			proxy_set_header      Proxy "";
 			proxy_set_header      X-Forwarded-Proto $scheme;
 		}
-	
+
 		location /playbook/ {
 			auth_request          /auth/sessions/whoami;
 			proxy_pass            http://{{ GLOBALS.manager }}:3000/playbook/;
@@ -255,7 +255,7 @@ http {
 			proxy_set_header      X-Forwarded-Proto $scheme;
 		}
 
-	
+
 		location /soctopus/ {
 			auth_request          /auth/sessions/whoami;
 			proxy_pass            http://{{ GLOBALS.manager }}:7000/;


### PR DESCRIPTION
The /auth/self-service/errors route is used to lookup auth issues so the route must also be proxied to kratos.