### PR TITLE
Add more Elastic Fleet integrations

### DIFF
--- a/salt/elasticfleet/defaults.yaml
+++ b/salt/elasticfleet/defaults.yaml
@@ -26,20 +26,51 @@ elasticfleet:
         - stderr
         - stdout
   packages:
+    - auditd
     - aws
     - azure
+    - barracuda
+    - cisco_asa
     - cloudflare
+    - crowdstrike
+    - darktrace
     - elasticsearch
     - endpoint
+    - f5_bigip
     - fleet_server
     - fim
+    - fortinet
+    - gcp
     - github
     - google_workspace
+    - http_endpoint
+    - httpjson
+    - juniper
+    - juniper_srx
+    - kafka_log
+    - lastpass
     - log
+    - m365_defender
+    - microsoft_defender_endpoint
+    - microsoft_dhcp
+    - netflow
+    - o365
+    - okta
     - osquery_manager
+    - panw
+    - pfsense
     - redis
+    - sentinel_one
+    - sonicwall_firewall
+    - symantec_endpoint
     - system
     - tcp
+    - ti_abusech
+    - ti_misp
+    - ti_otx
+    - ti_recordedfuture
     - udp
     - windows
+    - zscaler_zia
+    - zscaler_zpa
     - 1password

--- a/salt/elasticsearch/defaults.yaml
+++ b/salt/elasticsearch/defaults.yaml
@@ -286,6 +286,24 @@ elasticsearch:
         data_stream:
           hidden: false
           allow_custom_routing: false
+    so-logs-auditd_x_log:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-auditd.log-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-auditd.log@package"
+          - "logs-auditd.log@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
     so-logs-aws_x_cloudtrail:
       index_sorting: False
       index_template:
@@ -646,6 +664,42 @@ elasticsearch:
         data_stream:
           hidden: false
           allow_custom_routing: false
+    so-logs-barracuda_x_waf:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-barracuda.waf-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-barracuda.waf@package"
+          - "logs-barracuda.waf@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-cisco_asa_x_log:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-cisco_asa.log-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-cisco_asa.log@package"
+          - "logs-cisco_asa.log@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
     so-logs-cloudflare_x_audit:
       index_sorting: False
       index_template:
@@ -682,6 +736,114 @@ elasticsearch:
         data_stream:
           hidden: false
           allow_custom_routing: false
+    so-logs-crowdstrike_x_falcon:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-crowdstrike.falcon-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-crowdstrike.falcon@package"
+          - "logs-crowdstrike.falcon@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-crowdstrike_x_fdr:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-crowdstrike.fdr-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-crowdstrike.fdr@package"
+          - "logs-crowdstrike.fdr@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-darktrace_x_ai_analyst_alert:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-darktrace.ai_analyst_alert-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-darktrace.ai_analyst_alert@package"
+          - "logs-darktrace.ai_analyst_alert@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-darktrace_x_model_breach_alert:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-darktrace.model_breach_alert-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-darktrace.model_breach_alert@package"
+          - "logs-darktrace.model_breach_alert@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-darktrace_x_system_status_alert:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-darktrace.system_status_alert-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-darktrace.system_status_alert@package"
+          - "logs-darktrace.system_status_alert@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-f5_bigip_x_log:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-f5_bigip.log-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-f5_bigip.log@package"
+          - "logs-f5_bigip.log@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
     so-logs-fim_x_event:
       index_sorting: False
       index_template:
@@ -694,6 +856,186 @@ elasticsearch:
         composed_of:
           - "logs-fim.event@package"
           - "logs-fim.event@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-fortinet_x_clientendpoint:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-fortinet.clientendpoint-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-fortinet.clientendpoint@package"
