### PR TITLE
Fix system mapping

### DIFF
--- a/salt/elasticsearch/defaults.yaml
+++ b/salt/elasticsearch/defaults.yaml
@@ -9101,6 +9101,7 @@ elasticsearch:
         - logs-system.auth@custom
         - so-fleet_globals-1
         - so-fleet_agent_id_verification-1
+        - so-system
         data_stream:
           allow_custom_routing: false
           hidden: false
@@ -9195,6 +9196,7 @@ elasticsearch:
         - logs-system.syslog@custom
         - so-fleet_globals-1
         - so-fleet_agent_id_verification-1
+        - so-system
         data_stream:
           allow_custom_routing: false
           hidden: false

--- a/salt/elasticsearch/templates/component/so/so-system-mappings.json
+++ b/salt/elasticsearch/templates/component/so/so-system-mappings.json
@@ -1,0 +1,29 @@
+{
+  "template": {
+    "mappings": {
+      "properties": {
+        "host": {
+	  "properties":{
+            "ip": {
+              "type": "ip"
+            }
+	  }
+	},
+	"related": {
+          "properties":{
+            "ip": {
+              "type": "ip"
+            }
+          }
+        },
+	"source": {
+          "properties":{
+            "ip": {
+              "type": "ip"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
host.ip, related.ip, and source.ip were ending up as keyword for logs-system.auth-default