### PR TITLE
Updated Playbook Repo Config

### DIFF
--- a/salt/soc/defaults.yaml
+++ b/salt/soc/defaults.yaml
@@ -1464,8 +1464,8 @@ soc:
           autoUpdateEnabled: true
           playbookImportFrequencySeconds: 86400
           playbookImportErrorSeconds: 600
-          playbookRepoUrl: https://github.com/Security-Onion-Solutions/securityonion-resources
-          playbookRepoBranch: playbooks-stable
+          playbookRepoUrl: https://github.com/Security-Onion-Solutions/securityonion-resources-playbooks
+          playbookRepoBranch: main
           playbookRepoPath: /opt/sensoroni/playbooks/
           playbookPathInRepo: securityonion-normalized
         salt:


### PR DESCRIPTION
The repo and folder have changed. We're splitting out playbooks into their own repo: github.com/security-onion-solutions/securityonion-resources-playbooks.