### PR TITLE
don't set is_airgap when using nonairgap_useiso: not a true airgap sy…

### DIFF
--- a/salt/manager/tools/sbin/soup
+++ b/salt/manager/tools/sbin/soup
@@ -206,14 +206,18 @@ check_airgap() {
   else
     nonairgap_useiso=1
   fi
+
+  if [[ "$AIRGAP" == "true" ]]; then
+      is_airgap=0
+    else
+      is_airgap=1
+  fi
+
   # use ISO if its airgap install OR ISOLOC was set with -f <path>
   if [[ "$AIRGAP" == "true" ]] || [[ $nonairgap_useiso -eq 0 ]]; then
-      is_airgap=0
       UPDATE_DIR=/tmp/soagupdate/SecurityOnion
       AGDOCKER=/tmp/soagupdate/docker
       AGREPO=/tmp/soagupdate/minimal/Packages
-  else
-      is_airgap=1
   fi
 }
 


### PR DESCRIPTION
…stem so we should keep it separate