### PR TITLE
external access to kafka topics

### DIFF
--- a/salt/firewall/defaults.yaml
+++ b/salt/firewall/defaults.yaml
@@ -10,6 +10,7 @@ firewall:
     elasticsearch_rest: []
     endgame: []
     eval: []
+    external_kafka_data: []
     external_suricata: []
     fleet: []
     heavynode: []
@@ -470,6 +471,9 @@ firewall:
             endgame:
               portgroups:
                 - endgame
+            external_kafka_data:
+              portgroups:
+                - kafka_data
             external_suricata:
               portgroups:
                 - external_suricata
@@ -665,6 +669,9 @@ firewall:
             endgame:
               portgroups:
                 - endgame
+            external_kafka_data:
+              portgroups:
+                - kafka_data
             external_suricata:
               portgroups:
                 - external_suricata
@@ -864,6 +871,9 @@ firewall:
             endgame:
               portgroups:
                 - endgame
+            external_kafka_data:
+              portgroups:
+                - kafka_data
             external_suricata:
               portgroups:
                 - external_suricata
@@ -1337,6 +1347,9 @@ firewall:
             endgame:
               portgroups:
                 - endgame
+            external_kafka_data:
+              portgroups:
+                - kafka_data
             receiver:
               portgroups: []
             customhostgroup0:

--- a/salt/firewall/map.jinja
+++ b/salt/firewall/map.jinja
@@ -40,11 +40,11 @@
 {%     for r in ['manager', 'managersearch', 'standalone', 'receiver', 'fleet', 'idh', 'sensor', 'searchnode','heavynode', 'elastic_agent_endpoint', 'desktop', 'self'] %}
 {%       if FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups[r] is defined %}
 {%         do FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups[r].portgroups.append('kafka_data') %}
