### PR TITLE
check status before stopping service

### DIFF
--- a/setup/so-functions
+++ b/setup/so-functions
@@ -1603,7 +1603,9 @@ reinstall_init() {
 		# Kill any salt processes (safely)
 		for service in "${salt_services[@]}"; do
 			# Stop the service in the background so we can exit after a certain amount of time
-			systemctl stop "$service" &
+			if check_service_status "$service"; then
+				systemctl stop "$service" &
+			fi
 			local pid=$!
 
 			local count=0


### PR DESCRIPTION
Resolves #12811 so-verify detects rare false error

If salt is uninstalled prior to a call to so-setup where it detects a previous install, the "Failed" keyword from "systemctl stop $service" causes so-verify to falsely detect an installation error.  This might happen if the user removes the salt packages between calls to so-setup, or if upgrading from Ubuntu 20.04 to 22.04 then installing 2.4.xx on top of a 2.3.xx installation.

The fix is to wrap the call to stop the service within a check if the service is running.

This fix ignores the setting of pid var, as the next use of pid is within a while loop that will not execute for the same reason the systemctl stop call was not launched in the background.