### PR TITLE
Fix Index Patterns

### DIFF
--- a/salt/elasticsearch/defaults.yaml
+++ b/salt/elasticsearch/defaults.yaml
@@ -295,7 +295,7 @@ elasticsearch:
           hidden: false
         ignore_missing_component_templates: []
         index_patterns:
-        - so-assistant-chat-*
+        - so-assistant-chat*
         priority: 501
         template:
           mappings:
@@ -335,7 +335,7 @@ elasticsearch:
           hidden: false
         ignore_missing_component_templates: []
         index_patterns:
-        - so-assistant-session-*
+        - so-assistant-session*
         priority: 501
         template:
           mappings:


### PR DESCRIPTION
so-assistant-chat and so-assistant-session both had templates with a trailing dash that prevented the pattern from applying to the name of the indices.