### PR TITLE
New Limit on Bulk Creating Related Events

### DIFF
--- a/salt/soc/defaults.yaml
+++ b/salt/soc/defaults.yaml
@@ -2147,6 +2147,7 @@ soc:
           eventFetchLimit: 500
           relativeTimeValue: 24
           relativeTimeUnit: 30
+          maxBulkEscalateEvents: 100
           mostRecentlyUsedLimit: 5
           ackEnabled: true
           escalateEnabled: true

--- a/salt/soc/soc_soc.yaml
+++ b/salt/soc/soc_soc.yaml
@@ -499,7 +499,7 @@ soc:
         alerts:
           <<: *appSettings
           maxBulkEscalateEvents:
-            description: Maximum number of events to escalate in a single bulk escalation.
+            description: Maximum number of events to escalate in a single bulk escalation. Large values may run into other limits.
             global: True
         cases: *appSettings
         dashboards: *appSettings

--- a/salt/soc/soc_soc.yaml
+++ b/salt/soc/soc_soc.yaml
@@ -496,7 +496,11 @@ soc:
             global: True
             advanced: True
             forcedType: "[]{}"
-        alerts: *appSettings
+        alerts:
+          <<: *appSettings
+          maxBulkEscalateEvents:
+            description: Maximum number of events to escalate in a single bulk escalation.
+            global: True
         cases: *appSettings
         dashboards: *appSettings
         detections:


### PR DESCRIPTION
Used by the UI and API to hint at a user that not every event will be attached to a case. Supports values up to 10,000 (the default limit on the number of documents returned by a single ES search).