### PR TITLE
Add daily PostgreSQL database backup

### DIFF
--- a/salt/backup/config_backup.sls
+++ b/salt/backup/config_backup.sls
@@ -32,3 +32,23 @@ so_config_backup:
     - daymonth: '*'
     - month: '*'
     - dayweek: '*'
+
+postgres_backup_script:
+  file.managed:
+    - name: /usr/sbin/so-postgres-backup
+    - user: root
+    - group: root
+    - mode: 755
+    - source: salt://backup/tools/sbin/so-postgres-backup
+
+# Add postgres database backup
+so_postgres_backup:
+  cron.present:
+    - name: /usr/sbin/so-postgres-backup > /dev/null 2>&1
+    - identifier: so_postgres_backup
+    - user: root
+    - minute: '5'
+    - hour: '0'
+    - daymonth: '*'
+    - month: '*'
+    - dayweek: '*'

--- a/salt/backup/tools/sbin/so-postgres-backup
+++ b/salt/backup/tools/sbin/so-postgres-backup
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Copyright Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+# https://securityonion.net/license; you may not use this file except in compliance with the
+# Elastic License 2.0.
+
+. /usr/sbin/so-common
+
+TODAY=$(date '+%Y_%m_%d')
+BACKUPDIR=/nsm/backup
+BACKUPFILE="$BACKUPDIR/so-postgres-backup-$TODAY.sql.gz"
+MAXBACKUPS=7
+
+mkdir -p $BACKUPDIR
+
+# Skip if already backed up today
+if [ -f "$BACKUPFILE" ]; then
+  exit 0
+fi
+
+# Skip if container isn't running
+if ! docker ps --format '{{.Names}}' | grep -q '^so-postgres$'; then
+  exit 0
+fi
+
+# Dump all databases and roles, compress
+docker exec so-postgres pg_dumpall -U postgres | gzip > "$BACKUPFILE"
+
+# Retention cleanup
+NUMBACKUPS=$(find $BACKUPDIR -type f -name "so-postgres-backup*" | wc -l)
+while [ "$NUMBACKUPS" -gt "$MAXBACKUPS" ]; do
+  OLDEST=$(find $BACKUPDIR -type f -name "so-postgres-backup*" -printf '%T+ %p\n' | sort | head -n 1 | awk -F" " '{print $2}')
+  rm -f "$OLDEST"
+  NUMBACKUPS=$(find $BACKUPDIR -type f -name "so-postgres-backup*" | wc -l)
+done


### PR DESCRIPTION
## Summary
- Adds `so-postgres-backup` script that runs `pg_dumpall` via docker exec, compressed with gzip
- Daily cron at 00:05 (4 minutes after config backup)
- 7-day retention matching existing config backup policy
- Skips gracefully if container isn't running or backup already exists for today
- Backup stored in `/nsm/backup/so-postgres-backup-YYYY_MM_DD.sql.gz`

## Test plan
- [ ] Verify cron is installed: `crontab -l | grep so-postgres-backup`
- [ ] Run manually: `sudo /usr/sbin/so-postgres-backup`
- [ ] Verify backup created: `ls -la /nsm/backup/so-postgres-backup-*`
- [ ] Verify dump is valid: `zcat /nsm/backup/so-postgres-backup-*.sql.gz | head`