### PR TITLE
Fix reinstall & reset stability

### DIFF
--- a/salt/elasticfleet/tools/sbin_jinja/so-elastic-fleet-setup
+++ b/salt/elasticfleet/tools/sbin_jinja/so-elastic-fleet-setup
@@ -11,6 +11,35 @@ INTCA=/etc/pki/tls/certs/intca.crt
 . /usr/sbin/so-common
 . /usr/sbin/so-elastic-fleet-common
 
+# Deleting Elastic Fleet data...
+
+# Check to make sure that Elasticsearch is up & ready
+RETURN_CODE=0
+wait_for_web_response "https://localhost:9200/_cat/indices/.kibana*" "green open" 300 "curl -K /opt/so/conf/elasticsearch/curl.config"
+RETURN_CODE=$?
+
+if [[ "$RETURN_CODE" != "0" ]]; then
+    status "Elasticsearch not accessible, exiting Elastic Fleet setup..."
+    exit 1
+fi
+
+ALIASES=".fleet-servers .fleet-policies-leader .fleet-policies .fleet-agents .fleet-artifacts .fleet-enrollment-api-keys .kibana_ingest"
+for ALIAS in ${ALIASES}
+do
+    # Get all concrete indices from alias
+    INDXS=$(curl -K /opt/so/conf/kibana/curl.config -s -k -L -H "Content-Type: application/json" "https://localhost:9200/_resolve/index/${ALIAS}"  | jq -r '.aliases[].indices[]')
+
+    # Delete all resolved indices
+    for INDX in ${INDXS}
+    do
+            status "Deleting $INDX"
+            curl -K /opt/so/conf/kibana/curl.config -s -k -L -H "Content-Type: application/json" "https://localhost:9200/${INDX}" -XDELETE
+    done
+done
+
+# Restarting Kibana...
+so-kibana-restart --force
+
 # Check to make sure that Kibana API is up & ready
 RETURN_CODE=0
 wait_for_web_response "http://localhost:5601/api/fleet/settings" "fleet" 300 "curl -K /opt/so/conf/elasticsearch/curl.config"

--- a/salt/manager/tools/sbin_jinja/so-elastic-fleet-reset
+++ b/salt/manager/tools/sbin_jinja/so-elastic-fleet-reset
@@ -35,44 +35,8 @@ so-yaml.py remove /opt/so/saltstack/local/pillar/minions/{{ GLOBALS.minion_id }}
 so-yaml.py remove /opt/so/saltstack/local/pillar/global/soc_global.sls global.fleet_grid_enrollment_token_general
 so-yaml.py remove /opt/so/saltstack/local/pillar/global/soc_global.sls global.fleet_grid_enrollment_token_heavy
 
-status "Deleting Elastic Fleet data..."
-
-# Check to make sure that Elasticsearch is up & ready
-RETURN_CODE=0
-wait_for_web_response "https://localhost:9200/_cat/indices/.kibana*" "green open" 300 "curl -K /opt/so/conf/elasticsearch/curl.config"
-RETURN_CODE=$?
-
-if [[ "$RETURN_CODE" != "0" ]]; then
-    status "Elasticsearch not accessible, exiting script..."
-    exit 1
-fi
-
-ALIASES=".fleet-servers .fleet-policies-leader .fleet-agents .fleet-artifacts .fleet-enrollment-api-keys .kibana_ingest"
-for ALIAS in ${ALIASES}
-do
-    # Get all concrete indices from alias
-    INDXS=$(curl -K /opt/so/conf/kibana/curl.config -s -k -L -H "Content-Type: application/json" "https://localhost:9200/_resolve/index/${ALIAS}"  | jq -r '.aliases[].indices[]')
-
-    # Delete all resolved indices
-    for INDX in ${INDXS}
-    do
-            status "Deleting $INDX"
-            curl -K /opt/so/conf/kibana/curl.config -s -k -L -H "Content-Type: application/json" "https://localhost:9200/${INDX}" -XDELETE
-    done
-done
-
 status "Restarting Kibana..."
 so-kibana-restart --force
-
-status "Checking to make sure that Kibana API is up & ready..."
-RETURN_CODE=0
-wait_for_web_response "http://localhost:5601/api/fleet/settings" "fleet" 300 "curl -K /opt/so/conf/elasticsearch/curl.config"
-RETURN_CODE=$?
-
-if [[ "$RETURN_CODE" != "0" ]]; then
-    status "Kibana API not accessible, exiting script..."
-    exit 1
-fi
 
 status "Removing Integrations State File..."
 rm -f /opt/so/state/eaintegrations.txt

--- a/salt/playbook/files/automation_user_create.sh
+++ b/salt/playbook/files/automation_user_create.sh
@@ -36,7 +36,9 @@ while [[ $try_count -le 6 ]]; do
             }"
 
         # Update the Automation API key in the secrets pillar
-        sed "s/playbook_automation_api_key:/playbook_automation_api_key: ${automation_api_key}/g" -i $local_salt_dir/pillar/secrets.sls 
+        so-yaml.py remove $local_salt_dir/pillar/secrets.sls secrets.playbook_automation_api_key
+        printf '%s\n'\
+            "  playbook_automation_api_key: $automation_api_key" >> $local_salt_dir/pillar/secrets.sls
         exit 0
     fi
     ((try_count++))

--- a/setup/so-functions
+++ b/setup/so-functions
@@ -1648,8 +1648,8 @@ reinstall_init() {
 		backup_dir /nsm/kratos "$date_string"
 		backup_dir /nsm/influxdb "$date_string"
 
-		# Remove the old launcher package in case the config changes
-		remove_package launcher-final
+		# Uninstall local Elastic Agent, if installed
+		logCmd "elastic-agent uninstall -f"
 
 		if [[ $is_deb ]]; then
 			info "Unholding previously held packages."


### PR DESCRIPTION
- Replaces `so-playbook-reset` sed for so-yaml & fixes it for 2.4
- If so-setup is rerun, uninstalls Elastic-Agent on local node 
- Removes existing Elastic Fleet config prior to installing Elastic Fleet (in case of so-setup being run again)