### PR TITLE
Add RulesetName to Rule Repos

### DIFF
--- a/salt/soc/defaults.yaml
+++ b/salt/soc/defaults.yaml
@@ -1415,17 +1415,21 @@ soc:
                 license: Elastic-2.0
                 folder: sigma/stable
                 community: true
+                rulesetName: securityonion-resources
               - repo: file:///nsm/rules/custom-local-repos/local-sigma
                 license: Elastic-2.0
                 community: false
+                rulesetName: local-sigma
             airgap:
               - repo: file:///nsm/rules/detect-sigma/repos/securityonion-resources
                 license: Elastic-2.0
                 folder: sigma/stable
                 community: true
+                rulesetName: securityonion-resources
               - repo: file:///nsm/rules/custom-local-repos/local-sigma
                 license: Elastic-2.0
                 community: false
+                rulesetName: local-sigma
           sigmaRulePackages:
             - core
             - emerging_threats_addon
@@ -1500,16 +1504,20 @@ soc:
               - repo: https://github.com/Security-Onion-Solutions/securityonion-yara
                 license: DRL
                 community: true
+                rulesetName: securityonion-yara
               - repo: file:///nsm/rules/custom-local-repos/local-yara
                 license: Elastic-2.0
                 community: false
+                rulesetName: local-yara
             airgap:
               - repo: file:///nsm/rules/detect-yara/repos/securityonion-yara
                 license: DRL
                 community: true
+                rulesetName: securityonion-yara
               - repo: file:///nsm/rules/custom-local-repos/local-yara
                 license: Elastic-2.0
                 community: false
+                rulesetName: local-yara
           yaraRulesFolder: /opt/sensoroni/yara/rules
           stateFilePath: /opt/sensoroni/fingerprints/strelkaengine.state
           integrityCheckFrequencySeconds: 1200

--- a/salt/soc/soc_soc.yaml
+++ b/salt/soc/soc_soc.yaml
@@ -344,6 +344,23 @@ soc:
               advanced: True
               forcedType: "[]{}"
               helpLink: sigma.html
+              syntax: json
+              uiElements:
+              - field: rulesetName
+                label: Ruleset Name
+              - field: repo
+                label: Repo URL
+                required: True
+              - field: branch
+                label: Branch
+              - field: license
+                label: License
+                required: True
+              - field: folder
+                label: Folder
+              - field: community
+                label: Community
+                forcedType: bool
             airgap: *eerulesRepos
           sigmaRulePackages:
             description: 'Defines the Sigma Community Ruleset you want to run. One of these (core | core+ | core++ | all ) as well as an optional Add-on (emerging_threats_addon). Once you have changed the ruleset here, the new settings will be applied within 15 minutes. At that point, you will need to wait for the scheduled rule update to take place (by default, every 24 hours), or you can force the update by nagivating to Detections -->  Options dropdown menu --> Elastalert --> Full Update. WARNING! Changing the ruleset will remove all existing non-overlapping Sigma rules of the previous ruleset and their associated overrides. This removal cannot be undone.'
@@ -459,6 +476,23 @@ soc:
               advanced: True
               forcedType: "[]{}"
               helpLink: yara.html
+              syntax: json
+              uiElements:
+              - field: rulesetName
+                label: Ruleset Name
+              - field: repo
+                label: Repo URL
+                required: True
+              - field: branch
+                label: Branch
+              - field: license
+                label: License
+                required: True
+              - field: folder
+                label: Folder
+              - field: community
+                label: Community
+                forcedType: bool
             airgap: *serulesRepos
         suricataengine:
           aiRepoUrl:
@@ -592,7 +626,7 @@ soc:
               label: Query
               required: True
             - field: showSubtitle
-              label: Show Query in Dropdown. 
+              label: Show Query in Dropdown.
               forcedType: bool
           queryToggleFilters:
             description: Customize togglable query filters that apply to all queries. Exclusive toggles will invert the filter if toggled off rather than omitting the filter from the query.


### PR DESCRIPTION
Fill in `rulesetName` in the rules repos of the ElastAlert and Strelka engines. These will act as an example to anybody adding their repos to these lists. The field is not required, but helps avoid collisions when managing repos as the value is used for the folder name. When not present, the final folder of the repo url is used as the rulesetName and as the folder name on disk.

Note that rulesetNames including a `/` will create extra folders in the path but the rulesetName will contain the slash, i.e. `rulesetName="joesecurity/sigma-rules"` will create the nested structure of `reposFolder/joesecurity/sigma-rules" containing the contents of the repo. All rules imported from this repo will have the ruleset of `joesecurity/sigma-rules`.