### PR TITLE
Add customizable ulimit settings for all Docker containers

### DIFF
--- a/salt/docker/defaults.yaml
+++ b/salt/docker/defaults.yaml
@@ -9,6 +9,7 @@ docker:
       custom_bind_mounts: []
       extra_hosts: []
       extra_env: []
+      ulimits: []
     'so-elastic-fleet':
       final_octet: 21
       port_bindings:
@@ -16,6 +17,7 @@ docker:
       custom_bind_mounts: []
       extra_hosts: []
       extra_env: []
+      ulimits: []
     'so-elasticsearch':
       final_octet: 22
       port_bindings:
@@ -24,6 +26,10 @@ docker:
       custom_bind_mounts: []
       extra_hosts: []
       extra_env: []
+      ulimits:
+        - memlock=-1:-1
+        - nofile=65536:65536
+        - nproc=4096
     'so-influxdb':
       final_octet: 26
       port_bindings:
@@ -31,6 +37,7 @@ docker:
       custom_bind_mounts: []
       extra_hosts: []
       extra_env: []
+      ulimits: []
     'so-kibana':
       final_octet: 27
       port_bindings:
@@ -38,6 +45,7 @@ docker:
       custom_bind_mounts: []
       extra_hosts: []
       extra_env: []
+      ulimits: []
     'so-kratos':
       final_octet: 28
       port_bindings:
@@ -46,6 +54,7 @@ docker:
       custom_bind_mounts: []
       extra_hosts: []
       extra_env: []
+      ulimits: []
     'so-hydra':
       final_octet: 30
       port_bindings:
@@ -54,6 +63,7 @@ docker:
       custom_bind_mounts: []
       extra_hosts: []
       extra_env: []
+      ulimits: []
     'so-logstash':
       final_octet: 29
       port_bindings:
@@ -70,6 +80,7 @@ docker:
       custom_bind_mounts: []
       extra_hosts: []
       extra_env: []
+      ulimits: []
     'so-nginx':
       final_octet: 31
       port_bindings:
@@ -81,6 +92,7 @@ docker:
       custom_bind_mounts: []
       extra_hosts: []
       extra_env: []
+      ulimits: []
     'so-nginx-fleet-node':
       final_octet: 31
       port_bindings:
@@ -88,6 +100,7 @@ docker:
       custom_bind_mounts: []
       extra_hosts: []
       extra_env: []
+      ulimits: []
     'so-redis':
       final_octet: 33
       port_bindings:
@@ -96,11 +109,13 @@ docker:
       custom_bind_mounts: []
       extra_hosts: []
       extra_env: []
+      ulimits: []
     'so-sensoroni':
       final_octet: 99
       custom_bind_mounts: []
       extra_hosts: []
       extra_env: []
+      ulimits: []
     'so-soc':
       final_octet: 34
       port_bindings:
@@ -108,16 +123,19 @@ docker:
       custom_bind_mounts: []
       extra_hosts: []
       extra_env: []
+      ulimits: []
     'so-strelka-backend':
       final_octet: 36
       custom_bind_mounts: []
       extra_hosts: []
       extra_env: []
+      ulimits: []
     'so-strelka-filestream':
       final_octet: 37
       custom_bind_mounts: []
       extra_hosts: []
       extra_env: []
+      ulimits: []
     'so-strelka-frontend':
       final_octet: 38
       port_bindings:
@@ -125,11 +143,13 @@ docker:
       custom_bind_mounts: []
       extra_hosts: []
       extra_env: []
+      ulimits: []
     'so-strelka-manager':
       final_octet: 39
       custom_bind_mounts: []
       extra_hosts: []
       extra_env: []
+      ulimits: []
     'so-strelka-gatekeeper':
       final_octet: 40
       port_bindings:
@@ -137,6 +157,7 @@ docker:
       custom_bind_mounts: []
       extra_hosts: []
       extra_env: []
+      ulimits: []
     'so-strelka-coordinator':
       final_octet: 41
       port_bindings:
@@ -144,11 +165,13 @@ docker:
       custom_bind_mounts: []
       extra_hosts: []
       extra_env: []
