### PR TITLE
Use ID instead of name for getting integrations from agent policies

### DIFF
--- a/salt/elasticfleet/tools/sbin/so-elastic-fleet-common
+++ b/salt/elasticfleet/tools/sbin/so-elastic-fleet-common
@@ -102,6 +102,14 @@ elastic_fleet_package_is_installed() {
     curl -s -K /opt/so/conf/elasticsearch/curl.config -b "sid=$SESSIONCOOKIE" -L -X GET -H 'kbn-xsrf: true' "localhost:5601/api/fleet/epm/packages/$PACKAGE" | jq -r '.item.status'
 }
 
+elastic_fleet_agent_policy_ids() {
+    curl -s -K /opt/so/conf/elasticsearch/curl.config -b "sid=$SESSIONCOOKIE" -L -X GET "localhost:5601/api/fleet/agent_policies" | jq -r .items[].id
+    if [ $? -ne 0 ]; then
+        echo "Error: Failed to retrieve agent policies."
+        exit 1
+    fi
+}
+
 elastic_fleet_agent_policy_names() {
     curl -s -K /opt/so/conf/elasticsearch/curl.config -b "sid=$SESSIONCOOKIE" -L -X GET "localhost:5601/api/fleet/agent_policies" | jq -r .items[].name
     if [ $? -ne 0 ]; then

--- a/salt/elasticfleet/tools/sbin/so-elastic-fleet-integration-upgrade
+++ b/salt/elasticfleet/tools/sbin/so-elastic-fleet-integration-upgrade
@@ -13,7 +13,7 @@ if [ $? -ne 0 ]; then
 fi
 
 IFS=$'\n'
-agent_policies=$(elastic_fleet_agent_policy_names)
+agent_policies=$(elastic_fleet_agent_policy_ids)
 if [ $? -ne 0 ]; then
     echo "Error: Failed to retrieve agent policies."
     exit 1


### PR DESCRIPTION
Custom policies don't conform to the same standard of using the name for the ID, so we need to look for the ID instead of the name when getting integrations for an agent policy.