### PR TITLE
External Support for Detections

### DIFF
--- a/salt/firewall/defaults.yaml
+++ b/salt/firewall/defaults.yaml
@@ -10,6 +10,7 @@ firewall:
     elasticsearch_rest: []
     endgame: []
     eval: []
+    external_suricata: []
     fleet: []
     heavynode: []
     idh: []
@@ -85,6 +86,10 @@ firewall:
     endgame:
       tcp:
         - 3765
+      udp: []
+    external_suricata:
+      tcp: 
+        - 7789
       udp: []
     influxdb:
       tcp:
@@ -216,6 +221,9 @@ firewall:
             analyst:
               portgroups:
                 - nginx
+            external_suricata:
+              portgroups:
+                - external_suricata
             customhostgroup0:
               portgroups: []
             customhostgroup1:
@@ -462,6 +470,9 @@ firewall:
             endgame:
               portgroups:
                 - endgame
+            external_suricata:
+              portgroups:
+                - external_suricata
             desktop:
               portgroups:
                 - docker_registry
@@ -654,6 +665,9 @@ firewall:
             endgame:
               portgroups:
                 - endgame
+            external_suricata:
+              portgroups:
+                - external_suricata
             desktop:
               portgroups:
                 - docker_registry
@@ -850,6 +864,9 @@ firewall:
             endgame:
               portgroups:
                 - endgame
+            external_suricata:
+              portgroups:
+                - external_suricata
             strelka_frontend:
               portgroups:
                 - strelka_frontend
@@ -1216,6 +1233,9 @@ firewall:
                 - elastic_agent_control
                 - elastic_agent_data
                 - elastic_agent_update
+            external_suricata:
+              portgroups:
+                - external_suricata
             analyst:
               portgroups:
                 - nginx

--- a/salt/firewall/soc_firewall.yaml
+++ b/salt/firewall/soc_firewall.yaml
@@ -32,6 +32,7 @@ firewall:
     elasticsearch_rest: *hostgroupsettingsadv
     endgame: *hostgroupsettingsadv
     eval: *hostgroupsettings
+    external_suricata: *hostgroupsettings
     fleet: *hostgroupsettings
     heavynode: *hostgroupsettings
     idh: *hostgroupsettings
@@ -115,6 +116,9 @@ firewall:
       tcp: *tcpsettings
       udp: *udpsettings
     endgame:
+      tcp: *tcpsettings
+      udp: *udpsettings
+    external_suricata:
       tcp: *tcpsettings
       udp: *udpsettings
     influxdb:
@@ -214,6 +218,8 @@ firewall:
             elasticsearch_rest:
               portgroups: *portgroupsdocker
             elastic_agent_endpoint:
+              portgroups: *portgroupsdocker
+            external_suricata: 
               portgroups: *portgroupsdocker
             strelka_frontend:
               portgroups: *portgroupsdocker
@@ -370,6 +376,8 @@ firewall:
               portgroups: *portgroupsdocker
             endgame:
               portgroups: *portgroupsdocker
+            external_suricata: 
+              portgroups: *portgroupsdocker
             analyst:
               portgroups: *portgroupsdocker
             desktop:
@@ -463,6 +471,8 @@ firewall:
               portgroups: *portgroupsdocker
             analyst:
               portgroups: *portgroupsdocker
+            external_suricata: 
+              portgroups: *portgroupsdocker
             desktop:
               portgroups: *portgroupsdocker
             customhostgroup0:
@@ -553,6 +563,8 @@ firewall:
             elastic_agent_endpoint:
               portgroups: *portgroupsdocker
             endgame:
+              portgroups: *portgroupsdocker
+            external_suricata: 
               portgroups: *portgroupsdocker
             strelka_frontend:
               portgroups: *portgroupsdocker
@@ -827,6 +839,8 @@ firewall:
             elastic_agent_endpoint:
               portgroups: *portgroupsdocker
             analyst:
+              portgroups: *portgroupsdocker
+            external_suricata: 
               portgroups: *portgroupsdocker
             desktop:
               portgroups: *portgroupsdocker

--- a/salt/nginx/defaults.yaml
+++ b/salt/nginx/defaults.yaml
@@ -1,5 +1,6 @@
 nginx:
   enabled: False
+  external_suricata: False
   ssl:
     replace_cert: False
   config:

--- a/salt/nginx/enabled.sls
+++ b/salt/nginx/enabled.sls
@@ -130,6 +130,9 @@ so-nginx:
       - /opt/so/conf/navigator/config.json:/opt/socore/html/navigator/assets/config.json:ro
       - /nsm/repo:/opt/socore/html/repo:ro
       - /nsm/rules:/nsm/rules:ro
+      {%   if NGINXMERGED.external_suricata %}
+      - /opt/so/rules/nids/suri:/surirules:ro
+      {%   endif %}
       {% endif %}
       {% if DOCKER.containers[container_config].custom_bind_mounts %}
         {% for BIND in DOCKER.containers[container_config].custom_bind_mounts %}

