### PR TITLE
add ilm and update managed index settings

### DIFF
--- a/salt/elasticsearch/defaults.yaml
+++ b/salt/elasticsearch/defaults.yaml
@@ -111,15 +111,23 @@ elasticsearch:
                 match_mapping_type: string
           settings:
             index:
+              lifecycle:
+                name: so-case-logs
               mapping:
                 total_fields:
                   limit: 1500
               number_of_replicas: 0
+              auto_expand_replicas: 0-2
               number_of_shards: 1
               refresh_interval: 30s
               sort:
                 field: '@timestamp'
                 order: desc
+      policy:
+        phases:
+          hot:
+            actions: {}
+            min_age: 0ms
     so-common:
       close: 30
       delete: 365
@@ -258,15 +266,23 @@ elasticsearch:
                 match_mapping_type: string
           settings:
             index:
+              lifecycle:
+                name: so-detection-logs
               mapping:
                 total_fields:
                   limit: 1500
               number_of_replicas: 0
+              auto_expand_replicas: 0-2
               number_of_shards: 1
               refresh_interval: 30s
               sort:
                 field: '@timestamp'
                 order: desc
+      policy:
+        phases:
+          hot:
+            actions: {}
+            min_age: 0ms
     so-endgame:
       index_sorting: false
       index_template:

--- a/salt/manager/tools/sbin/soup
+++ b/salt/manager/tools/sbin/soup
@@ -725,7 +725,7 @@ up_to_2.4.110() {
 
 up_to_2.4.120() {
   # this is needed for the new versionlock state
-  mkdir /opt/so/saltstack/local/pillar/versionlock
+  mkdir -p /opt/so/saltstack/local/pillar/versionlock
   touch /opt/so/saltstack/local/pillar/versionlock/adv_versionlock.sls /opt/so/saltstack/local/pillar/versionlock/soc_versionlock.sls
 
   # New Grid Integration added this release

--- a/salt/manager/tools/sbin/soup
+++ b/salt/manager/tools/sbin/soup
@@ -523,7 +523,7 @@ post_to_2.4.120() {
   for idx in "so-detection" "so-detectionhistory" "so-case" "so-casehistory"; do
     JSON_STRING=$( jq -n \
                   --arg INDEX_NAME "$idx" \
-                  '{"settings": {"index.auto_expand_replicas":"0-2","index.lifecycle.name":($INDEX_NAME) + "-logs"}}'
+                  '{"settings": {"index.auto_expand_replicas":"0-2","index.lifecycle.name":($INDEX_NAME + "-logs")}}'
                 )
     echo "Updating $idx index settings"
     retry 5 15 "so-elasticsearch-query $idx/_settings -d "$JSON_STRING" -XPUT| grep '{\"acknowledged\":true}'"

--- a/salt/manager/tools/sbin/soup
+++ b/salt/manager/tools/sbin/soup
@@ -520,16 +520,7 @@ post_to_2.4.110() {
 }
 
 post_to_2.4.120() {
-  for idx in "so-detection" "so-detectionhistory" "so-case" "so-casehistory"; do
-    JSON_STRING=$( jq -n \
-                  --arg INDEX_NAME "$idx" \
-                  '{"settings": {"index.auto_expand_replicas":"0-2","index.lifecycle.name":($INDEX_NAME + "-logs")}}'
-                )
-    echo "Updating $idx index settings"
-    retry 5 15 "so-elasticsearch-query $idx/_settings -d "$JSON_STRING" -XPUT| grep '{\"acknowledged\":true}'"
-    echo ""
-  done
-
+  update_elasticsearch_index_settings
   POSTVERSION=2.4.120
 }
 
@@ -945,6 +936,23 @@ update_airgap_repo() {
   echo "Creating repo"
   dnf -y install yum-utils createrepo_c
   createrepo /nsm/repo
+}
+
+update_elasticsearch_index_settings() {
+  # Update managed indices to reflect latest index template
+  for idx in "so-detection" "so-detectionhistory" "so-case" "so-casehistory"; do
+    JSON_STRING=$( jq -n --arg INDEX_NAME "$idx" '{"settings": {"index.auto_expand_replicas":"0-2","index.lifecycle.name":($INDEX_NAME + "-logs")}}')
+    echo "Checking if index \"$idx\" exists"
+    exists=$(curl -K /opt/so/conf/elasticsearch/curl.config -s -o /dev/null -w "%{http_code}" -k -L -H "Content-Type: application/json" "https://localhost:9200/$idx")
+    if [ $exists -eq 200 ]; then
+      echo "$idx index found..."
+      echo "Updating $idx index settings"
+      so-elasticsearch-query $idx/_settings -d "$JSON_STRING" -XPUT
+      echo -e "\n"
+    else
+      echo -e "Skipping $idx... index does not exist\n"
+    fi
+  done
 }
 
 update_salt_mine() {

--- a/salt/manager/tools/sbin/soup
+++ b/salt/manager/tools/sbin/soup
@@ -947,7 +947,7 @@ update_elasticsearch_index_settings() {
     if [ $exists -eq 200 ]; then
       echo "$idx index found..."
       echo "Updating $idx index settings"
-      so-elasticsearch-query $idx/_settings -d "$JSON_STRING" -XPUT
+      curl -K /opt/so/conf/elasticsearch/curl.config -s -k -L -H "Content-Type: application/json" "https://localhost:9200/$idx/_settings" -d "$JSON_STRING" -XPUT
       echo -e "\n"
     else
       echo -e "Skipping $idx... index does not exist\n"

--- a/salt/manager/tools/sbin/soup
+++ b/salt/manager/tools/sbin/soup
@@ -520,7 +520,16 @@ post_to_2.4.110() {
 }
 
 post_to_2.4.120() {
-  echo "Nothing to apply"
+  for idx in "so-detection" "so-detectionhistory" "so-case" "so-casehistory"; do
+    JSON_STRING=$( jq -n \
+                  --arg INDEX_NAME "$idx" \
+                  '{"settings": {"index.auto_expand_replicas":"0-2","index.lifecycle.name":($INDEX_NAME) + "-logs"}}'
+                )
+    echo "Updating $idx index settings"
+    retry 5 15 "so-elasticsearch-query $idx/_settings -d "$JSON_STRING" -XPUT| grep '{\"acknowledged\":true}'"
+    echo ""
+  done
+
   POSTVERSION=2.4.120
 }
 


### PR DESCRIPTION
Allow so-detection, so-detectionhistory, so-case, so-casehistory to dynamically set replicas based on available data nodes.

Set indices hot status indefinitely 