### PR TITLE
Add option for detections without a license

### DIFF
--- a/salt/soc/defaults.yaml
+++ b/salt/soc/defaults.yaml
@@ -2266,6 +2266,7 @@ soc:
             license:
                 customEnabled: true
                 labels:
+                  - None
                   - Apache-2.0
                   - AGPL-3.0-only
                   - BSD-3-Clause


### PR DESCRIPTION
Currently, users are forced to choose a license for a detection. This option allows a user to create a detection without providing a specific license (`None`).