### PR TITLE
Add -r flag to so-yaml get and migrate pcap pillar to suricata

### DIFF
--- a/salt/manager/tools/sbin/so-yaml.py
+++ b/salt/manager/tools/sbin/so-yaml.py
@@ -22,7 +22,7 @@ def showUsage(args):
     print('    removelistitem   - Remove a list item from a yaml key, if it exists and is a list. Requires KEY and LISTITEM args.', file=sys.stderr)
     print('    replacelistobject  - Replace a list object based on a condition. Requires KEY, CONDITION_FIELD, CONDITION_VALUE, and JSON_OBJECT args.', file=sys.stderr)
     print('    add              - Add a new key and set its value. Fails if key already exists. Requires KEY and VALUE args.', file=sys.stderr)
-    print('    get              - Displays (to stdout) the value stored in the given key. Requires KEY arg.', file=sys.stderr)
+    print('    get [-r]         - Displays (to stdout) the value stored in the given key. Requires KEY arg. Use -r for raw output without YAML formatting.', file=sys.stderr)
     print('    remove           - Removes a yaml key, if it exists. Requires KEY arg.', file=sys.stderr)
     print('    replace          - Replaces (or adds) a new key and set its value. Requires KEY and VALUE args.', file=sys.stderr)
     print('    help             - Prints this usage information.', file=sys.stderr)
@@ -332,6 +332,11 @@ def getKeyValue(content, key):
 
 
 def get(args):
+    raw = False
+    if len(args) > 0 and args[0] == '-r':
+        raw = True
+        args = args[1:]
+
     if len(args) != 2:
         print('Missing filename or key arg', file=sys.stderr)
         showUsage(None)
@@ -346,12 +351,15 @@ def get(args):
         print(f"Key '{key}' not found by so-yaml.py", file=sys.stderr)
         return 2
 
-    if isinstance(output, bool):
-        print(str(output).lower())
-    elif isinstance(output, (dict, list)):
-        print(yaml.safe_dump(output).strip())
+    if raw:
+        if isinstance(output, bool):
+            print(str(output).lower())
+        elif isinstance(output, (dict, list)):
+            print(yaml.safe_dump(output).strip())
+        else:
+            print(output)
     else:
-        print(output)
+        print(yaml.safe_dump(output))
     return 0
 
 

--- a/salt/manager/tools/sbin/so-yaml_test.py
+++ b/salt/manager/tools/sbin/so-yaml_test.py
@@ -450,6 +450,18 @@ class TestRemove(unittest.TestCase):
             self.assertEqual(result, 0)
             self.assertEqual("false\n", mock_stdout.getvalue())
 
+    def test_get_dict_raw(self):
+        with patch('sys.stdout', new=StringIO()) as mock_stdout:
+            filename = "/tmp/so-yaml_test-get.yaml"
+            file = open(filename, "w")
+            file.write("{key1: { child1: 123, child2: { deep1: 45 } }, key2: false, key3: [e,f,g]}")
+            file.close()
+
+            result = soyaml.get(["-r", filename, "key1"])
+            self.assertEqual(result, 0)
+            self.assertIn("child1: 123", mock_stdout.getvalue())
+            self.assertNotIn("...", mock_stdout.getvalue())
+
     def test_get_list(self):
         with patch('sys.stdout', new=StringIO()) as mock_stdout:
             filename = "/tmp/so-yaml_test-get.yaml"

--- a/salt/manager/tools/sbin/so-yaml_test.py
+++ b/salt/manager/tools/sbin/so-yaml_test.py
@@ -393,6 +393,17 @@ class TestRemove(unittest.TestCase):
 
             result = soyaml.get([filename, "key1.child2.deep1"])
             self.assertEqual(result, 0)