+          - "logs-fortinet.clientendpoint@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-fortinet_x_firewall:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-fortinet.firewall-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-fortinet.firewall@package"
+          - "logs-fortinet.firewall@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-fortinet_x_fortimail:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-fortinet.fortimail-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-fortinet.fortimail@package"
+          - "logs-fortinet.fortimail@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-fortinet_x_fortimanager:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-fortinet.fortimanager-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-fortinet.fortimanager@package"
+          - "logs-fortinet.fortimanager@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-fortinet_x_fortigate:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-fortinet.fortigate-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-fortinet.fortigate@package"
+          - "logs-fortinet.fortigate@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-gcp_x_audit:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-gcp.audit-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-gcp.audit@package"
+          - "logs-gcp.audit@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-gcp_x_dns:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-gcp.dns-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-gcp.dns@package"
+          - "logs-gcp.dns@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-gcp_x_firewall:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-gcp.firewall-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-gcp.firewall@package"
+          - "logs-gcp.firewall@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-gcp_x_loadbalancing_logs:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-gcp.loadbalancing_logs-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-gcp.loadbalancing_logs@package"
+          - "logs-gcp.loadbalancing_logs@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-gcp_x_vpcflow:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-gcp.vpcflow-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-gcp.vpcflow@package"
+          - "logs-gcp.vpcflow@custom"
           - "so-fleet_globals-1"
           - "so-fleet_agent_id_verification-1"
         priority: 501
@@ -1036,6 +1378,798 @@ elasticsearch:
         composed_of:
           - "logs-google_workspace.user_accounts@package"
           - "logs-google_workspace.user_accounts@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-http_endpoint_x_generic:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-http_endpoint.generic-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-http_endpoint.generic@package"