+      ulimits: []
     'so-elastalert':
       final_octet: 42
       custom_bind_mounts: []
       extra_hosts: []
       extra_env: []
+      ulimits: []
     'so-elastic-fleet-package-registry':
       final_octet: 44
       port_bindings:
@@ -156,11 +179,13 @@ docker:
       custom_bind_mounts: []
       extra_hosts: []
       extra_env: []
+      ulimits: []
     'so-idh':
       final_octet: 45
       custom_bind_mounts: []
       extra_hosts: []
       extra_env: []
+      ulimits: []
     'so-elastic-agent':
       final_octet: 46
       port_bindings:
@@ -169,11 +194,13 @@ docker:
       custom_bind_mounts: []
       extra_hosts: []
       extra_env: []
+      ulimits: []
     'so-telegraf':
       final_octet: 99
       custom_bind_mounts: []
       extra_hosts: []
       extra_env: []
+      ulimits: []
     'so-suricata':
       final_octet: 99
       custom_bind_mounts: []
@@ -186,6 +213,9 @@ docker:
       custom_bind_mounts: []
       extra_hosts: []
       extra_env: []
+      ulimits:
+        - core=0
+        - nofile=1048576:1048576
     'so-kafka':
       final_octet: 88
       port_bindings:
@@ -196,3 +226,4 @@ docker:
       custom_bind_mounts: []
       extra_hosts: []
       extra_env: []
+      ulimits: []

--- a/salt/docker/soc_docker.yaml
+++ b/salt/docker/soc_docker.yaml
@@ -39,6 +39,12 @@ docker:
         helpLink: docker.html
         multiline: True
         forcedType: "[]string"
+      ulimits:
+        description: Ulimits for the container.
+        advanced: True
+        helpLink: docker.html
+        multiline: True
+        forcedType: "[]string"
     so-elastic-fleet: *dockerOptions
     so-elasticsearch: *dockerOptions
     so-influxdb: *dockerOptions
@@ -62,42 +68,6 @@ docker:
     so-idh: *dockerOptions
     so-elastic-agent: *dockerOptions
     so-telegraf: *dockerOptions
-    so-suricata:
-      final_octet:
-        description: Last octet of the container IP address.
-        helpLink: docker.html
-        readonly: True
-        advanced: True
-        global: True
-      port_bindings:
-        description: List of port bindings for the container.
-        helpLink: docker.html
-        advanced: True
-        multiline: True
-        forcedType: "[]string"
-      custom_bind_mounts:
-        description: List of custom local volume bindings.
-        advanced: True
-        helpLink: docker.html
-        multiline: True
-        forcedType: "[]string"
-      extra_hosts:
-        description: List of additional host entries for the container.
-        advanced: True
-        helpLink: docker.html
-        multiline: True
-        forcedType: "[]string"
-      extra_env:
-        description: List of additional ENV entries for the container.
-        advanced: True
-        helpLink: docker.html
-        multiline: True
-        forcedType: "[]string"
-      ulimits:
-        description: Ulimits for the container, in bytes.
-        advanced: True
-        helpLink: docker.html
-        multiline: True
-        forcedType: "[]string"
+    so-suricata: *dockerOptions
     so-zeek: *dockerOptions
     so-kafka: *dockerOptions

--- a/salt/elastalert/enabled.sls
+++ b/salt/elastalert/enabled.sls
@@ -51,6 +51,12 @@ so-elastalert:
       - {{ XTRAENV }}
         {% endfor %}
       {% endif %}
+    {% if DOCKER.containers['so-elastalert'].ulimits %}
+    - ulimits:
+    {%   for ULIMIT in DOCKER.containers['so-elastalert'].ulimits %}
+      - {{ ULIMIT }}
+    {%   endfor %}
+    {% endif %}
     - require:
       - cmd: wait_for_elasticsearch
       - file: elastarules

--- a/salt/elastic-fleet-package-registry/enabled.sls
+++ b/salt/elastic-fleet-package-registry/enabled.sls
@@ -45,6 +45,12 @@ so-elastic-fleet-package-registry:
       - {{ XTRAENV }}
         {% endfor %}
       {% endif %}
