### PR TITLE
Fix soup for 3.X.X installations

### DIFF
--- a/salt/common/soup_scripts.sls
+++ b/salt/common/soup_scripts.sls
@@ -3,7 +3,8 @@
 # https://securityonion.net/license; you may not use this file except in compliance with the
 # Elastic License 2.0.
 
-{% if '2.4' in salt['cp.get_file_str']('/etc/soversion') %}
+{% set soversion = salt['cp.get_file_str']('/etc/soversion') %}
+{% if '2.4' in soversion or soversion.startswith('3.') %}
 
 {%   import_yaml '/opt/so/saltstack/local/pillar/global/soc_global.sls' as SOC_GLOBAL %}
 {%   if SOC_GLOBAL.global.airgap %}

--- a/salt/manager/tools/sbin/soup
+++ b/salt/manager/tools/sbin/soup
@@ -317,7 +317,11 @@ clone_to_tmp() {
   # Make a temp location for the files
   mkdir -p /tmp/sogh
   cd /tmp/sogh
-  SOUP_BRANCH="-b 2.4/main"
+  if [[ "$INSTALLEDVERSION" == 3.* ]]; then
+    SOUP_BRANCH="-b 3/main"
+  else
+    SOUP_BRANCH="-b 2.4/main"
+  fi
   if [ -n "$BRANCH" ]; then
     SOUP_BRANCH="-b $BRANCH"
   fi

--- a/salt/manager/tools/sbin/soup
+++ b/salt/manager/tools/sbin/soup
@@ -317,11 +317,7 @@ clone_to_tmp() {
   # Make a temp location for the files
   mkdir -p /tmp/sogh
   cd /tmp/sogh
-  if [[ "$INSTALLEDVERSION" == 3.* ]]; then
-    SOUP_BRANCH="-b 3/main"
-  else
-    SOUP_BRANCH="-b 2.4/main"
-  fi
+  SOUP_BRANCH="-b 2.4/main"
   if [ -n "$BRANCH" ]; then
     SOUP_BRANCH="-b $BRANCH"
   fi
@@ -2131,6 +2127,12 @@ failed_soup_restore_items() {
 
 main() {
   trap 'check_err $?' EXIT
+
+  # If running 3.X.X, re-launch soup using the 3/main branch
+  if [[ "$INSTALLEDVERSION" == 3.* && "$BRANCH" != "3/main" ]]; then
+    echo "Detected Security Onion $INSTALLEDVERSION. Switching to 3/main branch."
+    exec env BRANCH=3/main soup "$@"
+  fi
 
   if [ -n "$BRANCH" ]; then
     echo "SOUP will use the $BRANCH branch."

--- a/salt/manager/tools/sbin/soup
+++ b/salt/manager/tools/sbin/soup
@@ -2128,9 +2128,23 @@ failed_soup_restore_items() {
 main() {
   trap 'check_err $?' EXIT
 
-  # If running 3.X.X, re-launch soup using the 3/main branch
+  # If running 3.X.X, we need to fetch the correct soup and supporting scripts
+  # from the 3/main branch before proceeding, otherwise we'll clone 2.4/main
+  # and end up with incompatible scripts.
   if [[ "$INSTALLEDVERSION" == 3.* && "$BRANCH" != "3/main" ]]; then
-    echo "Detected Security Onion $INSTALLEDVERSION. Switching to 3/main branch."
+    echo "Detected Security Onion $INSTALLEDVERSION. Fetching soup from 3/main branch."
+    rm -rf /tmp/sogh
+    mkdir -p /tmp/sogh
+    cd /tmp/sogh
+    git clone -b 3/main https://github.com/Security-Onion-Solutions/securityonion.git
+    if [ ! -f "$UPDATE_DIR/VERSION" ]; then
+      echo "Unable to clone 3/main branch from Github. Please check your Internet access."
+      exit 1
+    fi
+    cp "$UPDATE_DIR/salt/manager/tools/sbin/soup" /usr/sbin/soup
+    cp "$UPDATE_DIR/salt/common/tools/sbin/so-common" /usr/sbin/so-common
+    cp "$UPDATE_DIR/salt/common/tools/sbin/so-image-common" /usr/sbin/so-image-common
+    echo "Updated soup scripts from 3/main. Restarting soup."
     exec env BRANCH=3/main soup "$@"
   fi
 


### PR DESCRIPTION
## Summary
- Fix `soup_scripts.sls` to recognize 3.X versions so it doesn't fall back to curling the 2.3/main soup, which was the root cause of soup breaking on 3.0 machines
- Add early detection in `soup` `main()` for 3.X.X installations that clones 3/main, replaces soup/so-common/so-image-common, and re-execs with the correct branch

## Test plan
- [x] On a 3.0 machine with a broken soup pointing at 2.4/main, set `SOUP_BRANCH="-b soupfix2"` and run soup
- [x] Verify it no longer downloads the 2.3 soup via curl
- [x] Verify it detects 3.X.X and switches to 3/main branch