+          - "logs-http_endpoint.generic@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-httpjson_x_generic:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-httpjson.generic-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-httpjson.generic@package"
+          - "logs-httpjson.generic@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-juniper_x_junos:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-juniper.junos-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-juniper.junos@package"
+          - "logs-juniper.junos@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-juniper_x_netscreen:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-juniper.netscreen-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-juniper.netscreen@package"
+          - "logs-juniper.netscreen@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-juniper_x_srx:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-juniper.srx-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-juniper.srx@package"
+          - "logs-juniper.srx@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-juniper_srx_x_log:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-juniper_srx.log-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-juniper_srx.log@package"
+          - "logs-juniper_srx.log@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-kafka_log_x_generic:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-kafka_log.generic-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-kafka_log.generic@package"
+          - "logs-kafka_log.generic@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-lastpass_x_detailed_shared_folder:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-lastpass.detailed_shared_folder-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-lastpass.detailed_shared_folder@package"
+          - "logs-lastpass.detailed_shared_folder@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-lastpass_x_event_report:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-lastpass.event_report-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-lastpass.event_report@package"
+          - "logs-lastpass.event_report@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-lastpass_x_user:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-lastpass.user-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-lastpass.user@package"
+          - "logs-lastpass.user@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-m365_defender_x_event:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-m365_defender.event-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-m365_defender.event@package"
+          - "logs-m365_defender.event@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-m365_defender_x_incident:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-m365_defender.incident-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-m365_defender.incident@package"
+          - "logs-m365_defender.incident@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-m365_defender_x_log:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-m365_defender.log-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-m365_defender.log@package"
+          - "logs-m365_defender.log@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-microsoft_defender_endpoint_x_log:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-microsoft_defender_endpoint.log-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-microsoft_defender_endpoint.log@package"
+          - "logs-microsoft_defender_endpoint.log@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-microsoft_dhcp_x_log:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-microsoft_dhcp.log-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-microsoft_dhcp.log@package"
+          - "logs-microsoft_dhcp.log@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-netflow_x_log:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-netflow.log-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-netflow.log@package"
+          - "logs-netflow.log@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-panw_x_panos:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-panw.panos-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-panw.panos@package"
+          - "logs-panw.panos@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-pfsense_x_log:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-pfsense.log-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-pfsense.log@package"
+          - "logs-pfsense.log@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-sentinel_one_x_activity:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-sentinel_one.activity-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-sentinel_one.activity@package"
+          - "logs-sentinel_one.activity@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-sentinel_one_x_agent:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-sentinel_one.agent-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-sentinel_one.agent@package"
+          - "logs-sentinel_one.agent@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-sentinel_one_x_alert:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-sentinel_one.alert-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-sentinel_one.alert@package"
+          - "logs-sentinel_one.alert@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-sentinel_one_x_group:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-sentinel_one.group-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-sentinel_one.group@package"
+          - "logs-sentinel_one.group@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-sentinel_one_x_threat:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-sentinel_one.threat-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-sentinel_one.threat@package"
+          - "logs-sentinel_one.threat@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-sonicwall_firewall_x_log:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-sonicwall_firewall.log-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-sonicwall_firewall.log@package"
+          - "logs-sonicwall_firewall.log@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-symantec_endpoint_x_log:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-symantec_endpoint.log-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-symantec_endpoint.log@package"
+          - "logs-symantec_endpoint.log@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-ti_abusech_x_malware:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-ti_abusech.malware-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-ti_abusech.malware@package"
+          - "logs-ti_abusech.malware@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-ti_abusech_x_malwarebazaar:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-ti_abusech.malwarebazaar-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-ti_abusech.malwarebazaar@package"
+          - "logs-ti_abusech.malwarebazaar@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-ti_abusech_x_threatfox:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-ti_abusech.threatfox-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-ti_abusech.threatfox@package"
+          - "logs-ti_abusech.threatfox@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-ti_abusech_x_url:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-ti_abusech.url-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-ti_abusech.url@package"
+          - "logs-ti_abusech.url@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-ti_misp_x_threat:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-ti_misp.threat-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-ti_misp.threat@package"
+          - "logs-ti_misp.threat@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-ti_misp_x_threat_attributes:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-ti_misp.threat_attributes-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-ti_misp.threat_attributes@package"
+          - "logs-ti_misp.threat_attributes@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-ti_otx_x_threat:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-ti_otx.threat-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-ti_otx.threat@package"
+          - "logs-ti_otx.threat@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-ti_recordedfuture_x_latest_ioc-template:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-ti_recordedfuture.latest_ioc-template-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-ti_recordedfuture.latest_ioc-template@package"
+          - "logs-ti_recordedfuture.latest_ioc-template@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-ti_recordedfuture_x_threat:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-ti_recordedfuture.threat-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-ti_recordedfuture.threat@package"
+          - "logs-ti_recordedfuture.threat@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-zscaler_zia_x_alerts:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-zscaler_zia.alerts-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-zscaler_zia.alerts@package"
+          - "logs-zscaler_zia.alerts@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-zscaler_zia_x_dns:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-zscaler_zia.dns-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-zscaler_zia.dns@package"
+          - "logs-zscaler_zia.dns@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-zscaler_zia_x_firewall:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-zscaler_zia.firewall-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-zscaler_zia.firewall@package"
+          - "logs-zscaler_zia.firewall@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-zscaler_zia_x_tunnel:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-zscaler_zia.tunnel-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-zscaler_zia.tunnel@package"
+          - "logs-zscaler_zia.tunnel@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-zscaler_zia_x_web:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-zscaler_zia.web-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-zscaler_zia.web@package"
+          - "logs-zscaler_zia.web@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-zscaler_zpa_x_app_connector_status:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-zscaler_zpa.app_connector_status-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-zscaler_zpa.app_connector_status@package"
+          - "logs-zscaler_zpa.app_connector_status@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-zscaler_zpa_x_audit:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-zscaler_zpa.audit-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-zscaler_zpa.audit@package"
+          - "logs-zscaler_zpa.audit@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-zscaler_zpa_x_browser_access:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-zscaler_zpa.browser_access-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-zscaler_zpa.browser_access@package"
+          - "logs-zscaler_zpa.browser_access@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-zscaler_zpa_x_user_activity:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-zscaler_zpa.user_activity-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-zscaler_zpa.user_activity@package"
+          - "logs-zscaler_zpa.user_activity@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-zscaler_zpa_x_user_status:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-zscaler_zpa.user_status-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-zscaler_zpa.user_status@package"
+          - "logs-zscaler_zpa.user_status@custom"
           - "so-fleet_globals-1"
           - "so-fleet_agent_id_verification-1"
         priority: 501

--- a/salt/elasticsearch/defaults.yaml
+++ b/salt/elasticsearch/defaults.yaml
@@ -1672,6 +1672,42 @@ elasticsearch:
         data_stream:
           hidden: false
           allow_custom_routing: false