+    {% if DOCKER.containers['so-elastic-fleet-package-registry'].ulimits %}
+    - ulimits:
+    {%   for ULIMIT in DOCKER.containers['so-elastic-fleet-package-registry'].ulimits %}
+      - {{ ULIMIT }}
+    {%   endfor %}
+    {% endif %}
 delete_so-elastic-fleet-package-registry_so-status.disabled:
   file.uncomment:
     - name: /opt/so/conf/so-status/so-status.conf

--- a/salt/elasticagent/enabled.sls
+++ b/salt/elasticagent/enabled.sls
@@ -54,6 +54,12 @@ so-elastic-agent:
       - {{ XTRAENV }}
         {% endfor %}
       {% endif %}
+    {% if DOCKER.containers['so-elastic-agent'].ulimits %}
+    - ulimits:
+    {%   for ULIMIT in DOCKER.containers['so-elastic-agent'].ulimits %}
+      - {{ ULIMIT }}
+    {%   endfor %}
+    {% endif %}
     - require:
       - file: create-elastic-agent-config
       - file: trusttheca

--- a/salt/elasticfleet/enabled.sls
+++ b/salt/elasticfleet/enabled.sls
@@ -133,6 +133,12 @@ so-elastic-fleet:
       - {{ XTRAENV }}
         {% endfor %}
       {% endif %}
+    {% if DOCKER.containers['so-elastic-fleet'].ulimits %}
+    - ulimits:
+    {%   for ULIMIT in DOCKER.containers['so-elastic-fleet'].ulimits %}
+      - {{ ULIMIT }}
+    {%   endfor %}
+    {% endif %}
     - watch:
       - file: trusttheca
       - x509: etc_elasticfleet_key

--- a/salt/elasticsearch/enabled.sls
+++ b/salt/elasticsearch/enabled.sls
@@ -45,15 +45,17 @@ so-elasticsearch:
       - discovery.type=single-node
       {% endif %}
       - ES_JAVA_OPTS=-Xms{{ GLOBALS.elasticsearch.es_heap }} -Xmx{{ GLOBALS.elasticsearch.es_heap }} -Des.transport.cname_in_publish_address=true -Dlog4j2.formatMsgNoLookups=true
-      ulimits:
-      - memlock=-1:-1
-      - nofile=65536:65536
-      - nproc=4096
       {% if DOCKER.containers['so-elasticsearch'].extra_env %}
         {% for XTRAENV in DOCKER.containers['so-elasticsearch'].extra_env %}
       - {{ XTRAENV }}
         {% endfor %}
       {% endif %}
+    {% if DOCKER.containers['so-elasticsearch'].ulimits %}
+    - ulimits:
+    {%   for ULIMIT in DOCKER.containers['so-elasticsearch'].ulimits %}
+      - {{ ULIMIT }}
+    {%   endfor %}
+    {% endif %}
     - port_bindings:
       {% for BINDING in DOCKER.containers['so-elasticsearch'].port_bindings %}
       - {{ BINDING }}

--- a/salt/hydra/enabled.sls
+++ b/salt/hydra/enabled.sls
@@ -52,6 +52,12 @@ so-hydra:
       - {{ XTRAENV }}
       {% endfor %}
     {% endif %}
+    {% if DOCKER.containers['so-hydra'].ulimits %}
+    - ulimits:
+    {%   for ULIMIT in DOCKER.containers['so-hydra'].ulimits %}
+      - {{ ULIMIT }}
+    {%   endfor %}
+    {% endif %}
     - restart_policy: unless-stopped
     - watch:
       - file: hydraconfig

--- a/salt/idh/enabled.sls
+++ b/salt/idh/enabled.sls
@@ -39,6 +39,12 @@ so-idh:
       - {{ XTRAENV }}
       {% endfor %}
     {% endif %}
+    {% if DOCKER.containers['so-idh'].ulimits %}
+    - ulimits:
+    {%   for ULIMIT in DOCKER.containers['so-idh'].ulimits %}
+      - {{ ULIMIT }}
+    {%   endfor %}
+    {% endif %}
     - watch:
       - file: opencanary_config
     - require:

