### PR TITLE
Fix so-elastic-fleet-package-load

### DIFF
--- a/salt/elasticfleet/tools/sbin_jinja/so-elastic-fleet-package-load
+++ b/salt/elasticfleet/tools/sbin_jinja/so-elastic-fleet-package-load
@@ -11,7 +11,7 @@
 {%- for PACKAGE in SUPPORTED_PACKAGES %}
 echo "Setting up {{ PACKAGE }} package..."
 VERSION=$(elastic_fleet_package_version_check "{{ PACKAGE }}")
-elastic_fleet_package_install "{{ PACKAGE }}-$VERSION"
+elastic_fleet_package_install "{{ PACKAGE }}" "$VERSION"
 echo
 {%- endfor %}
 echo


### PR DESCRIPTION
Ensure the correct syntax is passed to the Elastic package install function in `so-elastic-fleet-common`.