### PR TITLE
Add postgres.auth to allowed_states

### DIFF
--- a/salt/allowed_states.map.jinja
+++ b/salt/allowed_states.map.jinja
@@ -30,6 +30,7 @@
     'nginx',
     'influxdb',
     'postgres',
+    'postgres.auth',
     'soc',
     'kratos',
     'hydra',


### PR DESCRIPTION
## Summary
- Add `postgres.auth` to `manager_states` in `allowed_states.map.jinja`
- Fixes `postgres.auth_state_not_allowed` error on manager nodes
- Matches the `elasticsearch.auth` pattern where auth states use full sls path check

## Test plan
- [ ] Run highstate on a manager/standalone node — no `postgres.auth_state_not_allowed` error
- [ ] Verify `/opt/so/saltstack/local/pillar/postgres/auth.sls` is created with so_postgres credentials