### PR TITLE
Assistant: charsPerTokenEstimate

### DIFF
--- a/salt/soc/defaults.yaml
+++ b/salt/soc/defaults.yaml
@@ -2687,4 +2687,5 @@ soc:
               lowBalanceColorAlert: 500000
               enabled: true
               adapter: SOAI
+              charsPerTokenEstimate: 4
             

--- a/salt/soc/soc_soc.yaml
+++ b/salt/soc/soc_soc.yaml
@@ -761,7 +761,7 @@ soc:
               required: True
             - field: origin
               label: Country of Origin for the Model Training
-              required: false
+              required: False
             - field: contextLimitSmall
               label: Context Limit (Small)
               forcedType: int
@@ -779,6 +779,10 @@ soc:
             - field: enabled
               label: Enabled
               forcedType: bool
+            - field: charsPerTokenEstimate
+              label: Characters per Token Estimate
+              forcedType: float
+              required: False
         apiTimeoutMs:
           description: Duration (in milliseconds) to wait for a response from the SOC server API before giving up and showing an error on the SOC UI.
           global: True


### PR DESCRIPTION
## Description

- Added the configurable `charsPerTokenEstimate` field to `availableModels`.
- This field is used in calculations in the query length checks.
- It is not required, and it takes in a float.
- If unset, set to 0, or set to a negative value, the query length checks will be skipped.

## Related Issues

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/Security-Onion-Solutions/securityonion/blob/3/main/CONTRIBUTING.md) file.
- [x] I have read and agree to the terms of the [Contributor License Agreement](https://securityonionsolutions.com/cla)

## Questions or Comments