### PR TITLE
fix so-setup error duplicate bond0

### DIFF
--- a/setup/so-functions
+++ b/setup/so-functions
@@ -729,7 +729,7 @@ configure_network_sensor() {
 	fi
 
 	# Create the bond interface only if it doesn't already exist
-	nmcli -f name,uuid -p con | grep -q '$INTERFACE'
+	nmcli -f name,uuid -p con | grep -q "$INTERFACE"
 	local found_int=$?
 
 	if [[ $found_int != 0 ]]; then


### PR DESCRIPTION
sosetup.log error
```
Warning: There are 6 other connections with the name 'bond0'. Reference the connection by its uuid 'ef53f152-cac0-46cb-a7d4-ecb6f071f83d'
Connection 'bond0' (ef53f152-cac0-46cb-a7d4-ecb6f071f83d) successfully added.
Could not change any device features
Error: Connection activation failed: Unknown error
```