--- a/salt/influxdb/enabled.sls
+++ b/salt/influxdb/enabled.sls
@@ -58,6 +58,12 @@ so-influxdb:
       - {{ XTRAHOST }}
       {% endfor %}
     {% endif %}
+    {% if DOCKER.containers['so-influxdb'].ulimits %}
+    - ulimits:
+    {%   for ULIMIT in DOCKER.containers['so-influxdb'].ulimits %}
+      - {{ ULIMIT }}
+    {%   endfor %}
+    {% endif %}
     - watch:
       - file: influxdbconf
       - x509: influxdb_key

--- a/salt/kafka/enabled.sls
+++ b/salt/kafka/enabled.sls
@@ -60,6 +60,12 @@ so-kafka:
       {% if KAFKA_EXTERNAL_ACCESS %}
       - /opt/so/conf/kafka/kafka_server_jaas.conf:/opt/kafka/config/kafka_server_jaas.conf:ro
       {% endif %}
+    {% if DOCKER.containers['so-kafka'].ulimits %}
+    - ulimits:
+    {%   for ULIMIT in DOCKER.containers['so-kafka'].ulimits %}
+      - {{ ULIMIT }}
+    {%   endfor %}
+    {% endif %}
     - watch:
       {% for sc in ['server', 'client'] %}
       - file: kafka_kraft_{{sc}}_properties

--- a/salt/kibana/enabled.sls
+++ b/salt/kibana/enabled.sls
@@ -51,6 +51,12 @@ so-kibana:
       {% for BINDING in DOCKER.containers['so-kibana'].port_bindings %}
       - {{ BINDING }}
       {% endfor %}
+    {% if DOCKER.containers['so-kibana'].ulimits %}
+    - ulimits:
+    {%   for ULIMIT in DOCKER.containers['so-kibana'].ulimits %}
+      - {{ ULIMIT }}
+    {%   endfor %}
+    {% endif %}
     - watch:
       - file: kibanaconfig
 

--- a/salt/kratos/enabled.sls
+++ b/salt/kratos/enabled.sls
@@ -45,6 +45,12 @@ so-kratos:
       - {{ XTRAENV }}
       {% endfor %}
     {% endif %}
+    {% if DOCKER.containers['so-kratos'].ulimits %}
+    - ulimits:
+    {%   for ULIMIT in DOCKER.containers['so-kratos'].ulimits %}
+      - {{ ULIMIT }}
+    {%   endfor %}
+    {% endif %}
     - restart_policy: unless-stopped
     - watch:
       - file: kratosschema

--- a/salt/logstash/enabled.sls
+++ b/salt/logstash/enabled.sls
@@ -96,6 +96,12 @@ so-logstash:
       - {{ BIND }}
         {% endfor %}
       {% endif %}
+    {% if DOCKER.containers['so-logstash'].ulimits %}
+    - ulimits:
+    {%   for ULIMIT in DOCKER.containers['so-logstash'].ulimits %}
+      - {{ ULIMIT }}
+    {%   endfor %}
+    {% endif %}
     - watch:
       - file: lsetcsync
       - file: trusttheca

--- a/salt/nginx/enabled.sls
+++ b/salt/nginx/enabled.sls
@@ -75,6 +75,12 @@ so-nginx:
       - {{ XTRAENV }}
       {% endfor %}
     {% endif %}
+    {% if DOCKER.containers[container_config].ulimits %}
+    - ulimits:
+    {%   for ULIMIT in DOCKER.containers[container_config].ulimits %}
+      - {{ ULIMIT }}
+    {%   endfor %}
+    {% endif %}
     - cap_add: NET_BIND_SERVICE
     - port_bindings:
       {% for BINDING in DOCKER.containers[container_config].port_bindings %}

--- a/salt/redis/enabled.sls
+++ b/salt/redis/enabled.sls
@@ -51,6 +51,12 @@ so-redis:
       - {{ XTRAENV }}
       {% endfor %}
     {% endif %}