+            self.assertIn("45\n...", mock_stdout.getvalue())
+
+    def test_get_int_raw(self):
+        with patch('sys.stdout', new=StringIO()) as mock_stdout:
+            filename = "/tmp/so-yaml_test-get.yaml"
+            file = open(filename, "w")
+            file.write("{key1: { child1: 123, child2: { deep1: 45 } }, key2: false, key3: [e,f,g]}")
+            file.close()
+
+            result = soyaml.get(["-r", filename, "key1.child2.deep1"])
+            self.assertEqual(result, 0)
             self.assertEqual("45\n", mock_stdout.getvalue())
 
     def test_get_str(self):
@@ -404,6 +415,17 @@ class TestRemove(unittest.TestCase):
 
             result = soyaml.get([filename, "key1.child2.deep1"])
             self.assertEqual(result, 0)
+            self.assertIn("hello\n...", mock_stdout.getvalue())
+
+    def test_get_str_raw(self):
+        with patch('sys.stdout', new=StringIO()) as mock_stdout:
+            filename = "/tmp/so-yaml_test-get.yaml"
+            file = open(filename, "w")
+            file.write("{key1: { child1: 123, child2: { deep1: \"hello\" } }, key2: false, key3: [e,f,g]}")
+            file.close()
+
+            result = soyaml.get(["-r", filename, "key1.child2.deep1"])
+            self.assertEqual(result, 0)
             self.assertEqual("hello\n", mock_stdout.getvalue())
 
     def test_get_bool(self):
@@ -414,6 +436,17 @@ class TestRemove(unittest.TestCase):
             file.close()
 
             result = soyaml.get([filename, "key2"])
+            self.assertEqual(result, 0)
+            self.assertIn("false\n...", mock_stdout.getvalue())
+
+    def test_get_bool_raw(self):
+        with patch('sys.stdout', new=StringIO()) as mock_stdout:
+            filename = "/tmp/so-yaml_test-get.yaml"
+            file = open(filename, "w")
+            file.write("{key1: { child1: 123, child2: { deep1: 45 } }, key2: false, key3: [e,f,g]}")
+            file.close()
+
+            result = soyaml.get(["-r", filename, "key2"])
             self.assertEqual(result, 0)
             self.assertEqual("false\n", mock_stdout.getvalue())
 

--- a/salt/manager/tools/sbin/soup
+++ b/salt/manager/tools/sbin/soup
@@ -396,7 +396,7 @@ migrate_pcap_to_suricata() {
 
   for pillar_file in "$PCAPFILE" "$MINIONDIR"/*.sls; do
     [[ -f "$pillar_file" ]] || continue
-    pcap_enabled=$(so-yaml.py get "$pillar_file" pcap.enabled 2>/dev/null) || continue
+    pcap_enabled=$(so-yaml.py get -r "$pillar_file" pcap.enabled 2>/dev/null) || continue
     so-yaml.py add "$pillar_file" suricata.pcap.enabled "$pcap_enabled"
     so-yaml.py remove "$pillar_file" pcap
   done


### PR DESCRIPTION
## Summary
- Consolidate soup version checks to use regex patterns for `2.4.21X` and `3.x` versions
- Add `migrate_pcap_to_suricata` function to move `pcap.enabled` to `suricata.pcap.enabled` in minion and pcap pillar files during upgrade
- Move `pcap.enabled` under `suricata.pcap.enabled` in so-minion
- Fix so-yaml `addKey` crash when intermediate key has `None` value
- Add `-r` flag to `so-yaml get` for raw output without YAML document end marker, preserving default behavior for backwards compatibility
- Update so-yaml tests for `-r` flag and boolean get

## Test plan
- [ ] Verify `so-yaml get` default output is unchanged (includes `...` marker)
- [ ] Verify `so-yaml get -r` outputs clean scalar values
- [ ] Verify upgrade from any 2.4.21X version triggers `up_to_3.0.0`
- [ ] Verify `pcap.enabled` is correctly migrated to `suricata.pcap.enabled`
- [ ] Verify so-minion creates pillar with `suricata.pcap.enabled` instead of `pcap.enabled`