### PR TITLE
Enable postgres by default for manager nodes

### DIFF
--- a/salt/postgres/defaults.yaml
+++ b/salt/postgres/defaults.yaml
@@ -1,5 +1,5 @@
 postgres:
-  enabled: False
+  enabled: True
   config:
     listen_addresses: '*'
     port: 5432


### PR DESCRIPTION
## Summary
- Change `enabled: False` to `enabled: True` in postgres defaults
- Safe because postgres states are only applied to manager-type nodes via top.sls and allowed_states.map.jinja

## Test plan
- [ ] Run highstate on a standalone/manager node — so-postgres should appear in so-status
- [ ] Verify non-manager nodes are unaffected