### PR TITLE
Updated default investigation prompt

### DIFF
--- a/salt/soc/defaults.yaml
+++ b/salt/soc/defaults.yaml
@@ -2545,7 +2545,7 @@ soc:
               level: 'high'  # info | low | medium | high | critical
         assistant:
           enabled: false
-          investigationPrompt: Investigate Alert ID {socid}
+          investigationPrompt: Investigate Alert ID {socId}
           contextLimitSmall: 200000
           contextLimitLarge: 1000000
           thresholdColorRatioLow: 0.5


### PR DESCRIPTION
Updated default investigation prompt, changing {socid} to {socId} to be more in line with standards on the alerts page.