+    so-logs-o365_x_audit:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-o365.audit-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-o365.audit@package"
+          - "logs-o365.audit@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
+    so-logs-okta_x_system:
+      index_sorting: False
+      index_template:
+        index_patterns:
+          - "logs-okta.system-*"
+        template:
+          settings:
+            index:
+              number_of_replicas: 0
+        composed_of:
+          - "logs-okta.system@package"
+          - "logs-okta.system@custom"
+          - "so-fleet_globals-1"
+          - "so-fleet_agent_id_verification-1"
+        priority: 501
+        data_stream:
+          hidden: false
+          allow_custom_routing: false
     so-logs-panw_x_panos:
       index_sorting: False
       index_template:

--- a/salt/elasticsearch/soc_elasticsearch.yaml
+++ b/salt/elasticsearch/soc_elasticsearch.yaml
@@ -278,8 +278,8 @@ elasticsearch:
     so-logs-microsoft_defender_endpoint_x_log: *indexSettings
     so-logs-microsoft_dhcp_x_log: *indexSettings
     so-logs-netflow_x_log: *indexSettings
-    so-logs-okta_x_system: *indexSettings
     so-logs-o365_x_audit: *indexSettings
+    so-logs-okta_x_system: *indexSettings
     so-logs-panw_x_panos: *indexSettings
     so-logs-pfsense_x_log: *indexSettings
     so-logs-sentinel_one_x_activity: *indexSettings

--- a/salt/elasticsearch/soc_elasticsearch.yaml
+++ b/salt/elasticsearch/soc_elasticsearch.yaml
@@ -201,6 +201,7 @@ elasticsearch:
     so-logs-windows_x_powershell: *indexSettings
     so-logs-windows_x_powershell_operational: *indexSettings
     so-logs-windows_x_sysmon_operational: *indexSettings
+    so-logs-auditd_x_log: *indexSettings
     so-logs-aws_x_cloudtrail: *indexSettings
     so-logs-aws_x_cloudwatch_logs: *indexSettings
     so-logs-aws_x_ec2_logs: *indexSettings
@@ -221,9 +222,27 @@ elasticsearch:
     so-logs-azure_x_provisioning: *indexSettings
     so-logs-azure_x_signinlogs: *indexSettings
     so-logs-azure_x_springcloudlogs: *indexSettings
+    so-logs-barracuda_x_waf: *indexSettings
+    so-logs-cisco_asa_x_log: *indexSettings
     so-logs-cloudflare_x_audit: *indexSettings
     so-logs-cloudflare_x_logpull: *indexSettings
+    so-logs-crowdstrike_x_falcon: *indexSettings
+    so-logs-crowdstrike_x_fdr: *indexSettings
+    so-logs-darktrace_x_ai_analyst_alert: *indexSettings
+    so-logs-darktrace_x_model_breach_alert: *indexSettings
+    so-logs-darktrace_x_system_status_alert: *indexSettings
+    so-logs-f5_bigip_x_log: *indexSettings
     so-logs-fim_x_event: *indexSettings
+    so-logs-fortinet_x_clientendpoint: *indexSettings
+    so-logs-fortinet_x_firewall: *indexSettings
+    so-logs-fortinet_x_fortimail: *indexSettings
+    so-logs-fortinet_x_fortimanager: *indexSettings
+    so-logs-fortinet_x_fortigate: *indexSettings
+    so-logs-gcp_x_audit: *indexSettings
+    so-logs-gcp_x_dns: *indexSettings
+    so-logs-gcp_x_firewall: *indexSettings
+    so-logs-gcp_x_loadbalancing_logs: *indexSettings
+    so-logs-gcp_x_vpcflow: *indexSettings
     so-logs-github_x_audit: *indexSettings
     so-logs-github_x_code_scanning: *indexSettings
     so-logs-github_x_dependabot: *indexSettings
@@ -243,6 +262,50 @@ elasticsearch:
     so-logs-google_workspace_x_saml: *indexSettings
     so-logs-google_workspace_x_token: *indexSettings
     so-logs-google_workspace_x_user_accounts: *indexSettings
