### PR TITLE
Mark Repos as Community

### DIFF
--- a/salt/soc/defaults.yaml
+++ b/salt/soc/defaults.yaml
@@ -580,7 +580,7 @@ soc:
         - file.source
         - file.mime_type
         - log.id.fuid
-        - event.dataset  
+        - event.dataset
       ':suricata:':
         - soc_timestamp
         - source.ip
@@ -1270,6 +1270,7 @@ soc:
           - repo: https://github.com/Security-Onion-Solutions/securityonion-resources
             license: Elastic-2.0
             folder: sigma/stable
+            community: true
           sigmaRulePackages:
             - core
             - emerging_threats_addon
@@ -1327,6 +1328,7 @@ soc:
           rulesRepos:
           - repo: https://github.com/Security-Onion-Solutions/securityonion-yara
             license: DRL
+            community: true
           yaraRulesFolder: /opt/sensoroni/yara/rules
           stateFilePath: /opt/sensoroni/fingerprints/strelkaengine.state
         suricataengine:
@@ -1917,7 +1919,7 @@ soc:
               query: 'event.dataset:soc.detections | groupby  soc.detection_type soc.error_type | groupby soc.error_analysis | groupby soc.rule.name | groupby soc.error_message'
 
 
-              
+
         job:
         alerts:
           advanced: false
@@ -1955,7 +1957,7 @@ soc:
               - event_data.destination.host
               - event_data.destination.port
               - event_data.process.executable
-              - event_data.process.pid    
+              - event_data.process.pid
             ':sigma:':
               - soc_timestamp
               - rule.name
@@ -1967,7 +1969,7 @@ soc:
               - event_data.destination.host
               - event_data.destination.port
               - event_data.process.executable
-              - event_data.process.pid    
+              - event_data.process.pid
             ':strelka:':
               - soc_timestamp
               - file.name


### PR DESCRIPTION
Indicate that detection rules pulled from configured repos should be marked as Community rules.