### PR TITLE
Specify Error Retry Wait and Error Limit for All Detection Engines

### DIFF
--- a/salt/soc/defaults.yaml
+++ b/salt/soc/defaults.yaml
@@ -1279,6 +1279,8 @@ soc:
               - securityonion-resources+critical
               - securityonion-resources+high
           communityRulesImportFrequencySeconds: 28800
+          communityRulesImportErrorSeconds: 300
+          failAfterConsecutiveErrorCount: 10
           denyRegex: ''
           elastAlertRulesFolder: /opt/sensoroni/elastalert
           reposFolder: /opt/sensoroni/sigma/repos
@@ -1346,6 +1348,8 @@ soc:
             - securityonion-yara
           autoUpdateEnabled: true
           communityRulesImportFrequencySeconds: 28800
+          communityRulesImportErrorSeconds: 300
+          failAfterConsecutiveErrorCount: 10
           compileYaraPythonScriptPath: /opt/sensoroni/yara/compile_yara.py
           denyRegex: ''
           reposFolder: /opt/sensoroni/yara/repos
@@ -1364,6 +1368,8 @@ soc:
           allowRegex: ''
           autoUpdateEnabled: true
           communityRulesImportFrequencySeconds: 28800
+          communityRulesImportErrorSeconds: 300
+          failAfterConsecutiveErrorCount: 10
           communityRulesFile: /nsm/rules/suricata/emerging-all.rules
           denyRegex: ''
           rulesFingerprintFile: /opt/sensoroni/fingerprints/emerging-all.fingerprint


### PR DESCRIPTION
If a sync errors out, the engine will wait `communityRulesImportErrorSeconds` seconds instead of the usual `communityRulesImportFrequencySeconds` seconds wait.

If `failAfterConsecutiveErrorCount` errors happen in a row when syncing detections to ElasticSearch then the sync is considered a failure and will give up and try again later. This assumes ElasticSearch is the source of the errors and backs of in hopes it'll be able to fix itself.