+    {% if DOCKER.containers['so-redis'].ulimits %}
+    - ulimits:
+    {%   for ULIMIT in DOCKER.containers['so-redis'].ulimits %}
+      - {{ ULIMIT }}
+    {%   endfor %}
+    {% endif %}
     - entrypoint: "redis-server /usr/local/etc/redis/redis.conf"
     - watch:
       - file: trusttheca

--- a/salt/registry/enabled.sls
+++ b/salt/registry/enabled.sls
@@ -51,6 +51,12 @@ so-dockerregistry:
       - {{ XTRAENV }}
         {% endfor %}
       {% endif %}
+    {% if DOCKER.containers['so-dockerregistry'].ulimits %}
+    - ulimits:
+    {%   for ULIMIT in DOCKER.containers['so-dockerregistry'].ulimits %}
+      - {{ ULIMIT }}
+    {%   endfor %}
+    {% endif %}
     - retry:
         attempts: 5
         interval: 30

--- a/salt/sensoroni/enabled.sls
+++ b/salt/sensoroni/enabled.sls
@@ -40,6 +40,12 @@ so-sensoroni:
       - {{ XTRAENV }}
       {% endfor %}
     {% endif %}
+    {% if DOCKER.containers['so-sensoroni'].ulimits %}
+    - ulimits:
+    {%   for ULIMIT in DOCKER.containers['so-sensoroni'].ulimits %}
+      - {{ ULIMIT }}
+    {%   endfor %}
+    {% endif %}
     - watch:
       - file: /opt/so/conf/sensoroni/sensoroni.json
     - require:

--- a/salt/soc/enabled.sls
+++ b/salt/soc/enabled.sls
@@ -78,6 +78,12 @@ so-soc:
       - {{ XTRAENV }}
     {%   endfor %}
     {% endif %}
