### PR TITLE
exclude docker pull unauth errors from failing setup

### DIFF
--- a/setup/so-verify
+++ b/setup/so-verify
@@ -52,6 +52,7 @@ log_has_errors() {
         grep -vE "/nsm/rules/yara*" | \
         grep -vE "Failed to restart snapd" | \
         grep -vE "Login Failed Details" | \
+        grep -vE "response from daemon: unauthorized" | \
         grep -vE "Running scope as unit" &> "$error_log"
     
     if [[ $? -eq 0 ]]; then


### PR DESCRIPTION
These are network or GitHub or Docker issues, and SO will retry them.