### PR TITLE
Remove non-Oracle Linux 9 support from salt states

### DIFF
--- a/salt/_modules/needs_restarting.py
+++ b/salt/_modules/needs_restarting.py
@@ -1,24 +1,14 @@
-from os import path
 import subprocess
 
 def check():
 
-  osfam = __grains__['os_family']
   retval = 'False'
 
-  if osfam == 'Debian':
-    if path.exists('/var/run/reboot-required'):
-      retval = 'True'
+  cmd = 'needs-restarting -r > /dev/null 2>&1'
 
-  elif osfam == 'RedHat':
-    cmd = 'needs-restarting -r > /dev/null 2>&1'
-    
-    try:
-      needs_restarting = subprocess.check_call(cmd, shell=True)
-    except subprocess.CalledProcessError:
-      retval = 'True'
-
-  else:
-    retval = 'Unsupported OS: %s' % os
+  try:
+    needs_restarting = subprocess.check_call(cmd, shell=True)
+  except subprocess.CalledProcessError:
+    retval = 'True'
 
   return retval

--- a/salt/ca/trustca.sls
+++ b/salt/ca/trustca.sls
@@ -3,8 +3,6 @@
 # https://securityonion.net/license; you may not use this file except in compliance with the
 # Elastic License 2.0.
 
-{% from 'vars/globals.map.jinja' import GLOBALS %}
-
 include:
   - docker
 
@@ -18,9 +16,3 @@ trusttheca:
     - show_changes: False
     - makedirs: True
 
-{% if GLOBALS.os_family == 'Debian' %}
-symlinkca:
-  file.symlink:
-    - target: /etc/pki/tls/certs/intca.crt
-    - name: /etc/ssl/certs/intca.crt
-{% endif %}

--- a/salt/common/packages.sls
+++ b/salt/common/packages.sls
@@ -1,52 +1,5 @@
 # we cannot import GLOBALS from vars/globals.map.jinja in this state since it is called in setup.virt.init
 # since it is early in setup of a new VM, the pillars imported in GLOBALS are not yet defined
-{% if grains.os_family == 'Debian' %}
-commonpkgs:
-  pkg.installed:
-    - skip_suggestions: True
-    - pkgs:
-      - apache2-utils
-      - wget
-      - ntpdate
-      - jq
-      - curl
-      - ca-certificates
-      - software-properties-common
-      - apt-transport-https
-      - openssl
-      - netcat-openbsd
-      - sqlite3
-      - libssl-dev
-      - procps
-      - python3-dateutil
-      - python3-docker
-      - python3-packaging
-      - python3-lxml
-      - git
-      - rsync
-      - vim
-      - tar
-      - unzip
-      - bc
-      {% if grains.oscodename != 'focal' %}
-      - python3-rich
-      {% endif %}
-
-{%     if grains.oscodename == 'focal' %}
-# since Ubuntu requires and internet connection we can use pip to install modules
-python3-pip:
-  pkg.installed
-
-python-rich:
-  pip.installed:
-    - name: rich
-    - target: /usr/local/lib/python3.8/dist-packages/
-    - require:
-      - pkg: python3-pip
-{%     endif %}
-{% endif %}
-
-{% if grains.os_family == 'RedHat' %}
 
 remove_mariadb:
   pkg.removed:
@@ -84,5 +37,3 @@ commonpkgs:
       - unzip
       - wget
       - yum-utils
-
-{% endif %}

--- a/salt/docker/init.sls
+++ b/salt/docker/init.sls
@@ -15,39 +15,6 @@ dockergroup:
     - name: docker
     - gid: 920
 
-{% if GLOBALS.os_family == 'Debian' %}
-{%    if grains.oscodename == 'bookworm' %}
-dockerheldpackages:
-  pkg.installed:
-    - pkgs:
-      - containerd.io: 2.2.1-1~debian.12~bookworm
-      - docker-ce: 5:29.2.1-1~debian.12~bookworm
-      - docker-ce-cli: 5:29.2.1-1~debian.12~bookworm
-      - docker-ce-rootless-extras: 5:29.2.1-1~debian.12~bookworm
-    - hold: True
-    - update_holds: True
-{%    elif grains.oscodename == 'jammy' %}
-dockerheldpackages:
-  pkg.installed:
-    - pkgs:
-      - containerd.io: 2.2.1-1~ubuntu.22.04~jammy
-      - docker-ce: 5:29.2.1-1~ubuntu.22.04~jammy
-      - docker-ce-cli: 5:29.2.1-1~ubuntu.22.04~jammy
-      - docker-ce-rootless-extras: 5:29.2.1-1~ubuntu.22.04~jammy
-    - hold: True
-    - update_holds: True
-{%    else %}
-dockerheldpackages:
-  pkg.installed:
-    - pkgs:
-      - containerd.io: 1.7.21-1
-      - docker-ce: 5:27.2.0-1~ubuntu.20.04~focal
-      - docker-ce-cli: 5:27.2.0-1~ubuntu.20.04~focal
-      - docker-ce-rootless-extras: 5:27.2.0-1~ubuntu.20.04~focal
-    - hold: True
-    - update_holds: True
-{%   endif %}
-{% else %}
 dockerheldpackages:
   pkg.installed:
     - pkgs:
@@ -57,7 +24,6 @@ dockerheldpackages:
       - docker-ce-rootless-extras: 29.2.1-1.el9
     - hold: True
     - update_holds: True
-{% endif %}
 
 #disable docker from managing iptables
 iptables_disabled:

--- a/salt/firewall/init.sls
+++ b/salt/firewall/init.sls
@@ -27,14 +27,12 @@ iptables_config:
     - source: salt://firewall/iptables.jinja
     - template: jinja
 
-{%   if grains.os_family == 'RedHat' %}
 disable_firewalld:
   service.dead:
     - name: firewalld
     - enable: False
     - require:
       - file: iptables_config
-{%   endif %}
 
 iptables_restore:
   cmd.run:
@@ -44,7 +42,6 @@ iptables_restore:
     - onlyif:
       - iptables-restore --test {{ iptmap.configfile }}
 
-{%   if grains.os_family == 'RedHat' %}
 enable_firewalld:
   service.running:
     - name: firewalld
@@ -52,7 +49,6 @@ enable_firewalld:
     - onfail:
       - file: iptables_config
       - cmd: iptables_restore
-{%   endif %}
 
 {% else %}
 

--- a/salt/firewall/ipt.map.jinja
+++ b/salt/firewall/ipt.map.jinja
@@ -1,14 +1,6 @@
-{% set iptmap = salt['grains.filter_by']({
-    'Debian': {
-        'service': 'netfilter-persistent',
-        'iptpkg': 'iptables',
-        'persistpkg': 'iptables-persistent',
-        'configfile': '/etc/iptables/rules.v4'
-    },
-    'RedHat': {
-        'service': 'iptables',
-        'iptpkg': 'iptables-nft',
-        'persistpkg': 'iptables-nft-services',
-        'configfile': '/etc/sysconfig/iptables'
-    },
-}) %}
+{% set iptmap = {
+    'service': 'iptables',
+    'iptpkg': 'iptables-nft',
+    'persistpkg': 'iptables-nft-services',
+    'configfile': '/etc/sysconfig/iptables'
+} %}

--- a/salt/idh/openssh/config.sls
+++ b/salt/idh/openssh/config.sls
@@ -3,7 +3,6 @@
 include:
   - idh.openssh
 
-{% if grains.os_family == 'RedHat' %}
 idh_sshd_selinux:
   selinux.port_policy_present:
     - port: {{ openssh_map.config.port }}
@@ -13,7 +12,6 @@ idh_sshd_selinux:
       - file: openssh_config
     - require:
       - pkg: python_selinux_mgmt_tools
-{% endif %}
 
 openssh_config:
   file.replace:

--- a/salt/idh/openssh/init.sls
+++ b/salt/idh/openssh/init.sls
@@ -16,8 +16,6 @@ openssh:
     - name: {{ openssh_map.service }}
   {% endif %}
 
-{% if grains.os_family == 'RedHat' %}
 python_selinux_mgmt_tools:
   pkg.installed:
     - name: policycoreutils-python-utils
-{% endif %}

--- a/salt/manager/init.sls
+++ b/salt/manager/init.sls
@@ -63,11 +63,9 @@ yara_log_dir:
       - user
       - group
 
-{% if GLOBALS.os_family == 'RedHat' %}
 install_createrepo:
   pkg.installed:
     - name: createrepo_c
-{% endif %}
 
 repo_conf_dir:
   file.directory:

--- a/salt/ntp/init.sls
+++ b/salt/ntp/init.sls
@@ -2,7 +2,6 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at 
 # https://securityonion.net/license; you may not use this file except in compliance with the
 # Elastic License 2.0.
-{% from 'vars/globals.map.jinja' import GLOBALS %}
 {% from 'ntp/config.map.jinja' import NTPCONFIG %}
 
 chrony_pkg:
@@ -17,11 +16,7 @@ chronyconf:
     - defaults:
         NTPCONFIG: {{ NTPCONFIG }}
 
-{% if GLOBALS.os_family == 'RedHat' %}
 chronyd:
-{% else %}
-chrony:
-{% endif %}
   service.running:
     - enable: True
     - watch: 

--- a/salt/repo/client/map.jinja
+++ b/salt/repo/client/map.jinja
@@ -1,43 +1,29 @@
-{% from 'vars/globals.map.jinja' import GLOBALS %}
-
-{% if GLOBALS.os_family == 'RedHat' %}
-  {% set REPOPATH = '/etc/yum.repos.d/' %}
-{%     if GLOBALS.os == 'OEL' %}
-  {% set ABSENTFILES = [
-         'centos-addons.repo',
-         'centos-devel.repo',
-         'centos-extras.repo',
-         'centos.repo',
-         'docker-ce.repo',
-         'epel.repo',
-         'epel-testing.repo',
-         'saltstack.repo',
-         'salt-latest.repo',
-         'wazuh.repo'
-         'Rocky-Base.repo',
-         'Rocky-CR.repo',
-         'Rocky-Debuginfo.repo',
-         'Rocky-fasttrack.repo',
-         'Rocky-Media.repo',
-         'Rocky-Sources.repo',
-         'Rocky-Vault.repo',
-         'Rocky-x86_64-kernel.repo',
-         'rocky-addons.repo',
-         'rocky-devel.repo',
-         'rocky-extras.repo',
-         'rocky.repo',
-         'oracle-linux-ol9.repo',
-         'uek-ol9.repo',
-         'virt-ol9.repo'
-       ]
-  %}
-{%     else %}
-  {% set ABSENTFILES = [] %}
-{%    endif %}
-
-{% else %}
-
-  {% set REPOPATH = '/etc/apt/sources.list.d/' %}
-  {% set ABSENTFILES = [] %}
-
-{% endif %}
+{% set REPOPATH = '/etc/yum.repos.d/' %}
+{% set ABSENTFILES = [
+       'centos-addons.repo',
+       'centos-devel.repo',
+       'centos-extras.repo',
+       'centos.repo',
+       'docker-ce.repo',
+       'epel.repo',
+       'epel-testing.repo',
+       'saltstack.repo',
+       'salt-latest.repo',
+       'wazuh.repo'
+       'Rocky-Base.repo',
+       'Rocky-CR.repo',
+       'Rocky-Debuginfo.repo',
+       'Rocky-fasttrack.repo',
+       'Rocky-Media.repo',
+       'Rocky-Sources.repo',
+       'Rocky-Vault.repo',
+       'Rocky-x86_64-kernel.repo',
+       'rocky-addons.repo',
+       'rocky-devel.repo',
+       'rocky-extras.repo',
+       'rocky.repo',
+       'oracle-linux-ol9.repo',
+       'uek-ol9.repo',
+       'virt-ol9.repo'
+     ]
+%}

--- a/salt/salt/init.sls
+++ b/salt/salt/init.sls
@@ -1,10 +1,3 @@
-{% if grains.oscodename == 'focal' %}
-saltpymodules:
-  pkg.installed:
-    - pkgs:
-      - python3-docker
-{% endif %}
-
 # distribute to minions for salt upgrades
 salt_bootstrap:
   file.managed:

--- a/salt/salt/map.jinja
+++ b/salt/salt/map.jinja
@@ -17,22 +17,12 @@
 {% set SALTVERSION = saltminion.salt.minion.version | string %}
 {% set INSTALLEDSALTVERSION = grains.saltversion | string %}
 
-{% if grains.os_family == 'Debian' %}
-  {% set SPLITCHAR = '+' %}
-  {% set SALTPACKAGES = ['salt-common', 'salt-master', 'salt-minion', 'salt-cloud'] %}
-  {% set SYSTEMD_UNIT_FILE = '/lib/systemd/system/salt-minion.service' %}
-{% else %}
-  {% set SPLITCHAR = '-' %}
-  {% set SALTPACKAGES = ['salt', 'salt-master', 'salt-minion', 'salt-cloud'] %}
-  {% set SYSTEMD_UNIT_FILE = '/usr/lib/systemd/system/salt-minion.service' %}
-{% endif %}
+{% set SPLITCHAR = '-' %}
+{% set SALTPACKAGES = ['salt', 'salt-master', 'salt-minion', 'salt-cloud'] %}
+{% set SYSTEMD_UNIT_FILE = '/usr/lib/systemd/system/salt-minion.service' %}
 
 {% if INSTALLEDSALTVERSION != SALTVERSION %}