+    {% if DOCKER.containers['so-soc'].ulimits %}
+    - ulimits:
+    {%   for ULIMIT in DOCKER.containers['so-soc'].ulimits %}
+      - {{ ULIMIT }}
+    {%   endfor %}
+    {% endif %}
     - watch:
       - file: trusttheca
       - file: /opt/so/conf/soc/*

--- a/salt/strelka/backend/enabled.sls
+++ b/salt/strelka/backend/enabled.sls
@@ -41,6 +41,12 @@ strelka_backend:
       - {{ XTRAENV }}
       {% endfor %}
     {% endif %}
+    {% if DOCKER.containers['so-strelka-backend'].ulimits %}
+    - ulimits:
+    {%   for ULIMIT in DOCKER.containers['so-strelka-backend'].ulimits %}
+      - {{ ULIMIT }}
+    {%   endfor %}
+    {% endif %}
     - restart_policy: on-failure
     - watch:
       - file: strelkasensorcompiledrules

--- a/salt/strelka/coordinator/enabled.sls
+++ b/salt/strelka/coordinator/enabled.sls
@@ -44,6 +44,12 @@ strelka_coordinator:
       - {{ BIND }}
         {% endfor %}
       {% endif %}
+    {% if DOCKER.containers['so-strelka-coordinator'].ulimits %}
+    - ulimits:
+    {%   for ULIMIT in DOCKER.containers['so-strelka-coordinator'].ulimits %}
+      - {{ ULIMIT }}
+    {%   endfor %}
+    {% endif %}
 delete_so-strelka-coordinator_so-status.disabled:
   file.uncomment:
     - name: /opt/so/conf/so-status/so-status.conf

--- a/salt/strelka/filestream/enabled.sls
+++ b/salt/strelka/filestream/enabled.sls
@@ -41,6 +41,12 @@ strelka_filestream:
       - {{ XTRAENV }}
       {% endfor %}
     {% endif %}
+    {% if DOCKER.containers['so-strelka-filestream'].ulimits %}
+    - ulimits:
+    {%   for ULIMIT in DOCKER.containers['so-strelka-filestream'].ulimits %}
+      - {{ ULIMIT }}
+    {%   endfor %}
+    {% endif %}
     - watch:
       - file: filestream_config
 

--- a/salt/strelka/frontend/enabled.sls
+++ b/salt/strelka/frontend/enabled.sls
@@ -46,6 +46,12 @@ strelka_frontend:
       - {{ XTRAENV }}
       {% endfor %}
     {% endif %}
+    {% if DOCKER.containers['so-strelka-frontend'].ulimits %}
+    - ulimits:
+    {%   for ULIMIT in DOCKER.containers['so-strelka-frontend'].ulimits %}
+      - {{ ULIMIT }}
+    {%   endfor %}
+    {% endif %}
     - watch:
       - file: frontend_config
 

--- a/salt/strelka/gatekeeper/enabled.sls
+++ b/salt/strelka/gatekeeper/enabled.sls
@@ -43,7 +43,13 @@ strelka_gatekeeper:
       {% for XTRAENV in DOCKER.containers['so-strelka-gatekeeper'].extra_env %}
       - {{ XTRAENV }}
       {% endfor %}
-    {% endif %}   
+    {% endif %}
+    {% if DOCKER.containers['so-strelka-gatekeeper'].ulimits %}
+    - ulimits:
+    {%   for ULIMIT in DOCKER.containers['so-strelka-gatekeeper'].ulimits %}
+      - {{ ULIMIT }}
+    {%   endfor %}
+    {% endif %}
 
 delete_so-strelka-gatekeeper_so-status.disabled:
   file.uncomment:

--- a/salt/strelka/manager/enabled.sls
+++ b/salt/strelka/manager/enabled.sls
@@ -40,6 +40,12 @@ strelka_manager:
       - {{ XTRAENV }}
       {% endfor %}
     {% endif %}
+    {% if DOCKER.containers['so-strelka-manager'].ulimits %}
+    - ulimits:
+    {%   for ULIMIT in DOCKER.containers['so-strelka-manager'].ulimits %}
+      - {{ ULIMIT }}
+    {%   endfor %}
+    {% endif %}
     - watch:
       - file: manager_config
 

--- a/salt/telegraf/enabled.sls
+++ b/salt/telegraf/enabled.sls
@@ -66,6 +66,12 @@ so-telegraf:
       - {{ XTRAHOST }}
       {% endfor %}
     {% endif %}
+    {% if DOCKER.containers['so-telegraf'].ulimits %}
+    - ulimits:
+    {%   for ULIMIT in DOCKER.containers['so-telegraf'].ulimits %}
+      - {{ ULIMIT }}
+    {%   endfor %}
+    {% endif %}
     - watch:
       - file: trusttheca
       - x509: telegraf_crt

--- a/salt/zeek/enabled.sls
+++ b/salt/zeek/enabled.sls
@@ -18,9 +18,12 @@ so-zeek:
     - image: {{ GLOBALS.registry_host }}:5000/{{ GLOBALS.image_repo }}/so-zeek:{{ GLOBALS.so_version }}
     - start: True
     - privileged: True
+    {% if DOCKER.containers['so-zeek'].ulimits %}
     - ulimits:
-      - core=0
-      - nofile=1048576:1048576
+    {%   for ULIMIT in DOCKER.containers['so-zeek'].ulimits %}
+      - {{ ULIMIT }}
+    {%   endfor %}
+    {% endif %}
     - binds:
       - /nsm/zeek/logs:/nsm/zeek/logs:rw
       - /nsm/zeek/spool:/nsm/zeek/spool:rw


### PR DESCRIPTION
## Summary
- Add `ulimits` as a configurable advanced setting for all 26 Docker containers via the web UI
- Move hardcoded ulimits from elasticsearch and zeek `.sls` files into `defaults.yaml` as customizable defaults
- Fix elasticsearch ulimits that were incorrectly nested under the `environment` key
- Collapse the `so-suricata` special case in `soc_docker.yaml` to use the shared `&dockerOptions` YAML anchor

## Test plan
- [ ] Verify ulimits appear as an advanced setting for all containers in the SOC web UI
- [ ] Confirm elasticsearch starts correctly with ulimits now as a proper top-level parameter
- [ ] Confirm zeek starts correctly with parameterized ulimits from defaults
- [ ] Confirm suricata ulimits still respect the mmap-locked gate
- [ ] Test customizing ulimits for a container via the UI and verify the container picks up the changes