-{# Remove redis port #}
+{#         Remove redis port #}
 {%         if 'redis' in FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups[r].portgroups %}
 {%           do FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups[r].portgroups.remove('redis') %}
 {%         endif %}
-{# Check if logstash was manually enabled for this node before removing logstash port #}
+{#         Check if logstash was manually enabled for this node before removing logstash port #}
 {%         if GLOBALS.hostname not in KAFKA_LOGSTASH %}
 {%           if 'elastic_agent_data' in FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups[r].portgroups %}
 {%             do FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups[r].portgroups.remove('elastic_agent_data') %}
@@ -52,7 +52,7 @@
 {%         endif %}
 {%       endif %}
 {%     endfor %}
-{# Remove external_kafka_data portgroup from any kafka node that isn't a broker #}
+{#     Remove external_kafka_data portgroup from any kafka node that isn't a broker #}
 {%     if GLOBALS.hostname in KAFKA_CONTROLLERS %}
 {%       do FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups.pop('external_kafka_data') %}
 {%     endif %}

--- a/salt/firewall/map.jinja
+++ b/salt/firewall/map.jinja
@@ -23,7 +23,7 @@
 {% endif %}
 
 {# Only add Kafka firewall items when Kafka enabled #}
-{# {% if GLOBALS.pipeline == 'KAFKA' %} #}
+{% if GLOBALS.pipeline == 'KAFKA' %}
 {%   set role = GLOBALS.role.split('-')[1] %}
 {%   if role in ['manager', 'managersearch', 'standalone'] %}
 {%     do FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups[role].portgroups.append('kafka_controller') %}

--- a/salt/firewall/map.jinja
+++ b/salt/firewall/map.jinja
@@ -1,6 +1,9 @@
 {% from 'vars/globals.map.jinja' import GLOBALS %}
 {% from 'docker/docker.map.jinja' import DOCKER %}
 {% import_yaml 'firewall/defaults.yaml' as FIREWALL_DEFAULT %}
+{% if GLOBALS.pipeline == 'KAFKA' %}
+{%   set KAFKA_LOGSTASH = salt['pillar.get']('kafka:logstash', []) %}
+{% endif %}
 
 {# add our ip to self #}
 {% do FIREWALL_DEFAULT.firewall.hostgroups.self.append(GLOBALS.node_ip) %}
@@ -35,9 +38,19 @@
 {% endif %}
 
 {% if GLOBALS.pipeline == 'KAFKA' and role in ['manager', 'managersearch', 'standalone', 'receiver'] %}
-{%   for r in ['manager', 'managersearch', 'standalone', 'receiver', 'fleet', 'idh', 'sensor', 'searchnode','heavynode', 'elastic_agent_endpoint', 'desktop'] %}
+{%   for r in ['manager', 'managersearch', 'standalone', 'receiver', 'fleet', 'idh', 'sensor', 'searchnode','heavynode', 'elastic_agent_endpoint', 'desktop', 'self'] %}
 {%     if FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups[r] is defined %}
 {%       do FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups[r].portgroups.append('kafka_data') %}
+{#       Remove redis port #}
+{%       if 'redis' in FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups[r].portgroups %}
+{%         do FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups[r].portgroups.remove('redis') %}
+{%       endif %}
+{#       Check if logstash was manually enabled for this node before removing logstash port #}
+{%       if GLOBALS.hostname not in KAFKA_LOGSTASH %}
+{%         if 'elastic_agent_data' in FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups[r].portgroups %}
+{%           do FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups[r].portgroups.remove('elastic_agent_data') %}
+{%         endif %}
+{%       endif %}
 {%     endif %}
 {%   endfor %}
 {% endif %}

--- a/salt/firewall/map.jinja
+++ b/salt/firewall/map.jinja
@@ -3,6 +3,7 @@
 {% import_yaml 'firewall/defaults.yaml' as FIREWALL_DEFAULT %}
 {% if GLOBALS.pipeline == 'KAFKA' %}
 {%   set KAFKA_LOGSTASH = salt['pillar.get']('kafka:logstash', []) %}
+{%   set KAFKA_CONTROLLERS = salt['pillar.get']('kafka:controllers', []) %}
 {% endif %}
 
 {# add our ip to self #}
@@ -22,37 +23,40 @@
 {% endif %}
 
 {# Only add Kafka firewall items when Kafka enabled #}
-{% set role = GLOBALS.role.split('-')[1] %}
-
-{% if GLOBALS.pipeline == 'KAFKA' and role in ['manager', 'managersearch', 'standalone'] %}
-{%   do FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups[role].portgroups.append('kafka_controller') %}
-{%   do FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups.receiver.portgroups.append('kafka_controller') %}
-{% endif %}
-
-{% if GLOBALS.pipeline == 'KAFKA' and role == 'receiver' %}
-{%   do FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups.self.portgroups.append('kafka_controller') %}
-{%   do FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups.standalone.portgroups.append('kafka_controller') %}
-{%   do FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups.manager.portgroups.append('kafka_controller') %}
-{%   do FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups.managersearch.portgroups.append('kafka_controller') %}
-{%   do FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups.receiver.portgroups.append('kafka_controller') %}
-{% endif %}
-
-{% if GLOBALS.pipeline == 'KAFKA' and role in ['manager', 'managersearch', 'standalone', 'receiver'] %}
-{%   for r in ['manager', 'managersearch', 'standalone', 'receiver', 'fleet', 'idh', 'sensor', 'searchnode','heavynode', 'elastic_agent_endpoint', 'desktop', 'self'] %}
-{%     if FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups[r] is defined %}
-{%       do FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups[r].portgroups.append('kafka_data') %}
-{#       Remove redis port #}
-{%       if 'redis' in FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups[r].portgroups %}
-{%         do FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups[r].portgroups.remove('redis') %}
-{%       endif %}
-{#       Check if logstash was manually enabled for this node before removing logstash port #}
-{%       if GLOBALS.hostname not in KAFKA_LOGSTASH %}
-{%         if 'elastic_agent_data' in FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups[r].portgroups %}
-{%           do FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups[r].portgroups.remove('elastic_agent_data') %}
+{# {% if GLOBALS.pipeline == 'KAFKA' %} #}
+{%   set role = GLOBALS.role.split('-')[1] %}
+{%   if role in ['manager', 'managersearch', 'standalone'] %}
+{%     do FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups[role].portgroups.append('kafka_controller') %}
+{%     do FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups.receiver.portgroups.append('kafka_controller') %}
+{%   endif %}
+{%   if role == 'receiver' %}
+{%     do FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups.self.portgroups.append('kafka_controller') %}
+{%     do FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups.standalone.portgroups.append('kafka_controller') %}
+{%     do FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups.manager.portgroups.append('kafka_controller') %}
+{%     do FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups.managersearch.portgroups.append('kafka_controller') %}
+{%     do FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups.receiver.portgroups.append('kafka_controller') %}
+{%   endif %}
+{%   if role in ['manager', 'managersearch', 'standalone', 'receiver'] %}
+{%     for r in ['manager', 'managersearch', 'standalone', 'receiver', 'fleet', 'idh', 'sensor', 'searchnode','heavynode', 'elastic_agent_endpoint', 'desktop', 'self'] %}
+{%       if FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups[r] is defined %}
+{%         do FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups[r].portgroups.append('kafka_data') %}
+{# Remove redis port #}
+{%         if 'redis' in FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups[r].portgroups %}
+{%           do FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups[r].portgroups.remove('redis') %}
+{%         endif %}
+{# Check if logstash was manually enabled for this node before removing logstash port #}
+{%         if GLOBALS.hostname not in KAFKA_LOGSTASH %}
+{%           if 'elastic_agent_data' in FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups[r].portgroups %}
+{%             do FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups[r].portgroups.remove('elastic_agent_data') %}
+{%           endif %}
 {%         endif %}
 {%       endif %}
+{%     endfor %}
+{# Remove external_kafka_data portgroup from any kafka node that isn't a broker #}
+{%     if GLOBALS.hostname in KAFKA_CONTROLLERS %}
+{%       do FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups.pop('external_kafka_data') %}
 {%     endif %}
-{%   endfor %}
+{%   endif %}
 {% endif %}
 
 {% set FIREWALL_MERGED = salt['pillar.get']('firewall', FIREWALL_DEFAULT.firewall, merge=True) %}

--- a/salt/firewall/soc_firewall.yaml
+++ b/salt/firewall/soc_firewall.yaml
@@ -32,6 +32,7 @@ firewall:
     elasticsearch_rest: *hostgroupsettingsadv
     endgame: *hostgroupsettingsadv
     eval: *hostgroupsettings
+    external_kafka_data: *hostgroupsettingsadv
     external_suricata: *hostgroupsettings
     fleet: *hostgroupsettings
     heavynode: *hostgroupsettings

--- a/salt/kafka/config.map.jinja
+++ b/salt/kafka/config.map.jinja
@@ -8,6 +8,7 @@
 {% set KAFKA_NODES_PILLAR = salt['pillar.get']('kafka:nodes') %}
 {% set KAFKA_PASSWORD = salt['pillar.get']('kafka:config:password') %}
 {% set KAFKA_TRUSTPASS = salt['pillar.get']('kafka:config:trustpass') %}
+{% set DEFAULT_BROKER_LISTENER = 'BROKER://' + GLOBALS.node_ip + ':9092' %}
 
 {# Create list of KRaft controllers #}
 {% set controllers = [] %}
@@ -28,7 +29,7 @@
 {# Generate server.properties for 'broker' , 'controller', 'broker,controller' node types
     anything above this line is a configuration needed for ALL Kafka nodes #}
 {% if node_type == 'broker' %}
-{%   do KAFKAMERGED.config.broker.update({'advertised_x_listeners': 'BROKER://'+ GLOBALS.node_ip +':9092' }) %}
+{%   do KAFKAMERGED.config.broker.update({'advertised_x_listeners': DEFAULT_BROKER_LISTENER }) %}
 {%   do KAFKAMERGED.config.broker.update({'controller_x_quorum_x_voters': kafka_controller_quorum_voters }) %}
 {%   do KAFKAMERGED.config.broker.update({'node_x_id': salt['pillar.get']('kafka:nodes:'+ GLOBALS.hostname +':nodeid') }) %}
 {%   do KAFKAMERGED.config.broker.update({'ssl_x_keystore_x_password': KAFKA_PASSWORD }) %}
@@ -50,7 +51,7 @@
 
 {# Kafka nodes of this type are not recommended for use outside of development / testing. #}
 {% if node_type == 'broker,controller' %}
-{%   do KAFKAMERGED.config.broker.update({'advertised_x_listeners': 'BROKER://'+ GLOBALS.node_ip +':9092' }) %}
+{%   do KAFKAMERGED.config.broker.update({'advertised_x_listeners': DEFAULT_BROKER_LISTENER }) %}
 {%   do KAFKAMERGED.config.broker.update({'controller_x_listener_x_names': KAFKAMERGED.config.controller.controller_x_listener_x_names }) %}
 {%   do KAFKAMERGED.config.broker.update({'controller_x_quorum_x_voters': kafka_controller_quorum_voters }) %}
 {%   do KAFKAMERGED.config.broker.update({'node_x_id': salt['pillar.get']('kafka:nodes:'+ GLOBALS.hostname +':nodeid') }) %}

--- a/salt/kafka/defaults.yaml
+++ b/salt/kafka/defaults.yaml
@@ -9,6 +9,7 @@ kafka:
     trustpass:
     broker:
       auto_x_create_x_topics_x_enable: true
+      controller_x_quorum_x_request_x_timeout_x_ms: 3000
       default_x_replication_x_factor: 1
       inter_x_broker_x_listener_x_name: BROKER
       listeners: BROKER://0.0.0.0:9092

--- a/salt/kafka/defaults.yaml
+++ b/salt/kafka/defaults.yaml
@@ -8,9 +8,7 @@ kafka:
     password:
     trustpass:
     broker:
-      advertised_x_listeners:
       auto_x_create_x_topics_x_enable: true
-      controller_x_quorum_x_voters:
       default_x_replication_x_factor: 1
       inter_x_broker_x_listener_x_name: BROKER
       listeners: BROKER://0.0.0.0:9092
@@ -47,7 +45,6 @@ kafka:
       ssl_x_keystore_x_password:
     controller:
       controller_x_listener_x_names: CONTROLLER
-      controller_x_quorum_x_voters:
       listeners: CONTROLLER://0.0.0.0:9093
       listener_x_security_x_protocol_x_map: CONTROLLER:SSL
       log_x_dirs: /nsm/kafka/data

--- a/salt/kafka/defaults.yaml
+++ b/salt/kafka/defaults.yaml
@@ -41,7 +41,7 @@ kafka:
       ssl_x_truststore_x_location: /etc/pki/kafka-truststore.jks
       ssl_x_truststore_x_type: JKS
       ssl_x_truststore_x_password:
-      ssl_x_keystore_x_location: /etc/pki/kafka.p12
+      ssl_x_keystore_x_location: /etc/pki/kafka-client.p12
       ssl_x_keystore_x_type: PKCS12
       ssl_x_keystore_x_password:
     controller:
@@ -60,3 +60,74 @@ kafka:
       ssl_x_truststore_x_location: /etc/pki/kafka-truststore.jks
       ssl_x_truststore_x_type: JKS
       ssl_x_truststore_x_password:
+    external:
+      custom001:
+        enabled: false
+        name: custom001
+        password: default_placeholder
+        hostname: localhost
+        ip: 127.0.0.1
+        days_valid: 365
+      custom002:
+        enabled: false
+        name: custom002
+        password: default_placeholder
+        hostname: localhost
+        ip: 127.0.0.1
+        days_valid: 365
+      custom003:
+        enabled: false
+        name: custom003
+        password: default_placeholder
+        hostname: localhost
+        ip: 127.0.0.1
+        days_valid: 365
+      custom004:
+        enabled: false
+        name: custom004
+        password: default_placeholder
+        hostname: localhost
+        ip: 127.0.0.1
+        days_valid: 365
+      custom005:
+        enabled: false
+        name: custom005
+        password: default_placeholder
+        hostname: localhost
+        ip: 127.0.0.1
+        days_valid: 365
+      custom006:
+        enabled: false
+        name: custom006
+        password: default_placeholder
+        hostname: localhost
+        ip: 127.0.0.1
+        days_valid: 365
+      custom007:
+        enabled: false
+        name: custom007
+        password: default_placeholder
+        hostname: localhost
+        ip: 127.0.0.1
+        days_valid: 365
+      custom008:
+        enabled: false
+        name: custom008
+        password: default_placeholder
+        hostname: localhost
+        ip: 127.0.0.1
+        days_valid: 365
+      custom009:
+        enabled: false
+        name: custom009
+        password: default_placeholder
+        hostname: localhost
+        ip: 127.0.0.1
+        days_valid: 365
+      custom010:
+        enabled: false
+        name: custom010
+        password: default_placeholder
+        hostname: localhost
+        ip: 127.0.0.1
+        days_valid: 365

--- a/salt/kafka/enabled.sls
+++ b/salt/kafka/enabled.sls
@@ -50,11 +50,12 @@ so-kafka:
       {% endfor %}
     - binds:
       - /etc/pki/kafka.p12:/etc/pki/kafka.p12:ro
+      - /etc/pki/kafka-client.p12:/etc/pki/kafka-client.p12:ro
       - /opt/so/conf/kafka/kafka-truststore.jks:/etc/pki/kafka-truststore.jks:ro
       - /nsm/kafka/data/:/nsm/kafka/data/:rw
       - /opt/so/log/kafka:/opt/kafka/logs/:rw
       - /opt/so/conf/kafka/server.properties:/opt/kafka/config/kraft/server.properties:ro
-      - /opt/so/conf/kafka/client.properties:/opt/kafka/config/kraft/client.properties
+      - /opt/so/conf/kafka/client.properties:/opt/kafka/config/kraft/client.properties:ro
     - watch:
       {% for sc in ['server', 'client'] %}
       - file: kafka_kraft_{{sc}}_properties

--- a/salt/kafka/etc/external.properties.jinja
+++ b/salt/kafka/etc/external.properties.jinja
@@ -1,0 +1,14 @@
+{# Copyright Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+   or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at 
+   https://securityonion.net/license; you may not use this file except in compliance with the
+   Elastic License 2.0. #}
+
+{% from 'kafka/config.map.jinja' import KAFKACLIENT with context -%}
+{% set custom_key_path = "/opt/so/conf/kafka/" ~ external ~ "/" ~ values.name ~ ".p12" %}
+{% set custom_trust_path = "/opt/so/conf/kafka/" ~ external ~ "/kafka-truststore.jks" %}
+
+{% do KAFKACLIENT.update({'ssl_x_keystore_x_password': values.password }) %}
+{% do KAFKACLIENT.update({'ssl_x_keystore_x_location': custom_key_path }) %}
+{% do KAFKACLIENT.update({'ssl_x_truststore_x_location': custom_trust_path }) %}
+
+{{ KAFKACLIENT | yaml(False) | replace("_x_", ".") }}

--- a/salt/kafka/etc/external.properties.jinja
+++ b/salt/kafka/etc/external.properties.jinja
@@ -3,12 +3,12 @@
    https://securityonion.net/license; you may not use this file except in compliance with the
    Elastic License 2.0. #}
 
-{% from 'kafka/config.map.jinja' import KAFKACLIENT with context -%}
-{% set custom_key_path = "/opt/so/conf/kafka/" ~ external ~ "/" ~ values.name ~ ".p12" %}
-{% set custom_trust_path = "/opt/so/conf/kafka/" ~ external ~ "/kafka-truststore.jks" %}
+{%- from 'kafka/config.map.jinja' import KAFKACLIENT with context %}
+{%- set custom_key_path = "/opt/so/conf/kafka/" ~ external ~ "/" ~ values.name ~ ".p12" %}
+{%- set custom_trust_path = "/opt/so/conf/kafka/" ~ external ~ "/kafka-truststore.jks" -%}
 
-{% do KAFKACLIENT.update({'ssl_x_keystore_x_password': values.password }) %}
-{% do KAFKACLIENT.update({'ssl_x_keystore_x_location': custom_key_path }) %}
-{% do KAFKACLIENT.update({'ssl_x_truststore_x_location': custom_trust_path }) %}
+{%- do KAFKACLIENT.update({'ssl_x_keystore_x_password': values.password }) %}
+{%- do KAFKACLIENT.update({'ssl_x_keystore_x_location': custom_key_path }) %}
+{%- do KAFKACLIENT.update({'ssl_x_truststore_x_location': custom_trust_path }) -%}
 
 {{ KAFKACLIENT | yaml(False) | replace("_x_", ".") }}

--- a/salt/kafka/soc_kafka.yaml
+++ b/salt/kafka/soc_kafka.yaml
@@ -224,3 +224,34 @@ kafka:
         title: process.roles
         readonly: True
         helpLink: kafka.html
+    external:
+      custom001: &external
+        enabled:
+          description: Enable or disable the creation of certificate for accessing Kafka externally
+          forcedType: bool
+          helpLink: kafka.html
+        name:
+          description: Name of certificate
+          helpLink: kafka.html
+        password:
+          description: Password used for certificate
+          sensitive: True
+          helpLink: kafka.html
+        hostname:
+          description: Hostname to be included in certificate subjectAltName
+          helpLink: kafka.html
+        ip:
+          description: IP address to be included in certificate subjectAltName
+          helpLink: kafka.html
+        days_valid:
+          description: Number of days the custom certificate is valid for
+          helpLink: kafka.html
+      custom002: *external
+      custom003: *external
+      custom004: *external
+      custom005: *external
+      custom006: *external
+      custom007: *external
+      custom008: *external
+      custom009: *external
+      custom010: *external

--- a/salt/kafka/soc_kafka.yaml
+++ b/salt/kafka/soc_kafka.yaml
@@ -232,19 +232,23 @@ kafka:
           helpLink: kafka.html
         name:
           description: Name of certificate
+          forcedType: string
           helpLink: kafka.html
         password:
           description: Password used for certificate
           sensitive: True
+          forcedType: string
           helpLink: kafka.html
         hostname:
           description: Hostname to be included in certificate subjectAltName
+          forcedType: string
           helpLink: kafka.html
         ip:
           description: IP address to be included in certificate subjectAltName
           helpLink: kafka.html
         days_valid:
           description: Number of days the custom certificate is valid for
+          forcedType: int
           helpLink: kafka.html
       custom002: *external
       custom003: *external

--- a/salt/kafka/soc_kafka.yaml
+++ b/salt/kafka/soc_kafka.yaml
@@ -39,9 +39,9 @@ kafka:
         title: auto.create.topics.enable
         forcedType: bool
         helpLink: kafka.html
-      controller_x_quorum_x_requests_x_timeout_x_ms:
+      controller_x_quorum_x_request_x_timeout_x_ms:
         description: Specify the amount of time broker will wait for a response from the controller.
-        title: controller.quorum.requests.timeout.ms
+        title: controller.quorum.request.timeout.ms
         forcedType: int
         helplink: kafka.html
       default_x_replication_x_factor:

--- a/salt/kafka/soc_kafka.yaml
+++ b/salt/kafka/soc_kafka.yaml
@@ -43,6 +43,17 @@ kafka:
         title: auto.create.topics.enable
         forcedType: bool
         helpLink: kafka.html
+      controller_x_quorum_x_voters:
+        description: Kafka Kraft controller quorum voters.
+        title: controller.quorum.voters
+        advanced: True
+        readonly: True
+        helpLink: kafka.html
+      controller_x_quorum_x_requests_x_timeout_x_ms:
+        description: Specify the amount of time broker will wait for a response from the controller.
+        title: controller.quorum.requests.timeout.ms
+        forcedType: int
+        helplink: kafka.html
       default_x_replication_x_factor:
         description: The default replication factor for automatically created topics. This value must be less than the amount of brokers in the cluster. Hosts specified in controllers should not be counted towards total broker count.
         title: default.replication.factor

--- a/salt/kafka/soc_kafka.yaml
+++ b/salt/kafka/soc_kafka.yaml
@@ -34,20 +34,10 @@ kafka:
       sensitive: True
       helpLink: kafka.html
     broker:
-      advertised_x_listeners:
-        description: Specify the list of listeners (hostname and port) that Kafka brokers provide to clients for communication.
-        title: advertised.listeners
-        helpLink: kafka.html
       auto_x_create_x_topics_x_enable:
         description: Enable the auto creation of topics.
         title: auto.create.topics.enable
         forcedType: bool
-        helpLink: kafka.html
-      controller_x_quorum_x_voters:
-        description: Kafka Kraft controller quorum voters.
-        title: controller.quorum.voters
-        advanced: True
-        readonly: True
         helpLink: kafka.html
       controller_x_quorum_x_requests_x_timeout_x_ms:
         description: Specify the amount of time broker will wait for a response from the controller.
@@ -204,10 +194,6 @@ kafka:
         sensitive: True
         helpLink: kafka.html
     controller:
-      controller_x_listener_x_names:
-        description: Set listeners used by the controller in a comma-seperated list.
-        title: controller.listener.names
-        helpLink: kafka.html
       listeners:
         description: Set of URIs that is listened on and the listener names in a comma-seperated list.
         helpLink: kafka.html

--- a/salt/logstash/map.jinja
+++ b/salt/logstash/map.jinja
@@ -34,6 +34,8 @@
 {# Append Kafka input pipeline when Kafka is enabled #}
 {% if GLOBALS.pipeline == 'KAFKA' %}
 {%   do LOGSTASH_MERGED.defined_pipelines.search.remove('so/0900_input_redis.conf.jinja') %}
+{%   do LOGSTASH_MERGED.defined_pipelines.manager.remove('so/9999_output_redis.conf.jinja') %}
+{%   do LOGSTASH_MERGED.defined_pipelines.receiver.remove('so/9999_output_redis.conf.jinja') %}
 {%   do LOGSTASH_MERGED.defined_pipelines.search.append('so/0800_input_kafka.conf.jinja') %}
 {%   do LOGSTASH_MERGED.defined_pipelines.manager.append('so/0800_input_kafka.conf.jinja') %}
 {# Disable logstash on manager & receiver nodes unless it has an override configured #}


### PR DESCRIPTION
- Allows for creating custom certs for use from an external consumer/producer of kafka messages
- Added firewall config item for external_kafka_data

Also includes 
- Removes logstash redis output when kafka is enabled
- Removes redis portgroup from firewall defaults when kafka is enabled
- Remove unsupported config items from soc_kafka.yaml