### PR TITLE
Add salt states for custom Zeek package loading

### DIFF
--- a/salt/zeek/config.sls
+++ b/salt/zeek/config.sls
@@ -39,6 +39,7 @@ zeekzkgsync:
     - user: 937
     - group: 939
     - makedirs: True
+    - exclude_pat: README
 
 # Zeek Log Directory
 zeeklogdir:

--- a/salt/zeek/config.sls
+++ b/salt/zeek/config.sls
@@ -32,19 +32,13 @@ zeekpolicydir:
     - group: 939
     - makedirs: True
 
-zeekzkgdir:
-  file.directory:
-    - name: /opt/so/conf/zeek/zkg
-    - user: 937
-    - group: 939
-    - makedirs: True
-
 zeekzkgsync:
   file.recurse:
     - name: /opt/so/conf/zeek/zkg
     - source: salt://zeek/zkg
     - user: 937
     - group: 939
+    - makedirs: True
 
 # Zeek Log Directory
 zeeklogdir:

--- a/salt/zeek/config.sls
+++ b/salt/zeek/config.sls
@@ -32,6 +32,20 @@ zeekpolicydir:
     - group: 939
     - makedirs: True
 
+zeekzkgdir:
+  file.directory:
+    - name: /opt/so/conf/zeek/zkg
+    - user: 937
+    - group: 939
+    - makedirs: True
+
+zeekzkgsync:
+  file.recurse:
+    - name: /opt/so/conf/zeek/zkg
+    - source: salt://zeek/zkg
+    - user: 937
+    - group: 939
+
 # Zeek Log Directory
 zeeklogdir:
   file.directory:

--- a/salt/zeek/enabled.sls
+++ b/salt/zeek/enabled.sls
@@ -35,6 +35,7 @@ so-zeek:
       - /opt/so/conf/zeek/policy/intel:/opt/zeek/share/zeek/policy/intel:rw
       - /opt/so/conf/zeek/bpf:/opt/zeek/etc/bpf:ro
       - /opt/so/conf/zeek/config.zeek:/opt/zeek/share/zeek/site/packages/ja4/config.zeek:ro
+      - /opt/so/conf/zeek/zkg:/opt/so/conf/zeek/zkg:ro
       {% if DOCKER.containers['so-zeek'].custom_bind_mounts %}
         {% for BIND in DOCKER.containers['so-zeek'].custom_bind_mounts %}
       - {{ BIND }}

--- a/salt/zeek/zkg/README
+++ b/salt/zeek/zkg/README
@@ -1,0 +1,1 @@
+# Place custom Zeek packages in /opt/so/saltstack/local/salt/zeek/zkg/


### PR DESCRIPTION
## Summary
- Create `/opt/so/conf/zeek/zkg` directory and sync custom packages from manager via `file.recurse`
- Bind mount the zkg directory into the so-zeek container
- Users place custom Zeek package directories in `/opt/so/saltstack/local/salt/zeek/zkg/` on the manager

## Test plan
- [ ] Run highstate on a sensor and verify `/opt/so/conf/zeek/zkg` is created
- [ ] Place a custom Zeek package in `/opt/so/saltstack/local/salt/zeek/zkg/` on the manager, run highstate, and verify it syncs to the sensor and gets installed on container start