### PR TITLE
Zeek 6 upgrade

### DIFF
--- a/salt/zeek/defaults.yaml
+++ b/salt/zeek/defaults.yaml
@@ -49,12 +49,13 @@ zeek:
         - frameworks/files/hash-all-files
         - frameworks/files/detect-MHR
         - policy/frameworks/notice/extend-email/hostnames
+        - policy/frameworks/notice/community-id
+        - policy/protocols/conn/community-id-logging
         - ja3
         - hassh
         - intel
         - cve-2020-0601
         - securityonion/bpfconf
-        - securityonion/communityid
         - securityonion/file-extraction
         - oui-logging
         - icsnpp-modbus
@@ -65,8 +66,8 @@ zeek:
         - icsnpp-opcua-binary
         - icsnpp-bsap
         - icsnpp-s7comm
-        - zeek-plugin-tds
-        - zeek-plugin-profinet
+        # - zeek-plugin-tds
+        # - zeek-plugin-profinet
         - zeek-spicy-wireguard
         - zeek-spicy-stun
       load-sigs:
@@ -75,7 +76,7 @@ zeek:
         - LogAscii::use_json = T;
         - CaptureLoss::watch_interval = 5 mins;
     networks:
-      HOME_NET: 
+      HOME_NET:
         - 192.168.0.0/16
         - 10.0.0.0/8
         - 172.16.0.0/12
@@ -120,4 +121,4 @@ zeek:
       - stats
       - stderr
       - stdout
- 
+

--- a/salt/zeek/defaults.yaml
+++ b/salt/zeek/defaults.yaml
@@ -66,8 +66,6 @@ zeek:
         - icsnpp-opcua-binary
         - icsnpp-bsap
         - icsnpp-s7comm
-        # - zeek-plugin-tds
-        # - zeek-plugin-profinet
         - zeek-spicy-wireguard
         - zeek-spicy-stun
       load-sigs:


### PR DESCRIPTION
Replace external zeek-community-id with builtin community-id. Disable plugin-tds + plugin-profinet. Not updated for Zeek 6.x