### PR TITLE
Remove support for non-Oracle Linux 9 operating systems

### DIFF
--- a/salt/common/tools/sbin/so-common
+++ b/salt/common/tools/sbin/so-common
@@ -349,21 +349,16 @@ get_random_value() {
 }
 
 gpg_rpm_import() {
-	if [[ $is_oracle ]]; then
-	    if [[ "$WHATWOULDYOUSAYYAHDOHERE" == "setup" ]]; then
-	        local RPMKEYSLOC="../salt/repo/client/files/$OS/keys"
-	    else
-	        local RPMKEYSLOC="$UPDATE_DIR/salt/repo/client/files/$OS/keys"
-	    fi
-		RPMKEYS=('RPM-GPG-KEY-oracle' 'RPM-GPG-KEY-EPEL-9' 'SALT-PROJECT-GPG-PUBKEY-2023.pub' 'docker.pub' 'securityonion.pub')
-		for RPMKEY in "${RPMKEYS[@]}"; do
-    	        rpm --import $RPMKEYSLOC/$RPMKEY
-	        echo "Imported $RPMKEY"
-	    done
-	elif [[ $is_rpm ]]; then
-		echo "Importing the security onion GPG key"
-		rpm --import ../salt/repo/client/files/oracle/keys/securityonion.pub
+	if [[ "$WHATWOULDYOUSAYYAHDOHERE" == "setup" ]]; then
+		local RPMKEYSLOC="../salt/repo/client/files/$OS/keys"
+	else
+		local RPMKEYSLOC="$UPDATE_DIR/salt/repo/client/files/$OS/keys"
 	fi
+	RPMKEYS=('RPM-GPG-KEY-oracle' 'RPM-GPG-KEY-EPEL-9' 'SALT-PROJECT-GPG-PUBKEY-2023.pub' 'docker.pub' 'securityonion.pub')
+	for RPMKEY in "${RPMKEYS[@]}"; do
+		rpm --import $RPMKEYSLOC/$RPMKEY
+		echo "Imported $RPMKEY"
+	done
 }
 
 header() {
@@ -615,69 +610,19 @@ salt_minion_count() {
 }
 
 set_os() {
-	if [ -f /etc/redhat-release ]; then
-		if grep -q "Rocky Linux release 9" /etc/redhat-release; then
-			OS=rocky
-			OSVER=9
-			is_rocky=true
-			is_rpm=true
-		elif grep -q "CentOS Stream release 9" /etc/redhat-release; then
-			OS=centos
-			OSVER=9
-			is_centos=true
-			is_rpm=true
-		elif grep -q "AlmaLinux release 9" /etc/redhat-release; then
-			OS=alma
-			OSVER=9
-			is_alma=true
-			is_rpm=true
-		elif grep -q "Red Hat Enterprise Linux release 9" /etc/redhat-release; then
-			if [ -f /etc/oracle-release ]; then
-				OS=oracle
-				OSVER=9
-				is_oracle=true
-				is_rpm=true
-			else
-				OS=rhel
-				OSVER=9
-				is_rhel=true
-				is_rpm=true
-			fi
-		fi
-		cron_service_name="crond"
-	elif [ -f /etc/os-release ]; then
-		if grep -q "UBUNTU_CODENAME=focal" /etc/os-release; then
-			OSVER=focal
-			UBVER=20.04
-			OS=ubuntu
-			is_ubuntu=true
-			is_deb=true
-		elif grep -q "UBUNTU_CODENAME=jammy" /etc/os-release; then
-			OSVER=jammy
-			UBVER=22.04
-			OS=ubuntu
-			is_ubuntu=true
-			is_deb=true
-		elif grep -q "VERSION_CODENAME=bookworm" /etc/os-release; then
-			OSVER=bookworm
-			DEBVER=12
-			is_debian=true
-			OS=debian
-			is_deb=true
-		fi
-		cron_service_name="cron"
+	if [ -f /etc/redhat-release ] && grep -q "Red Hat Enterprise Linux release 9" /etc/redhat-release && [ -f /etc/oracle-release ]; then
+		OS=oracle
+		OSVER=9
+		is_oracle=true
+		is_rpm=true
 	fi
+	cron_service_name="crond"
 }
 
 set_minionid() {
 	MINIONID=$(lookup_grain id)
 }
 
-set_palette() {
-	if [[ $is_deb ]]; then
-	    update-alternatives --set newt-palette /etc/newt/palette.original
-    fi
-}
 
 set_version() {
 	CURRENTVERSION=0.0.0

--- a/salt/manager/tools/sbin/soup
+++ b/salt/manager/tools/sbin/soup
@@ -576,78 +576,46 @@ upgrade_check_salt() {
 upgrade_salt() {
   echo "Performing upgrade of Salt from $INSTALLEDSALTVERSION to $NEWSALTVERSION."
   echo ""
-  # If rhel family
-  if [[ $is_rpm ]]; then
-    # Check if salt-cloud is installed
-    if rpm -q salt-cloud &>/dev/null; then
-      SALT_CLOUD_INSTALLED=true
-    fi
-    # Check if salt-cloud is configured
-    if [[ -f /etc/salt/cloud.profiles.d/socloud.conf ]]; then
-      SALT_CLOUD_CONFIGURED=true
-    fi
-    
-    echo "Removing yum versionlock for Salt."
-    echo ""
-    yum versionlock delete "salt"
-    yum versionlock delete "salt-minion"
-    yum versionlock delete "salt-master"
-    # Remove salt-cloud versionlock if installed
-    if [[ $SALT_CLOUD_INSTALLED == true ]]; then
-      yum versionlock delete "salt-cloud"
-    fi
-    echo "Updating Salt packages."
-    echo ""
-    set +e
-    # if oracle run with -r to ignore repos set by bootstrap
-    if [[ $OS == 'oracle' ]]; then
-      # Add -L flag only if salt-cloud is already installed
-      if [[ $SALT_CLOUD_INSTALLED == true ]]; then
-        run_check_net_err \
-        "sh $UPDATE_DIR/salt/salt/scripts/bootstrap-salt.sh -X -r -L -F -M stable \"$NEWSALTVERSION\"" \
-        "Could not update salt, please check $SOUP_LOG for details."
-      else
-        run_check_net_err \
-        "sh $UPDATE_DIR/salt/salt/scripts/bootstrap-salt.sh -X -r -F -M stable \"$NEWSALTVERSION\"" \
-        "Could not update salt, please check $SOUP_LOG for details."
-      fi
-    # if another rhel family variant we want to run without -r to allow the bootstrap script to manage repos
-    else
-      run_check_net_err \
-      "sh $UPDATE_DIR/salt/salt/scripts/bootstrap-salt.sh -X -F -M stable \"$NEWSALTVERSION\"" \
-      "Could not update salt, please check $SOUP_LOG for details."
-    fi
-    set -e
-    echo "Applying yum versionlock for Salt."
-    echo ""
-    yum versionlock add "salt-0:$NEWSALTVERSION-0.*"
-    yum versionlock add "salt-minion-0:$NEWSALTVERSION-0.*"
-    yum versionlock add "salt-master-0:$NEWSALTVERSION-0.*"
-    # Add salt-cloud versionlock if installed
-    if [[ $SALT_CLOUD_INSTALLED == true ]]; then
-      yum versionlock add "salt-cloud-0:$NEWSALTVERSION-0.*"
-    fi
-  # Else do Ubuntu things
-  elif [[ $is_deb ]]; then
-    # ensure these files don't exist when upgrading from 3006.9 to 3006.16
-    rm -f /etc/apt/keyrings/salt-archive-keyring-2023.pgp /etc/apt/sources.list.d/salt.list
-    echo "Removing apt hold for Salt."
-    echo ""
-    apt-mark unhold "salt-common"
-    apt-mark unhold "salt-master"
-    apt-mark unhold "salt-minion"
-    echo "Updating Salt packages."
-    echo ""
-    set +e
+  # Check if salt-cloud is installed
+  if rpm -q salt-cloud &>/dev/null; then
+    SALT_CLOUD_INSTALLED=true
+  fi
+  # Check if salt-cloud is configured
+  if [[ -f /etc/salt/cloud.profiles.d/socloud.conf ]]; then
+    SALT_CLOUD_CONFIGURED=true
+  fi
+
+  echo "Removing yum versionlock for Salt."
+  echo ""
+  yum versionlock delete "salt"
+  yum versionlock delete "salt-minion"
+  yum versionlock delete "salt-master"
+  # Remove salt-cloud versionlock if installed
+  if [[ $SALT_CLOUD_INSTALLED == true ]]; then
+    yum versionlock delete "salt-cloud"
+  fi
+  echo "Updating Salt packages."
+  echo ""
+  set +e
+  # Run with -r to ignore repos set by bootstrap
+  if [[ $SALT_CLOUD_INSTALLED == true ]]; then
     run_check_net_err \
-    "sh $UPDATE_DIR/salt/salt/scripts/bootstrap-salt.sh -X -F -M stable \"$NEWSALTVERSION\"" \
+    "sh $UPDATE_DIR/salt/salt/scripts/bootstrap-salt.sh -X -r -L -F -M stable \"$NEWSALTVERSION\"" \
     "Could not update salt, please check $SOUP_LOG for details."
-    set -e
-    echo "Applying apt hold for Salt."
-    echo ""
-    apt-mark hold "salt-common"
-    apt-mark hold "salt-master"
-    apt-mark hold "salt-minion"
+  else
+    run_check_net_err \
+    "sh $UPDATE_DIR/salt/salt/scripts/bootstrap-salt.sh -X -r -F -M stable \"$NEWSALTVERSION\"" \
+    "Could not update salt, please check $SOUP_LOG for details."
+  fi
+  set -e
+  echo "Applying yum versionlock for Salt."
+  echo ""
+  yum versionlock add "salt-0:$NEWSALTVERSION-0.*"
+  yum versionlock add "salt-minion-0:$NEWSALTVERSION-0.*"
+  yum versionlock add "salt-master-0:$NEWSALTVERSION-0.*"
+  # Add salt-cloud versionlock if installed
+  if [[ $SALT_CLOUD_INSTALLED == true ]]; then
+    yum versionlock add "salt-cloud-0:$NEWSALTVERSION-0.*"
   fi
 
   echo "Checking if Salt was upgraded."
@@ -1084,6 +1052,10 @@ main() {
   echo ""
   set_os
 
+  if [[ ! $is_oracle ]]; then
+    fail "This OS is not supported. Security Onion requires Oracle Linux 9."
+  fi
+
   check_salt_master_status 1 || fail  "Could not talk to salt master: Please run 'systemctl status salt-master' to ensure the salt-master service is running and check the log at /opt/so/log/salt/master."
 
   echo "Checking to see if this is a manager."
@@ -1193,14 +1165,6 @@ main() {
       echo "Upgrading Salt"
       # Update the repo files so it can actually upgrade
       upgrade_salt
-
-      # for Debian based distro, we need to stop salt again after upgrade output below is from bootstrap-salt
-      # *  WARN: Not starting daemons on Debian based distributions
-      #    is not working mostly because starting them is the default behaviour.
-      if [[ $is_deb ]]; then
-        stop_salt_minion
-        stop_salt_master
-      fi
     fi
 
     preupgrade_changes

--- a/setup/so-functions
+++ b/setup/so-functions
@@ -852,74 +852,14 @@ detect_cloud() {
 
 detect_os() {
 	title "Detecting Base OS"
-	if [ -f /etc/redhat-release ]; then
-		if grep -q "Rocky Linux release 9" /etc/redhat-release; then
-			OS=rocky
-			OSVER=9
-			is_rocky=true
-			is_rpm=true
-			not_supported=true
-			unset is_supported
-		elif grep -q "CentOS Stream release 9" /etc/redhat-release; then
-			OS=centos
-			OSVER=9
-			is_centos=true
-			is_rpm=true
-			not_supported=true
-			unset is_supported
-		elif grep -q "AlmaLinux release 9" /etc/redhat-release; then
-			OS=alma
-			OSVER=9
-			is_alma=true
-			is_rpm=true
-			not_supported=true
-			unset is_supported
-		elif grep -q "Red Hat Enterprise Linux release 9" /etc/redhat-release; then
-			if [ -f /etc/oracle-release ]; then
-				OS=oracle
-				OSVER=9
-				is_oracle=true
-				is_rpm=true
-				is_supported=true
-			else
-				OS=rhel
-				OSVER=9
-				is_rhel=true
-				is_rpm=true
-				not_supported=true
-				unset is_supported
-			fi
-		fi
-	elif [ -f /etc/os-release ]; then
-		if grep -q "UBUNTU_CODENAME=focal" /etc/os-release; then
-			OSVER=focal
-			UBVER=20.04
-			OS=ubuntu
-			is_ubuntu=true
-			is_deb=true
-			not_supported=true
-			unset is_supported
-		elif grep -q "UBUNTU_CODENAME=jammy" /etc/os-release; then
-			OSVER=jammy
-			UBVER=22.04
-			OS=ubuntu
-			is_ubuntu=true
-			is_deb=true
-			not_supported=true
-			unset is_supported
-		elif grep -q "VERSION_CODENAME=bookworm" /etc/os-release; then
-			OSVER=bookworm
-			DEBVER=12
-			is_debian=true
-			OS=debian
-			is_deb=true
-			not_supported=true
-			unset is_supported
-		fi
-		installer_prereq_packages
-
+	if [ -f /etc/redhat-release ] && grep -q "Red Hat Enterprise Linux release 9" /etc/redhat-release && [ -f /etc/oracle-release ]; then
+		OS=oracle
+		OSVER=9
+		is_oracle=true
+		is_rpm=true
+		is_supported=true
 	else
-		info "We were unable to determine if you are using a supported OS."
+		info "This OS is not supported. Security Onion requires Oracle Linux 9."
 		fail_setup
 	fi
 
@@ -932,23 +872,6 @@ download_elastic_agent_artifacts() {
 	fi
 }
 
-installer_prereq_packages() {	
-	if [[ $is_deb ]]; then
-		# Print message to stdout so the user knows setup is doing something
-		info "Running apt-get update"
-		retry 150 10 "apt-get update" "" "Err:" >> "$setup_log" 2>&1 || fail_setup
-		# Install network manager so we can do interface stuff
-		if ! command -v nmcli > /dev/null 2>&1; then
-			info "Installing network-manager"
-			retry 150 10 "apt-get -y install network-manager ethtool" >> "$setup_log" 2>&1 || fail_setup
-			logCmd "systemctl enable NetworkManager"
-			logCmd "systemctl start NetworkManager"
-		fi
-		if ! command -v curl > /dev/null 2>&1; then
-			retry 150 10 "apt-get -y install curl"  >> "$setup_log" 2>&1 || fail_setup
-		fi
-	fi
-}
 
 disable_auto_start() {
 	
@@ -1460,7 +1383,7 @@ network_init() {
 	title "Initializing Network"
 	disable_ipv6
 	set_hostname
-	if [[ ( $is_iso || $is_desktop_iso || $is_debian ) ]]; then
+	if [[ ( $is_iso || $is_desktop_iso ) ]]; then
 		set_management_interface
 	fi
 }
@@ -1694,11 +1617,6 @@ reinstall_init() {
 		# Uninstall local Elastic Agent, if installed
 		elastic-agent uninstall -f
 
-		if [[ $is_deb ]]; then
-			echo "Unholding previously held packages."
-			apt-mark unhold $(apt-mark showhold)
-		fi
-
 	} >> "$setup_log" 2>&1
 
 	info "System reinstall init has been completed."
@@ -1715,11 +1633,7 @@ reset_proxy() {
 
 	[[ -f /etc/gitconfig ]] && rm -f /etc/gitconfig
 	
-	if [[ $is_rpm ]]; then
-		sed -i "/proxy=/d" /etc/dnf/dnf.conf
-	else
-		[[ -f /etc/apt/apt.conf.d/00-proxy.conf ]] && rm -f /etc/apt/apt.conf.d/00-proxy.conf
-	fi
+	sed -i "/proxy=/d" /etc/dnf/dnf.conf
 }
 
 restore_file() {
@@ -1765,14 +1679,8 @@ drop_install_options() {
 
 remove_package() {
 	local package_name=$1
-	if [[ $is_rpm ]]; then
-		if rpm -qa | grep -q "$package_name"; then
-			logCmd "dnf remove -y $package_name"
-		fi
-	else
-		if dpkg -l | grep -q "$package_name"; then
-			retry 150 10 "apt purge -y \"$package_name\""
-		fi
+	if rpm -qa | grep -q "$package_name"; then
+		logCmd "dnf remove -y $package_name"
 	fi
 }
 
@@ -1786,122 +1694,91 @@ remove_package() {
 
 securityonion_repo() {
 	# Remove all the current repos
-	if [[ $is_oracle ]]; then
-		logCmd "dnf -v clean all"
-		logCmd "mkdir -vp /root/oldrepos"
-		if [ -n "$(ls -A /etc/yum.repos.d/ 2>/dev/null)" ]; then
-			logCmd "mv -v /etc/yum.repos.d/* /root/oldrepos/"
-		fi
-		if ! $is_desktop_grid; then
-			gpg_rpm_import
-			if [[ ! $is_airgap ]]; then
-				echo "https://repo.securityonion.net/file/so-repo/prod/3/oracle/9" > /etc/yum/mirror.txt
-				echo "https://so-repo-east.s3.us-east-005.backblazeb2.com/prod/3/oracle/9" >> /etc/yum/mirror.txt
-				echo "[main]" > /etc/yum.repos.d/securityonion.repo
-				echo "gpgcheck=1" >> /etc/yum.repos.d/securityonion.repo
-				echo "installonly_limit=3" >> /etc/yum.repos.d/securityonion.repo
-				echo "clean_requirements_on_remove=True" >> /etc/yum.repos.d/securityonion.repo
-				echo "best=True" >> /etc/yum.repos.d/securityonion.repo
-				echo "skip_if_unavailable=False" >> /etc/yum.repos.d/securityonion.repo
-				echo "cachedir=/opt/so/conf/reposync/cache" >> /etc/yum.repos.d/securityonion.repo
-				echo "keepcache=0" >> /etc/yum.repos.d/securityonion.repo
-				echo "[securityonionsync]" >> /etc/yum.repos.d/securityonion.repo
-				echo "name=Security Onion Repo repo" >> /etc/yum.repos.d/securityonion.repo
-				echo "mirrorlist=file:///etc/yum/mirror.txt" >> /etc/yum.repos.d/securityonion.repo
-				echo "enabled=1" >> /etc/yum.repos.d/securityonion.repo
-				echo "gpgcheck=1" >> /etc/yum.repos.d/securityonion.repo
-				logCmd "dnf repolist"
-			else
-				echo "[securityonion]" > /etc/yum.repos.d/securityonion.repo
-				echo "name=Security Onion Repo" >> /etc/yum.repos.d/securityonion.repo
-				echo "baseurl=https://$MSRV/repo" >> /etc/yum.repos.d/securityonion.repo
-				echo "enabled=1" >> /etc/yum.repos.d/securityonion.repo
-				echo "gpgcheck=1" >> /etc/yum.repos.d/securityonion.repo
-				echo "sslverify=0" >> /etc/yum.repos.d/securityonion.repo
-				logCmd "dnf repolist"
-			fi
-		elif [[ ! $waitforstate ]]; then
+	logCmd "dnf -v clean all"
+	logCmd "mkdir -vp /root/oldrepos"
+	if [ -n "$(ls -A /etc/yum.repos.d/ 2>/dev/null)" ]; then
+		logCmd "mv -v /etc/yum.repos.d/* /root/oldrepos/"
+	fi
+	if ! $is_desktop_grid; then
+		gpg_rpm_import
+		if [[ ! $is_airgap ]]; then
+			echo "https://repo.securityonion.net/file/so-repo/prod/3/oracle/9" > /etc/yum/mirror.txt
+			echo "https://so-repo-east.s3.us-east-005.backblazeb2.com/prod/3/oracle/9" >> /etc/yum/mirror.txt
+			echo "[main]" > /etc/yum.repos.d/securityonion.repo
+			echo "gpgcheck=1" >> /etc/yum.repos.d/securityonion.repo
+			echo "installonly_limit=3" >> /etc/yum.repos.d/securityonion.repo
+			echo "clean_requirements_on_remove=True" >> /etc/yum.repos.d/securityonion.repo
+			echo "best=True" >> /etc/yum.repos.d/securityonion.repo
+			echo "skip_if_unavailable=False" >> /etc/yum.repos.d/securityonion.repo
+			echo "cachedir=/opt/so/conf/reposync/cache" >> /etc/yum.repos.d/securityonion.repo
+			echo "keepcache=0" >> /etc/yum.repos.d/securityonion.repo
+			echo "[securityonionsync]" >> /etc/yum.repos.d/securityonion.repo
+			echo "name=Security Onion Repo repo" >> /etc/yum.repos.d/securityonion.repo
+			echo "mirrorlist=file:///etc/yum/mirror.txt" >> /etc/yum.repos.d/securityonion.repo
+			echo "enabled=1" >> /etc/yum.repos.d/securityonion.repo
+			echo "gpgcheck=1" >> /etc/yum.repos.d/securityonion.repo
+			logCmd "dnf repolist"
+		else
 			echo "[securityonion]" > /etc/yum.repos.d/securityonion.repo
 			echo "name=Security Onion Repo" >> /etc/yum.repos.d/securityonion.repo
 			echo "baseurl=https://$MSRV/repo" >> /etc/yum.repos.d/securityonion.repo
 			echo "enabled=1" >> /etc/yum.repos.d/securityonion.repo
 			echo "gpgcheck=1" >> /etc/yum.repos.d/securityonion.repo
-			echo "sslverify=0" >> /etc/yum.repos.d/securityonion.repo		
-		elif [[ $waitforstate ]]; then
-			echo "[securityonion]" > /etc/yum.repos.d/securityonion.repo
-			echo "name=Security Onion Repo" >> /etc/yum.repos.d/securityonion.repo
-			echo "baseurl=file:///nsm/repo/" >> /etc/yum.repos.d/securityonion.repo
-			echo "enabled=1" >> /etc/yum.repos.d/securityonion.repo
-			echo "gpgcheck=1" >> /etc/yum.repos.d/securityonion.repo
+			echo "sslverify=0" >> /etc/yum.repos.d/securityonion.repo
+			logCmd "dnf repolist"
 		fi
+	elif [[ ! $waitforstate ]]; then
+		echo "[securityonion]" > /etc/yum.repos.d/securityonion.repo
+		echo "name=Security Onion Repo" >> /etc/yum.repos.d/securityonion.repo
+		echo "baseurl=https://$MSRV/repo" >> /etc/yum.repos.d/securityonion.repo
+		echo "enabled=1" >> /etc/yum.repos.d/securityonion.repo
+		echo "gpgcheck=1" >> /etc/yum.repos.d/securityonion.repo
+		echo "sslverify=0" >> /etc/yum.repos.d/securityonion.repo
+	elif [[ $waitforstate ]]; then
+		echo "[securityonion]" > /etc/yum.repos.d/securityonion.repo
+		echo "name=Security Onion Repo" >> /etc/yum.repos.d/securityonion.repo
+		echo "baseurl=file:///nsm/repo/" >> /etc/yum.repos.d/securityonion.repo
+		echo "enabled=1" >> /etc/yum.repos.d/securityonion.repo
+		echo "gpgcheck=1" >> /etc/yum.repos.d/securityonion.repo
 	fi
-	if [[ $is_rpm ]]; then logCmd "dnf repolist all"; fi
+	logCmd "dnf repolist all"
 	if [[ $waitforstate ]]; then
-		if [[ $is_rpm ]]; then
-				# Build the repo locally so we can use it
-				echo "Syncing Repos"
-				repo_sync_local
-		fi
+		# Build the repo locally so we can use it
+		echo "Syncing Repos"
+		repo_sync_local
 	fi
 }
 
 repo_sync_local() {
 	SALTVERSION=$(grep "version:" ../salt/salt/master.defaults.yaml | grep -o "[0-9]\+\.[0-9]\+")
 	info "Repo Sync"
-	if [[ $is_supported ]]; then
-		# Sync the repo from the the SO repo locally.
-		# Check for reposync
-		info "Adding Repo Download Configuration"
-		mkdir -p /nsm/repo
-		mkdir -p /opt/so/conf/reposync/cache
-		echo "https://repo.securityonion.net/file/so-repo/prod/3/oracle/9" > /opt/so/conf/reposync/mirror.txt
-		echo "https://repo-alt.securityonion.net/prod/3/oracle/9" >> /opt/so/conf/reposync/mirror.txt
-		echo "[main]" > /opt/so/conf/reposync/repodownload.conf
-		echo "gpgcheck=1" >> /opt/so/conf/reposync/repodownload.conf
-		echo "installonly_limit=3" >> /opt/so/conf/reposync/repodownload.conf
-		echo "clean_requirements_on_remove=True" >> /opt/so/conf/reposync/repodownload.conf
-		echo "best=True" >> /opt/so/conf/reposync/repodownload.conf
-		echo "skip_if_unavailable=False" >> /opt/so/conf/reposync/repodownload.conf
-		echo "cachedir=/opt/so/conf/reposync/cache" >> /opt/so/conf/reposync/repodownload.conf
-		echo "keepcache=0" >> /opt/so/conf/reposync/repodownload.conf
-		echo "[securityonionsync]" >> /opt/so/conf/reposync/repodownload.conf
-		echo "name=Security Onion Repo repo" >> /opt/so/conf/reposync/repodownload.conf
-		echo "mirrorlist=file:///opt/so/conf/reposync/mirror.txt" >> /opt/so/conf/reposync/repodownload.conf
-		echo "enabled=1" >> /opt/so/conf/reposync/repodownload.conf
-		echo "gpgcheck=1" >> /opt/so/conf/reposync/repodownload.conf
-	
-		logCmd "dnf repolist"
-		
-		if [[ ! $is_airgap ]]; then
-        	curl --retry 5 --retry-delay 60 -A "netinstall/$SOVERSION/$OS/$(uname -r)/1" https://sigs.securityonion.net/checkup --output /tmp/install
-			retry 5 60 "dnf reposync --norepopath -g --delete -m -c /opt/so/conf/reposync/repodownload.conf --repoid=securityonionsync --download-metadata -p /nsm/repo/" >> "$setup_log" 2>&1 || fail_setup
-			# After the download is complete run createrepo
-			create_repo
-		fi
-	else
-		# Add the proper repos for unsupported stuff
-		echo "Adding Repos"
-		if [[ $is_rpm ]]; then
-			if [[ $is_rhel ]]; then
-				logCmd "subscription-manager repos --enable codeready-builder-for-rhel-9-$(arch)-rpms"
-				info "Install epel for rhel" 
-				logCmd "dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
-				logCmd "dnf -y install https://dl.fedoraproject.org/pub/epel/epel-next-release-latest-9.noarch.rpm"
-			else  
-				logCmd "dnf config-manager --set-enabled crb"
-				logCmd "dnf -y install epel-release"
-			fi
-			dnf install -y yum-utils device-mapper-persistent-data lvm2
-			curl -fsSL https://repo.securityonion.net/file/so-repo/prod/3/so/so.repo | tee /etc/yum.repos.d/so.repo
-			rpm --import https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public
-			dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-			curl -fsSL "https://github.com/saltstack/salt-install-guide/releases/latest/download/salt.repo" | tee /etc/yum.repos.d/salt.repo
-			dnf repolist
-			curl --retry 5 --retry-delay 60 -A "netinstall/$SOVERSION/$OS/$(uname -r)/1" https://sigs.securityonion.net/checkup --output /tmp/install
-		else
-			echo "Not sure how you got here."
-			exit 1
-		fi
+	# Sync the repo from the SO repo locally.
+	info "Adding Repo Download Configuration"
+	mkdir -p /nsm/repo
+	mkdir -p /opt/so/conf/reposync/cache
+	echo "https://repo.securityonion.net/file/so-repo/prod/3/oracle/9" > /opt/so/conf/reposync/mirror.txt
+	echo "https://repo-alt.securityonion.net/prod/3/oracle/9" >> /opt/so/conf/reposync/mirror.txt
+	echo "[main]" > /opt/so/conf/reposync/repodownload.conf
+	echo "gpgcheck=1" >> /opt/so/conf/reposync/repodownload.conf
+	echo "installonly_limit=3" >> /opt/so/conf/reposync/repodownload.conf
+	echo "clean_requirements_on_remove=True" >> /opt/so/conf/reposync/repodownload.conf
+	echo "best=True" >> /opt/so/conf/reposync/repodownload.conf
+	echo "skip_if_unavailable=False" >> /opt/so/conf/reposync/repodownload.conf
+	echo "cachedir=/opt/so/conf/reposync/cache" >> /opt/so/conf/reposync/repodownload.conf
+	echo "keepcache=0" >> /opt/so/conf/reposync/repodownload.conf
+	echo "[securityonionsync]" >> /opt/so/conf/reposync/repodownload.conf
+	echo "name=Security Onion Repo repo" >> /opt/so/conf/reposync/repodownload.conf
+	echo "mirrorlist=file:///opt/so/conf/reposync/mirror.txt" >> /opt/so/conf/reposync/repodownload.conf
+	echo "enabled=1" >> /opt/so/conf/reposync/repodownload.conf
+	echo "gpgcheck=1" >> /opt/so/conf/reposync/repodownload.conf
+
+	logCmd "dnf repolist"
+
+	if [[ ! $is_airgap ]]; then
+		curl --retry 5 --retry-delay 60 -A "netinstall/$SOVERSION/$OS/$(uname -r)/1" https://sigs.securityonion.net/checkup --output /tmp/install
+		retry 5 60 "dnf reposync --norepopath -g --delete -m -c /opt/so/conf/reposync/repodownload.conf --repoid=securityonionsync --download-metadata -p /nsm/repo/" >> "$setup_log" 2>&1 || fail_setup
+		# After the download is complete run createrepo
+		create_repo
 	fi
 }
 
@@ -1909,57 +1786,13 @@ saltify() {
 	SALTVERSION=$(grep "version:" ../salt/salt/master.defaults.yaml | grep -o "[0-9]\+\.[0-9]\+")
 	info "Installing Salt $SALTVERSION"
 	chmod u+x ../salt/salt/scripts/bootstrap-salt.sh
-	if [[ $is_deb ]]; then
 
-		DEBIAN_FRONTEND=noninteractive retry 30 10 "apt-get -y -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" upgrade" >> "$setup_log" 2>&1 || fail_setup
-		if [ $OSVER == "focal" ]; then update-alternatives --install /usr/bin/python python /usr/bin/python3.10 10; fi
-		local pkg_arr=(
-			'apache2-utils'
-			'ca-certificates'
-			'curl'
-			'software-properties-common'
-			'apt-transport-https'
-			'openssl'
-			'netcat-openbsd'
-			'jq'
-			'gnupg'
-		)
-		retry 30 10 "apt-get -y install ${pkg_arr[*]}" || fail_setup
-
-		logCmd "mkdir -vp /etc/apt/keyrings"
-		logCmd "wget -q --inet4-only -O /etc/apt/keyrings/docker.pub https://download.docker.com/linux/ubuntu/gpg"
-
-		if [[ $is_ubuntu ]]; then
-			# Add Docker Repo
-			add-apt-repository -y "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" 
-		
-		else
-			# Add Docker Repo
-			curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-			echo "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian $OSVER stable" > /etc/apt/sources.list.d/docker.list 
-		fi
-
-		logCmd "apt-key add /etc/apt/keyrings/docker.pub"
-
-		retry 30 10 "apt-get update" "" "Err:" || fail_setup
-		if [[ $waitforstate ]]; then
-			retry 30 10 "bash ../salt/salt/scripts/bootstrap-salt.sh -M -X stable $SALTVERSION" || fail_setup
-			retry 30 10 "apt-mark hold salt-minion salt-common salt-master" || fail_setup
-			retry 30 10 "apt-get -y install python3-pip python3-dateutil python3-m2crypto python3-packaging python3-influxdb python3-lxml" || exit 1
-		else
-			retry 30 10 "bash ../salt/salt/scripts/bootstrap-salt.sh -X stable $SALTVERSION" || fail_setup
-			retry 30 10 "apt-mark hold salt-minion salt-common" || fail_setup
-		fi
-	fi
-		
-	if [[ $is_rpm ]]; then
-		if [[ $waitforstate ]]; then 
-			# install all for a manager
-			retry 30 10 "bash ../salt/salt/scripts/bootstrap-salt.sh -r -M -X stable $SALTVERSION" || fail_setup
-		else
-			# just a minion
-			retry 30 10 "bash ../salt/salt/scripts/bootstrap-salt.sh -r -X stable $SALTVERSION" || fail_setup
-		fi
+	if [[ $waitforstate ]]; then
+		# install all for a manager
+		retry 30 10 "bash ../salt/salt/scripts/bootstrap-salt.sh -r -M -X stable $SALTVERSION" || fail_setup
+	else
+		# just a minion
+		retry 30 10 "bash ../salt/salt/scripts/bootstrap-salt.sh -r -X stable $SALTVERSION" || fail_setup
 	fi
 
 	salt_install_module_deps
@@ -2105,14 +1938,7 @@ set_proxy() {
 		"}" > /root/.docker/config.json
 
 	# Set proxy for package manager
-	if [[ $is_rpm ]]; then
-		echo "proxy=$so_proxy" >> /etc/yum.conf
-	else
-		# Set it up so the updates roll through the manager
-		printf '%s\n'\
-			"Acquire::http::Proxy \"$so_proxy\";"\
-			"Acquire::https::Proxy \"$so_proxy\";" > /etc/apt/apt.conf.d/00-proxy.conf
-	fi
+	echo "proxy=$so_proxy" >> /etc/yum.conf
 
 	# Set global git proxy
 	printf '%s\n'\
@@ -2302,23 +2128,13 @@ update_sudoers_for_testing() {
 }
 
 update_packages() {
-	if [[ $is_oracle ]]; then
-		logCmd "dnf repolist"
-		logCmd "dnf -y update --allowerasing --exclude=salt*,docker*,containerd*"
-		RMREPOFILES=("oracle-linux-ol9.repo" "uek-ol9.repo" "virt-ol9.repo")
-		info "Removing repo files added by oracle-repos package update"
-		for FILE in ${RMREPOFILES[@]}; do
-			logCmd "rm -f /etc/yum.repos.d/$FILE"
-		done
-	elif [[ $is_deb ]]; then
-		info "Running apt-get update"
-		retry 150 10 "apt-get -y update" "" "Err:" >> "$setup_log" 2>&1 || fail_setup
-		info "Running apt-get upgrade"
-		retry 150 10 "apt-get -y upgrade" >> "$setup_log" 2>&1 || fail_setup
-	else
-		info "Updating packages"
-		logCmd "dnf -y update --allowerasing --exclude=salt*,docker*,containerd*"
-	fi
+	logCmd "dnf repolist"
+	logCmd "dnf -y update --allowerasing --exclude=salt*,docker*,containerd*"
+	RMREPOFILES=("oracle-linux-ol9.repo" "uek-ol9.repo" "virt-ol9.repo")
+	info "Removing repo files added by oracle-repos package update"
+	for FILE in ${RMREPOFILES[@]}; do
+		logCmd "rm -f /etc/yum.repos.d/$FILE"
+	done
 }
 
 # This is used for development to speed up network install tests.
@@ -2328,15 +2144,7 @@ use_turbo_proxy() {
 		return
 	fi
 
-	if [[ $OS == 'centos' ]]; then
-		printf '%s\n' "proxy=${TURBO}:3142" >> /etc/yum.conf
-	else
-		printf '%s\n'\
-			"Acquire {"\
-			"  HTTP::proxy \"${TURBO}:3142\";"\
-			"  HTTPS::proxy \"${TURBO}:3142\";"\
-			"}" > /etc/apt/apt.conf.d/proxy.conf
-	fi
+	printf '%s\n' "proxy=${TURBO}:3142" >> /etc/yum.conf
 }
 
 wait_for_file() {

--- a/setup/so-preflight
+++ b/setup/so-preflight
@@ -34,32 +34,19 @@ check_default_repos() {
 		printf '%s' "$repo_str" | tee -a "$preflight_log"
 	fi
 
-	if [[ $OS == 'centos' ]]; then
-		if [[ $script_run == true ]]; then
-			printf '%s' 'yum update.'
-		else
-			printf '%s' 'yum update.' | tee -a "$preflight_log"
-		fi
-		echo "" >> "$preflight_log"
-		yum -y check-update >> $preflight_log 2>&1
-		ret_code=$?
-		if [[ $ret_code == 0 || $ret_code == 100 ]]; then
-			printf '%s\n' '  SUCCESS'
-			ret_code=0
-		else
-			printf '%s\n' '  FAILURE'
-		fi
+	if [[ $script_run == true ]]; then
+		printf '%s' 'yum update.'
 	else
-		if [[ $script_run == true ]]; then
-			printf '%s' 'apt update.'
-		else
-			printf '%s' 'apt update.' | tee -a "$preflight_log"
-		fi
-		echo "" >> "$preflight_log"
-		retry 150 10 "apt-get -y update" >> $preflight_log 2>&1
-		ret_code=$?
-		[[ $ret_code == 0 ]] && printf '%s\n' '  SUCCESS' || printf '%s\n' '  FAILURE'
-
+		printf '%s' 'yum update.' | tee -a "$preflight_log"
+	fi
+	echo "" >> "$preflight_log"
+	yum -y check-update >> $preflight_log 2>&1
+	ret_code=$?
+	if [[ $ret_code == 0 || $ret_code == 100 ]]; then
+		printf '%s\n' '  SUCCESS'
+		ret_code=0
+	else
+		printf '%s\n' '  FAILURE'
 	fi
 
 	return $ret_code
@@ -73,21 +60,11 @@ check_new_repos() {
 		printf '%s' "$repo_url_str" | tee -a "$preflight_log"
 	fi
 
-	if [[ $OS == 'centos' ]]; then
-		local repo_arr=( 
-			"https://download.docker.com/linux/centos/docker-ce.repo"
-			"https://repo.securityonion.net/file/securityonion-repo/keys/SALTSTACK-GPG-KEY.pub"
-			"https://download.docker.com/linux/ubuntu/gpg"
-			)
-	else
-		local ubuntu_version
-		ubuntu_version=$(grep VERSION_ID /etc/os-release 2> /dev/null | awk -F '[ "]' '{print $2}')
-		local repo_arr=(
-			"https://download.docker.com/linux/ubuntu/gpg"
-			"https://download.docker.com/linux/ubuntu"
-			"https://repo.securityonion.net/file/securityonion-repo/ubuntu/$ubuntu_version/amd64/salt/SALTSTACK-GPG-KEY.pub"
+	local repo_arr=(
+		"https://download.docker.com/linux/centos/docker-ce.repo"
+		"https://repo.securityonion.net/file/securityonion-repo/keys/SALTSTACK-GPG-KEY.pub"
+		"https://download.docker.com/linux/ubuntu/gpg"
 		)
-	fi
 
 	__check_url_arr "${repo_arr[@]}"
 	local ret_code=$?
@@ -155,17 +132,6 @@ __check_url_arr() {
 	return $ret_code
 }
 
-preflight_prereqs() {
-	local ret_code=0
-	
-	if [[ $OS == 'centos' ]]; then
-		: # no-op to match structure of other checks for $OS var
-	else
-		retry 150 10 "apt-get -y install curl" >> "$preflight_log" 2>&1 || ret_code=1
-	fi
-
-	return $ret_code
-}
 
 main() {
 	local intro_str="Beginning pre-flight checks."
@@ -183,7 +149,6 @@ main() {
 	fi
 
 	check_default_repos &&\
-	preflight_prereqs &&\
 	check_new_repos &&\
 	check_misc_urls
 

--- a/setup/so-setup
+++ b/setup/so-setup
@@ -66,36 +66,6 @@ set_timezone
 # Let's see what OS we are dealing with here
 detect_os
 
-# Ubuntu/Debian whiptail pallete to make it look the same as CentOS and Rocky.
-set_palette >> $setup_log 2>&1
-
-if [[ $not_supported ]] && [ -z "$test_profile" ]; then
-	if [[ "$OSVER" == "focal" ]]; then
-		if (whiptail_focal_warning); then
-			true
-		else
-			info "User cancelled setup."
-			whiptail_cancel
-		fi
-	else
-		if (whiptail_unsupported_os_warning); then
-			true
-		else
-			info "User cancelled setup."
-			whiptail_cancel
-		fi
-	fi
-fi
-
-# we need to upgrade packages on debian prior to install and reboot if there are due to iptables-restore not running properly
-# if packages are updated and the box isn't rebooted
-if [[ $is_debian ]]; then
-	update_packages
-	if [[ -f "/var/run/reboot-required" ]] && [ -z "$test_profile" ]; then
-		whiptail_debian_reboot_required
-		reboot
-	fi
-fi
 
 # Check to see if this is the setup type of "desktop".
 is_desktop=
@@ -108,7 +78,7 @@ if [ "$setup_type" = 'desktop' ]; then
 	fi
 fi
 
-# Make sure if ISO is specified that we are dealing with CentOS or Rocky
+# Make sure if ISO is specified that we are dealing with an RPM-based install
 title "Detecting if this is an ISO install"
 if [[ "$setup_type" == 'iso' ]]; then
 	if [[ $is_rpm ]]; then

--- a/setup/so-whiptail
+++ b/setup/so-whiptail
@@ -27,23 +27,6 @@ whiptail_airgap() {
 	fi
 }
 
-whiptail_debian_reboot_required() {
-
-	[ -n "$TESTING" ] && return
-
-	read -r -d '' message <<- EOM
-
-	Packages were upgraded and a reboot is required prior to Security Onion installation.
-
-	Once the reboot has completed, rerun Security Onion setup.
-
-	Press TAB and then the ENTER key to reboot the system.
-
-	EOM
-
-	whiptail --title "$whiptail_title" --msgbox "$message" 24 75 --scrolltext
-}
-
 whiptail_desktop_install() {
 
 	[ -n "$TESTING" ] && return
@@ -496,27 +479,6 @@ __append_end_msg() {
 	EOM
 }
 
-whiptail_focal_warning() {
-
-	[ -n "$TESTING" ] && return
-
-	read -r -d '' focal_warning_continue <<- EOM
-
-	WARNING: Ubuntu 20.04 is only supported as a minion role.
-
-	This node may not install or operate as expected if installed
-	as a manager, managersearch, standalone, eval, or import.
-
-	Would you like to continue the install?
-
-	EOM
-	whiptail --title "$whiptail_title" \
-		--yesno "$focal_warning_continue" 14 75 --defaultno
-
-	local exitstatus=$?
-	return $exitstatus
-
-}
 
 whiptail_gauge_post_setup() {
 
@@ -586,23 +548,15 @@ whiptail_install_type() {
 	[ -n "$TESTING" ] && return
 
 	# What kind of install are we doing?
-	if [[ "$OSVER" != "focal" ]]; then
-		install_type=$(whiptail --title "$whiptail_title" --menu \
-		"What kind of installation would you like to do?\n\nFor more information, please see:\n$DOC_BASE_URL/architecture" 18 65 5 \
-			"IMPORT" "Import PCAP or log files " \
-			"EVAL" "Evaluation mode (not for production) " \
-			"STANDALONE" "Standalone production install " \
-			"DISTRIBUTED" "Distributed deployment " \
-			"DESKTOP" "Security Onion Desktop" \
-			3>&1 1>&2 2>&3
-		)
-	elif [[ "$OSVER" == "focal" ]]; then
-		install_type=$(whiptail --title "$whiptail_title" --menu \
-		"What kind of installation would you like to do?\n\nFor more information, please see:\n$DOC_BASE_URL/architecture" 18 65 5 \
-			"DISTRIBUTED" "Distributed install submenu " \
-			3>&1 1>&2 2>&3
-		)
-	fi
+	install_type=$(whiptail --title "$whiptail_title" --menu \
+	"What kind of installation would you like to do?\n\nFor more information, please see:\n$DOC_BASE_URL/architecture" 18 65 5 \
+		"IMPORT" "Import PCAP or log files " \
+		"EVAL" "Evaluation mode (not for production) " \
+		"STANDALONE" "Standalone production install " \
+		"DISTRIBUTED" "Distributed deployment " \
+		"DESKTOP" "Security Onion Desktop" \
+		3>&1 1>&2 2>&3
+	)
 
 	local exitstatus=$?
 	whiptail_check_exitstatus $exitstatus
@@ -623,18 +577,11 @@ whiptail_install_type_dist() {
 
 	[ -n "$TESTING" ] && return
 
-	if [[ "$OSVER" != "focal" ]]; then
 	dist_option=$(whiptail --title "$whiptail_title" --menu "Do you want to start a new deployment or join this box to \nan existing deployment?" 11 75 2 \
 		"New Deployment         " "Create a new Security Onion deployment" \
 		"Existing Deployment    " "Join to an existing Security Onion deployment " \
 		 3>&1 1>&2 2>&3
 	)
-	elif [[ "$OSVER" == "focal" ]]; then
-	dist_option=$(whiptail --title "$whiptail_title" --menu "Since this is Ubuntu, this box can only be connected to \nan existing deployment." 11 75 2 \
-		"Existing Deployment    " "Join to an existing Security Onion deployment " \
-		 3>&1 1>&2 2>&3
-	)
-	fi
 
 	local exitstatus=$?
 	whiptail_check_exitstatus $exitstatus
@@ -916,7 +863,7 @@ whiptail_net_method() {
 	[ -n "$TESTING" ] && return
 
 	local pkg_mngr
-	if [[ $OS = 'centos' ]]; then pkg_mngr="yum"; else pkg_mngr='apt'; fi
+	pkg_mngr="yum"
 
 	read -r -d '' options_msg <<- EOM
 	"Direct" - Internet requests connect directly to the Internet.
@@ -1151,7 +1098,7 @@ whiptail_proxy_ask() {
 	[ -n "$TESTING" ] && return
 
 	local pkg_mngr
-	if [[ $OS = 'centos' ]]; then pkg_mngr="yum"; else pkg_mngr='apt'; fi
+	pkg_mngr="yum"
 	whiptail --title "$whiptail_title" --yesno "Do you want to proxy the traffic for git, docker client, wget, curl, ${pkg_mngr}, and various other SO components through a separate server in your environment?" 9 65 --defaultno
 }
 
@@ -1434,48 +1381,6 @@ whiptail_storage_requirements() {
 	whiptail_check_exitstatus $exitstatus
 }
 
-whiptail_ubuntu_notsupported() {
-	[ -n "$TESTING" ] && return
-	
-	read -r -d '' message <<- EOM
-		Ubuntu is not supported for this node type.
-
-		Please use a supported OS or install via ISO.
-	EOM
-	whiptail --title "$whiptail_title"  --msgbox "$message" 14 75
-}
-
-whiptail_ubuntu_warning() {
-	[ -n "$TESTING" ] && return
-	
-	read -r -d '' message <<- EOM
-		Ubuntu support for this node type is limited.
-
-		Please consider using a fully supported OS or install via ISO.
-	EOM
-	whiptail --title "$whiptail_title"  --msgbox "$message" 14 75
-
-}
-
-whiptail_unsupported_os_warning() {
-
-	[ -n "$TESTING" ] && return
-
-	read -r -d '' unsupported_os_continue <<- EOM
-	
-	WARNING: An unsupported operating system has been detected. 
-	Security Onion may not install or operate as expected. 
-
-	Would you like to continue the install?
-
-	EOM
-	whiptail --title "$whiptail_title" \
-		--yesno "$unsupported_os_continue" 14 75 --defaultno
-
-	local exitstatus=$?
-	return $exitstatus
-
-}
 
 whiptail_uppercase_warning() {
 


### PR DESCRIPTION
## Summary
- Simplifies OS detection in `so-functions`, `so-common` to only support Oracle Linux 9, failing early for any other OS
- Removes all Ubuntu, Debian, CentOS, Rocky, AlmaLinux, and RHEL setup/update/package management logic
- Adds early OS validation check in `soup` to exit if not Oracle Linux 9
- Removes now-unused whiptail dialogs (`focal_warning`, `debian_reboot_required`, `ubuntu_notsupported`, `ubuntu_warning`, `unsupported_os_warning`)
- Removes empty functions (`installer_prereq_packages`, `set_palette`, `preflight_prereqs`) and their call sites

## Test plan
- [ ] Verify ISO install on Oracle Linux 9 completes successfully
- [ ] Verify network install on Oracle Linux 9 completes successfully
- [ ] Verify `soup` runs successfully on Oracle Linux 9
- [ ] Verify `soup` exits early with clear error on non-Oracle OS
- [ ] Verify airgap install still uses `file:///nsm/repo/` for local repo
- [ ] Verify desktop install still validates Oracle OS