### PR TITLE
reduce pcapMaxCount to fit better with max upload size

### DIFF
--- a/salt/sensoroni/defaults.yaml
+++ b/salt/sensoroni/defaults.yaml
@@ -15,7 +15,7 @@ sensoroni:
     sensoronikey:
     soc_host:
     suripcap:
-      pcapMaxCount: 999999
+      pcapMaxCount: 100000
   analyzers:
       echotrail:
         base_url: https://api.echotrail.io/insights/


### PR DESCRIPTION
Given nginx max body size of 2.5GB, and jumbo frame packet size of 9000B:

`2500000000 / 9000 = ~277777`

Rounding down to 100K as an addt'l precaution.