-  {% if grains.os_family|lower == 'redhat' %}
-      {% set UPGRADECOMMAND = 'yum clean all ; /usr/sbin/bootstrap-salt.sh -X -r -F stable ' ~ SALTVERSION %}
-  {% elif grains.os_family|lower == 'debian' %}
-    {% set UPGRADECOMMAND = '/usr/sbin/bootstrap-salt.sh -X -F stable ' ~ SALTVERSION %}
-  {% endif %}
+  {% set UPGRADECOMMAND = 'yum clean all ; /usr/sbin/bootstrap-salt.sh -X -r -F stable ' ~ SALTVERSION %}
 {% else %}
   {% set UPGRADECOMMAND = 'echo Already running Salt Minion version ' ~ SALTVERSION %}
 {% endif %}

--- a/salt/strelka/filestream/config.sls
+++ b/salt/strelka/filestream/config.sls
@@ -47,12 +47,6 @@ filestream_config:
         FILESTREAMCONFIG: {{ STRELKAMERGED.filestream.config }}
 
 # Filecheck Section
-{% if GLOBALS.os_family == 'Debian' %}
-install_watchdog:
-  pkg.installed:
-    - name: python3-watchdog
-
-{% elif GLOBALS.os_family == 'RedHat' %}
 remove_old_watchdog:
   pkg.removed:
     - name: python3-watchdog
@@ -60,7 +54,6 @@ remove_old_watchdog:
 install_watchdog:
   pkg.installed:
     - name: securityonion-python39-watchdog
-{% endif %}
 
 filecheck_logdir:
   file.directory:

--- a/salt/versionlock/init.sls
+++ b/salt/versionlock/init.sls
@@ -3,7 +3,7 @@
 # https://securityonion.net/license; you may not use this file except in compliance with the
 # Elastic License 2.0.
 
-{% if grains.os_family == 'Debian' or (grains.os_family == 'RedHat' and salt['pkg.version']('python3-dnf-plugin-versionlock') !=  "") %}
+{% if salt['pkg.version']('python3-dnf-plugin-versionlock') != "" %}
 {%   from 'versionlock/map.jinja' import VERSIONLOCKMERGED %}
 {%   for pkg in VERSIONLOCKMERGED.hold %}
 {{pkg}}_held:

--- a/salt/versionlock/map.jinja
+++ b/salt/versionlock/map.jinja
@@ -6,11 +6,7 @@
 {% import_yaml 'versionlock/defaults.yaml' as VERSIONLOCKDEFAULTS %}
 {% set VERSIONLOCKMERGED = salt['pillar.get']('versionlock', VERSIONLOCKDEFAULTS.versionlock, merge=True) %}
 
-{% if grains.os_family == 'RedHat' %}
-{%   set HELD = salt['pkg.list_holds']() %}
-{% else %}
-{%   set HELD = salt['pkg.get_selections'](state='hold')['hold'] %}
-{% endif %}
+{% set HELD = salt['pkg.list_holds']() %}
 
 {# these are packages held / versionlock in other states #}
 {% set PACKAGES_HELD_IN_OTHER_STATES = [


### PR DESCRIPTION
## Summary
- Removes Debian/Ubuntu conditional branches from salt states (`docker/init.sls`, `common/packages.sls`, `salt/init.sls`, `ca/trustca.sls`, `strelka/filestream/config.sls`)
- Simplifies map files to Oracle Linux 9 only (`salt/map.jinja`, `firewall/ipt.map.jinja`, `repo/client/map.jinja`, `versionlock/map.jinja`)
- Removes OS family conditionals where only RedHat path remains (`firewall/init.sls`, `ntp/init.sls`, `manager/init.sls`, `idh/openssh/init.sls`, `idh/openssh/config.sls`, `versionlock/init.sls`)
- Simplifies `_modules/needs_restarting.py` to RedHat-only reboot detection
- Removes unused GLOBALS imports after OS branching removal

## Test plan
- [ ] Verify highstate completes successfully on Oracle Linux 9
- [ ] Verify docker packages install with correct `.el9` versions
- [ ] Verify firewalld disable/enable logic still works
- [ ] Verify versionlock state applies correctly
- [ ] Verify salt upgrade command uses `-r` flag (Oracle bootstrap mode)
- [ ] Verify iptables uses correct RedHat paths (`/etc/sysconfig/iptables`)
- [ ] Verify strelka filecheck watchdog installs `securityonion-python39-watchdog`