--- a/salt/nginx/etc/nginx.conf
+++ b/salt/nginx/etc/nginx.conf
@@ -84,7 +84,8 @@ http {
 	}
 
 	server {
-		listen 443 ssl http2 default_server;
+		listen 443 ssl default_server;
+		http2 on;
 		server_name _;
 		return 307 https://{{ GLOBALS.url_base }}$request_uri;
 
@@ -118,17 +119,10 @@ http {
 	}
 	{%-   if NGINXMERGED.external_suricata %}
     server {
-        listen 7789 ssl http2;
+        listen 7789 ssl;
+		http2 on;
         server_name {{ GLOBALS.url_base }};
         root /surirules;
-        location / {
-        allow all;
-        sendfile on;
-        sendfile_max_chunk 1m;
-        autoindex on;
-        autoindex_exact_size off;
-        autoindex_format html;
-        autoindex_localtime on;
 		ssl_certificate "/etc/pki/nginx/server.crt";
 		ssl_certificate_key "/etc/pki/nginx/server.key";
 		ssl_session_cache shared:SSL:1m;
@@ -136,12 +130,21 @@ http {
 		ssl_ciphers HIGH:!aNULL:!MD5;
 		ssl_prefer_server_ciphers on;
 		ssl_protocols TLSv1.2;
+        location / {
+        	allow all;
+        	sendfile on;
+        	sendfile_max_chunk 1m;
+        	autoindex on;
+        	autoindex_exact_size off;
+        	autoindex_format html;
+        	autoindex_localtime on;
         }
     }
     {%-   endif %}
 
 	server {
-		listen       443 ssl http2;
+		listen       443 ssl;
+		http2 on;
 		server_name  {{ GLOBALS.url_base }};
 		root         /opt/socore/html;
 		index        index.html;

--- a/salt/nginx/etc/nginx.conf
+++ b/salt/nginx/etc/nginx.conf
@@ -116,6 +116,29 @@ http {
 			autoindex_localtime on;
 		}
 	}
+	{%-   if NGINXMERGED.external_suricata %}
+    server {
+        listen 7789 ssl http2;
+        server_name {{ GLOBALS.url_base }};
+        root /surirules;
+        location / {
+        allow all;
+        sendfile on;
+        sendfile_max_chunk 1m;
+        autoindex on;
+        autoindex_exact_size off;
+        autoindex_format html;
+        autoindex_localtime on;
+		ssl_certificate "/etc/pki/nginx/server.crt";
+		ssl_certificate_key "/etc/pki/nginx/server.key";
+		ssl_session_cache shared:SSL:1m;
+		ssl_session_timeout  10m;
+		ssl_ciphers HIGH:!aNULL:!MD5;
+		ssl_prefer_server_ciphers on;
+		ssl_protocols TLSv1.2;
+        }
+    }
+    {%-   endif %}
 
 	server {
 		listen       443 ssl http2;
@@ -251,20 +274,20 @@ http {
 			proxy_cookie_path     /api/ /influxdb/api/;
 		}
 
-                location /app/dashboards/ {
-                         auth_request          /auth/sessions/whoami;
-                         rewrite               /app/dashboards/(.*) /app/dashboards/$1 break;
-                         proxy_pass            http://{{ GLOBALS.manager }}:5601/app/;
-                         proxy_read_timeout    300;
-                         proxy_connect_timeout 300;
-                         proxy_set_header      Host $host;
-                         proxy_set_header      X-Real-IP $remote_addr;
-                         proxy_set_header      X-Forwarded-For $proxy_add_x_forwarded_for;
-                         proxy_set_header      Proxy "";
-                         proxy_set_header      X-Forwarded-Proto $scheme;
-                } 
+        location /app/dashboards/ {
+            auth_request          /auth/sessions/whoami;
+            rewrite               /app/dashboards/(.*) /app/dashboards/$1 break;
+            proxy_pass            http://{{ GLOBALS.manager }}:5601/app/;
+            proxy_read_timeout    300;
+            proxy_connect_timeout 300;
+            proxy_set_header      Host $host;
+            proxy_set_header      X-Real-IP $remote_addr;
+            proxy_set_header      X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header      Proxy "";
+            proxy_set_header      X-Forwarded-Proto $scheme;
+        } 
                
-                location /kibana/ {
+        location /kibana/ {
 			auth_request          /auth/sessions/whoami;
 			rewrite               /kibana/(.*) /$1 break;
 			proxy_pass            http://{{ GLOBALS.manager }}:5601/;

--- a/salt/nginx/soc_nginx.yaml
+++ b/salt/nginx/soc_nginx.yaml
@@ -3,6 +3,11 @@ nginx:
     description: You can enable or disable Nginx.
     advanced: True
     helpLink: nginx.html
+  external_suricata:
+    description: Enable this to allow external access to Suricata Rulesets managed by Detections.
+    advanced: True
+    helplink: nginx.html
+    forcedType: bool
   ssl:
     replace_cert:
       description: Enable this if you would like to replace the Security Onion Certificate with your own.


### PR DESCRIPTION
This allows users to open their all.rules files to be exposed to allow external suricata instances to use the same ruleset as your SO sensors.