### PR TITLE
Added missing config options to navigator_config.json

### DIFF
--- a/salt/nginx/files/navigator_config.json
+++ b/salt/nginx/files/navigator_config.json
@@ -57,7 +57,10 @@
             {"name": "links", "enabled": true, "description": "Disable to remove the ability to assign hyperlinks to techniques."},
             {"name": "link_underline", "enabled": true, "description": "Disable to remove the hyperlink underline effect on techniques."},
             {"name": "metadata", "enabled": true, "description": "Disable to remove the ability to add metadata to techniques."},
-            {"name": "clear_annotations", "enabled": true, "description": "Disable to remove the button to clear all annotations on the selected techniques."}
+            {"name": "clear_annotations", "enabled": true, "description": "Disable to remove the button to clear all annotations on the selected techniques."},
+            {"name": "background_color", "enabled": true, "description": "Disable to remove the background color effect on manually assigned colors."},
+            {"name": "non_aggregate_score_color", "enabled": true, "description": "Disable to remove the color effect on non-aggregate scores."},
+            {"name": "aggregate_score_color", "enabled": true, "description": "Disable to remove the color effect on aggregate scores."}
         ]}
     ]
 }


### PR DESCRIPTION
I noticed that Navigator was no longer showing background colors for active playbooks, and I could not manually assign background colors. This [Github Issue](https://github.com/mitre-attack/attack-navigator/issues/563#issuecomment-1647858789) revealed that Navigator v4.8.1 included new configuration options that needed to be set.

I made these changes to a local Security Onion v2.4.10 and it fixed the issues.

Related Issue [here](https://github.com/Security-Onion-Solutions/securityonion/issues/12646#issue-2203449704).