### PR TITLE
New Config Values for Detections Bulk Indexer

### DIFF
--- a/salt/soc/defaults.yaml
+++ b/salt/soc/defaults.yaml
@@ -1366,6 +1366,8 @@ soc:
           maxLogLength: 1024
           asyncThreshold: 10
           lookupTunnelParent: true
+          maxScrollSize: 10000
+          bulkIndexerWorkerCount: -1
         influxdb:
           hostUrl:
           token:
@@ -2292,15 +2294,15 @@ soc:
 
               alert http $EXTERNAL_NET any -> $HOME_NET any (msg:"Example Rule Title - 'example' String Detected"; content:"example"; sid:[publicId]; rev:1;)
             strelka: |
-              /* 
+              /*
               This is a YARA rule template. Replace all template values with your own values.
               The YARA rule name is the unique identifier for the rule.
               Docs: https://yara.readthedocs.io/en/stable/writingrules.html#writing-yara-rules
-              */ 
+              */
 
               rule Example // This identifier _must_ be unique
               {
-                  meta: 
+                  meta:
                       description = "Generic YARA Rule"
                       author = "@SecurityOnion"
                       date = "YYYY-MM-DD"
@@ -2323,7 +2325,7 @@ soc:
               id: [publicId]
               status: 'experimental'
               description: |
-                  This should be a detailed description of what this Detection focuses on: what we are trying to find and why we are trying to find it. 
+                  This should be a detailed description of what this Detection focuses on: what we are trying to find and why we are trying to find it.
                   For example, from rule 97a80ec7-0e2f-4d05-9ef4-65760e634f6b: "Detects a whoami.exe executed with the /priv command line flag instructing the tool to show all current user privileges. This is often used after a privilege escalation attempt."
               references:
                 - 'https://local.invalid'
@@ -2332,7 +2334,7 @@ soc:
               tags:
                 - detection.threat_hunting
                 - attack.technique_id
-              logsource: 
+              logsource:
                 category: process_creation
                 product: windows
               detection:

--- a/salt/soc/soc_soc.yaml
+++ b/salt/soc/soc_soc.yaml
@@ -174,6 +174,10 @@ soc:
           lookupTunnelParent:
             description: When true, if a pivoted event appears to be encapsulated, such as in a VXLAN packet, then SOC will pivot to the VXLAN packet stream. When false, SOC will attempt to pivot to the encapsulated packet stream itself, but at the risk that it may be unable to locate it in the stored PCAP data.
             global: True
+          maxScrollSize:
+            description: The maximum number of documents to request in a single Elasticsearch scroll request.
+          bulkIndexWorkerCount:
+            description: The number of worker threads to use when bulk indexing data into Elasticsearch. A value below 1 will default to the number of CPUs available.
         sostatus:
           refreshIntervalMs:
             description: Duration (in milliseconds) between refreshes of the grid status. Shortening this duration may not have expected results, as the backend systems feeding this sostatus data will continue their updates as scheduled.


### PR DESCRIPTION
`maxScrollSize` defines the "page size" of each scroll request.

`bulkIndexerWorkerCount` defines how many worker threads a bulk indexer should use. 0 or fewer indicates that 1 thread per CPU core should be used.