### PR TITLE
FIX: SOC Config pcap doc links should point to steno docs #11302

### DIFF
--- a/salt/pcap/soc_pcap.yaml
+++ b/salt/pcap/soc_pcap.yaml
@@ -1,35 +1,35 @@
 pcap:
   enabled: 
     description: You can enable or disable Stenographer on all sensors or a single sensor.
-    helpLink: pcap.html
+    helpLink: stenographer.html
   config:
     maxdirectoryfiles:
       description: The maximum number of packet/index files to create before deleting old files.
-      helpLink: pcap.html
+      helpLink: stenographer.html
     diskfreepercentage:
       description: The disk space percent to always keep free for PCAP
-      helpLink: pcap.html
+      helpLink: stenographer.html
     blocks:
       description: The number of 1MB packet blocks used by AF_PACKET to store packets in memory, per thread. You shouldn't need to change this. 
       advanced: True
-      helpLink: pcap.html
+      helpLink: stenographer.html
     preallocate_file_mb:
       description: File size to pre-allocate for individual PCAP files. You shouldn't need to change this. 
       advanced: True
-      helpLink: pcap.html
+      helpLink: stenographer.html
     aiops:
       description: The max number of async writes to allow at once.
       advanced: True
-      helpLink: pcap.html
+      helpLink: stenographer.html
     pin_to_cpu:
       description: Enable CPU pinning for PCAP.
       advanced: True
-      helpLink: pcap.html
+      helpLink: stenographer.html
     cpus_to_pin_to:
       description: CPU to pin PCAP to. Currently only a single CPU is supported.
       advanced: True
-      helpLink: pcap.html
+      helpLink: stenographer.html
     disks:
       description: List of disks to use for PCAP. This is currently not used.
       advanced: True
-      helpLink: pcap.html
+      helpLink: stenographer.html


### PR DESCRIPTION
In SOC Config, the values in the pcap section all link to pcap.html which is the documentation for the PCAP web interface. These values are for the underlying stenographer process so we should link to stenographer.html.

