### PR TITLE
FIX: SOC Config sensoroni doc links should point to correct docs #11362

### DIFF
--- a/salt/sensoroni/soc_sensoroni.yaml
+++ b/salt/sensoroni/soc_sensoroni.yaml
@@ -2,53 +2,53 @@ sensoroni:
   enabled:
     description: Enable or disable Sensoroni.
     advanced: True
-    helpLink: sensoroni.html
+    helpLink: grid.html
   config:
     analyze:
       enabled:
         description: Enable or disable the analyzer.
         advanced: True
-        helpLink: sensoroni.html
+        helpLink: cases.html
       timeout_ms:
         description: Timeout period for the analyzer.
         advanced: True
-        helpLink: sensoroni.html
+        helpLink: cases.html
       parallel_limit:
         description: Parallel limit for the analyzer.
         advanced: True
-        helpLink: sensoroni.html
+        helpLink: cases.html
     node_checkin_interval_ms:
       description: Interval in ms to checkin to the soc_host.
       advanced: True
-      helpLink: sensoroni.html
+      helpLink: grid.html
     node_description:
       description: Description of the specific node.
-      helpLink: sensoroni.html
+      helpLink: grid.html
       node: True
       forcedType: string
     sensoronikey:
       description: Shared key for sensoroni authentication.
-      helpLink: sensoroni.html
+      helpLink: grid.html
       global: True
       sensitive: True
       advanced: True
     soc_host:
       description: Host for sensoroni agents to connect to.
-      helpLink: sensoroni.html
+      helpLink: grid.html
       global: True
       advanced: True
   analyzers:
     emailrep:
       api_key:
         description: API key for the EmailRep analyzer.
-        helpLink: sensoroni.html
+        helpLink: cases.html
         global: False
         sensitive: True
         advanced: True
         forcedType: string
       base_url:
         description: Base URL for the EmailRep analyzer.
-        helpLink: sensoroni.html
+        helpLink: cases.html
         global: False
         sensitive: False
         advanced: True
@@ -56,21 +56,21 @@ sensoroni:
     greynoise:
       api_key:
         description: API key for the GreyNoise analyzer.
-        helpLink: sensoroni.html
+        helpLink: cases.html
         global: False
         sensitive: True
         advanced: True
         forcedType: string
       api_version:
         description: API version for the GreyNoise analyzer.
-        helpLink: sensoroni.html
+        helpLink: cases.html
         global: False
         sensitive: False
         advanced: True
         forcedType: string
       base_url:
         description: Base URL for the GreyNoise analyzer.
-        helpLink: sensoroni.html
+        helpLink: cases.html
         global: False
         sensitive: False
         advanced: True
@@ -78,7 +78,7 @@ sensoroni:
     localfile:
       file_path:
         description: File path for the LocalFile analyzer.
-        helpLink: sensoroni.html
+        helpLink: cases.html
         global: False
         sensitive: False
         advanced: True
@@ -86,14 +86,14 @@ sensoroni:
     otx:
       api_key:
         description: API key for the OTX analyzer.
-        helpLink: sensoroni.html
+        helpLink: cases.html
         global: False
         sensitive: True
         advanced: True
         forcedType: string
       base_url:
         description: Base URL for the OTX analyzer.
-        helpLink: sensoroni.html
+        helpLink: cases.html
         global: False
         sensitive: False
         advanced: True
@@ -101,14 +101,14 @@ sensoroni:
     pulsedive:
       api_key:
         description: API key for the Pulsedive analyzer.
-        helpLink: sensoroni.html
+        helpLink: cases.html
         global: False
         sensitive: True
         advanced: True
         forcedType: string
       base_url:
         description: Base URL for the Pulsedive analyzer.
-        helpLink: sensoroni.html
+        helpLink: cases.html
         global: False
         sensitive: False
         advanced: True
@@ -116,14 +116,14 @@ sensoroni:
     spamhaus:
       lookup_host:
         description: Host to use for lookups.
-        helpLink: sensoroni.html
+        helpLink: cases.html
         global: False
         sensitive: False
         advanced: True
         forcedType: string
       nameservers:
         description: Nameservers used for queries.
-        helpLink: sensoroni.html
+        helpLink: cases.html
         global: False
         sensitive: False
         advanced: True
@@ -131,35 +131,35 @@ sensoroni:
     urlscan:
       api_key:
         description: API key for the Urlscan analyzer.
-        helpLink: sensoroni.html
+        helpLink: cases.html
         global: False
         sensitive: True
         advanced: True
         forcedType: string
       base_url:
         description: Base URL for the Urlscan analyzer.
-        helpLink: sensoroni.html
+        helpLink: cases.html
         global: False
         sensitive: False
         advanced: True
         forcedType: string
       enabled:
         description: Analyzer enabled
-        helpLink: sensoroni.html
+        helpLink: cases.html
         global: False
         sensitive: False
         advanced: True
         forcedType: bool
       timeout:
         description: Timeout for the Urlscan analyzer.
-        helpLink: sensoroni.html
+        helpLink: cases.html
         global: False
         sensitive: False
         advanced: True
         forcedType: int
       visibility:
         description: Type of visibility.
-        helpLink: sensoroni.html
+        helpLink: cases.html
         global: False
         sensitive: False
         advanced: True
@@ -167,14 +167,14 @@ sensoroni:
     virustotal:
       api_key:
         description: API key for the VirusTotal analyzer.
-        helpLink: sensoroni.html
+        helpLink: cases.html
         global: False
         sensitive: True
         advanced: True
         forcedType: string
       base_url:
         description: Base URL for the VirusTotal analyzer.
-        helpLink: sensoroni.html
+        helpLink: cases.html
         global: False
         sensitive: False
         advanced: True


### PR DESCRIPTION
Currently, the SOC Config sensoroni section has help links that point to sensoroni.html but this page does not exist. Change these links to point to pages that do exist.