### PR TITLE
FEATURE: Check for mountpoint during Elastic size limit calculations

### DIFF
--- a/setup/so-functions
+++ b/setup/so-functions
@@ -2148,11 +2148,12 @@ set_default_log_size() {
 	esac
 
 	local disk_dir="/"
-	if [ -d /nsm ]; then
+	if mountpoint -q /nsm; then
 		disk_dir="/nsm"
 	fi
-	if [ -d /nsm/elasticsearch ]; then
+	if mountpoint -q /nsm/elasticsearch; then
 		disk_dir="/nsm/elasticsearch"
+		percentage=80
 	fi
 	
 	local disk_size_1k


### PR DESCRIPTION
Instead of just directory existence, this checks if the directories are separate mountpoints when determining disk size and log_size_limit calculations.

It also sets the percentage to 80 if /nsm/elasticsearch is a separate mountpoint.  This allows for better disk utilization on server configurations where /nsm is based on large slow HDDs for increased PCAP retention but /nsm/elasticsearch is based on SSDs for faster Elasticsearch performance.

The mountpoint command has been in RHEL and derivatives at least to RHEL7, and debian and derivatives for just as long.