### PR TITLE
do not log set_timezone in setup

### DIFF
--- a/setup/so-functions
+++ b/setup/so-functions
@@ -2305,7 +2305,7 @@ set_redirect() {
 
 set_timezone() {
 
-	logCmd "timedatectl set-timezone Etc/UTC"
+	timedatectl set-timezone Etc/UTC
 
 }
 


### PR DESCRIPTION
creates additional sosetup.log file

```
[root@manager ~]# cat sosetup.log.2025-10-15T19\:46\:48 
2025-10-15T19:46:47Z | INFO | Executing command: timedatectl set-timezone Etc/UTC
```