+    so-logs-http_endpoint_x_generic: *indexSettings
+    so-logs-httpjson_x_generic: *indexSettings
+    so-logs-juniper_x_junos: *indexSettings
+    so-logs-juniper_x_netscreen: *indexSettings
+    so-logs-juniper_x_srx: *indexSettings
+    so-logs-juniper_srx_x_log: *indexSettings
+    so-logs-kafka_log_x_generic: *indexSettings
+    so-logs-lastpass_x_detailed_shared_folder: *indexSettings
+    so-logs-lastpass_x_event_report: *indexSettings
+    so-logs-lastpass_x_user: *indexSettings
+    so-logs-m365_defender_x_event: *indexSettings
+    so-logs-m365_defender_x_incident: *indexSettings
+    so-logs-m365_defender_x_log: *indexSettings
+    so-logs-microsoft_defender_endpoint_x_log: *indexSettings
+    so-logs-microsoft_dhcp_x_log: *indexSettings
+    so-logs-netflow_x_log: *indexSettings
+    so-logs-panw_x_panos: *indexSettings
+    so-logs-pfsense_x_log: *indexSettings
+    so-logs-sentinel_one_x_activity: *indexSettings
+    so-logs-sentinel_one_x_agent: *indexSettings
+    so-logs-sentinel_one_x_alert: *indexSettings
+    so-logs-sentinel_one_x_group: *indexSettings
+    so-logs-sentinel_one_x_threat: *indexSettings
+    so-logs-sonicwall_firewall_x_log: *indexSettings
+    so-logs-symantec_endpoint_x_log: *indexSettings
+    so-logs-ti_abusech_x_malware: *indexSettings
+    so-logs-ti_abusech_x_malwarebazaar: *indexSettings
+    so-logs-ti_abusech_x_threatfox: *indexSettings
+    so-logs-ti_abusech_x_url: *indexSettings
+    so-logs-ti_misp_x_threat: *indexSettings
+    so-logs-ti_misp_x_threat_attributes: *indexSettings
+    so-logs-ti_otx_x_threat: *indexSettings
+    so-logs-ti_recordedfuture_x_latest_ioc-template: *indexSettings
+    so-logs-ti_recordedfuture_x_threat: *indexSettings
+    so-logs-zscaler_zia_x_alerts: *indexSettings
+    so-logs-zscaler_zia_x_dns: *indexSettings
+    so-logs-zscaler_zia_x_firewall: *indexSettings
+    so-logs-zscaler_zia_x_tunnel: *indexSettings
+    so-logs-zscaler_zia_x_web: *indexSettings
+    so-logs-zscaler_zpa_x_app_connector_status: *indexSettings
+    so-logs-zscaler_zpa_x_audit: *indexSettings
+    so-logs-zscaler_zpa_x_browser_access: *indexSettings
+    so-logs-zscaler_zpa_x_user_activity: *indexSettings
+    so-logs-zscaler_zpa_x_user_status: *indexSettings
     so-logs-1password_x_item_usages: *indexSettings
     so-logs-1password_x_signin_attempts: *indexSettings
     so-logs-osquery-manager-actions: *indexSettings

--- a/salt/elasticsearch/soc_elasticsearch.yaml
+++ b/salt/elasticsearch/soc_elasticsearch.yaml
@@ -278,6 +278,8 @@ elasticsearch:
     so-logs-microsoft_defender_endpoint_x_log: *indexSettings
     so-logs-microsoft_dhcp_x_log: *indexSettings
     so-logs-netflow_x_log: *indexSettings
+    so-logs-okta_x_system: *indexSettings
+    so-logs-o365_x_audit: *indexSettings
     so-logs-panw_x_panos: *indexSettings
     so-logs-pfsense_x_log: *indexSettings
     so-logs-sentinel_one_x_activity: *indexSettings


### PR DESCRIPTION
Adds the following integrations and templates:

- auditd
- barracuda
- cisco_asa
- crowdstrike
- darktrace
- f5_bigip
- fortinet
- gcp
- http_endpoint
- httpjson
- juniper
- juniper_srx
- kafka_log
- lastpass
- m365_defender
- microsoft_defender_endpoint
- microsoft_dhcp
- netflow
- o365
- okta
- panw
- pfsense
- sentinel_one
- sonicwall_firewall
- symantec_endpoint
- ti_abusech
- ti_misp
- ti_otx
- ti_recordedfuture
- zscaler_zia
- zscaler_zpa