### PR TITLE
Improve soup version checks and migrate pcap to suricata

### DIFF
--- a/salt/manager/tools/sbin/soup
+++ b/salt/manager/tools/sbin/soup
@@ -362,7 +362,7 @@ preupgrade_changes() {
     # This function is to add any new pillar items if needed.
     echo "Checking to see if changes are needed."
 
-    [[ "$INSTALLEDVERSION" == 2.4.210 ]] && up_to_3.0.0   
+    [[ "$INSTALLEDVERSION" =~ ^2\.4\.21[0-9]+$ ]] && up_to_3.0.0   
     true
 }
 
@@ -370,12 +370,12 @@ postupgrade_changes() {
     # This function is to add any new pillar items if needed.
     echo "Running post upgrade processes."
 
-    [[ "$POSTVERSION" == 2.4.210 ]] && post_to_3.0.0
+    [[ "$POSTVERSION" =~ ^2\.4\.21[0-9]+$ ]] && post_to_3.0.0
     true
 }
 
 check_minimum_version() {
-  if [[ "$INSTALLEDVERSION" != "2.4.210" ]] && [[ "$INSTALLEDVERSION" != "2.4.211" ]] && [[ ! "$INSTALLEDVERSION" =~ ^3\. ]]; then
+  if [[ ! "$INSTALLEDVERSION" =~ ^(2\.4\.21[0-9]+|3\.) ]]; then
     echo "You must be on at least Security Onion 2.4.210 to upgrade. Currently installed version: $INSTALLEDVERSION"
     exit 1
   fi
@@ -385,8 +385,21 @@ check_minimum_version() {
 
 up_to_3.0.0() {
   determine_elastic_agent_upgrade
+  migrate_pcap_to_suricata
 
   INSTALLEDVERSION=3.0.0
+}
+
+migrate_pcap_to_suricata() {
+  local MINIONDIR=/opt/so/saltstack/local/pillar/minions
+  local PCAPFILE=/opt/so/saltstack/local/pillar/pcap/soc_pcap.sls
+
+  for pillar_file in "$PCAPFILE" "$MINIONDIR"/*.sls; do
+    [[ -f "$pillar_file" ]] || continue
+    pcap_enabled=$(so-yaml.py get "$pillar_file" pcap.enabled 2>/dev/null) || continue
+    so-yaml.py add "$pillar_file" suricata.pcap.enabled "$pcap_enabled"
+    so-yaml.py remove "$pillar_file" pcap
+  done
 }
 
 post_to_3.0.0() {


### PR DESCRIPTION
## Summary
- Consolidate version checks to use regex patterns matching any `2.4.21X` version and any `3.x` version instead of hardcoded version strings
- Add `migrate_pcap_to_suricata` function to move `pcap.enabled` to `suricata.pcap.enabled` in minion pillar files and pcap pillar during upgrade to 3.0.0

## Test plan
- [ ] Verify upgrade from 2.4.210, 2.4.211, and other 2.4.21X versions triggers `up_to_3.0.0`
- [ ] Verify `check_minimum_version` accepts all 2.4.21X and 3.x versions
- [ ] Verify `pcap.enabled` is correctly migrated to `suricata.pcap.enabled` in minion and pcap pillar files