### PR TITLE
New Config Default: longRelayTimeoutMs

### DIFF
--- a/salt/soc/defaults.yaml
+++ b/salt/soc/defaults.yaml
@@ -1012,6 +1012,7 @@ soc:
           verifyCert: false
         salt:
           queueDir: /opt/sensoroni/queue
+          longRelayTimeoutMs: 120000
         sostatus:
           refreshIntervalMs: 30000
           offlineThresholdMs: 900000

--- a/salt/soc/soc_soc.yaml
+++ b/salt/soc/soc_soc.yaml
@@ -111,6 +111,11 @@ soc:
             description: Duration (in milliseconds) that must elapse after a grid node fails to check-in before the node will be marked offline (fault).
             global: True
             advanced: True
+        salt:
+          longRelayTimeoutMs:
+            description: Duration (in milliseconds) to wait for a response from the Salt API when executing tasks known for being long running before giving up and showing an error on the SOC UI.
+            global: True
+            advanced: True
       client:
         enableReverseLookup:
           description: Set to true to enable reverse DNS lookups for IP addresses in the SOC UI.


### PR DESCRIPTION
Salt is getting a second timeout for operations known to take a long time such as sending and importing files. There's also an entry in soc_soc.yaml so the value can be changed in SOC's config page.