### PR TITLE
Wire postgres credentials into SOC module config

### DIFF
--- a/salt/soc/defaults.map.jinja
+++ b/salt/soc/defaults.map.jinja
@@ -24,6 +24,10 @@
 
 {% do SOCDEFAULTS.soc.config.server.modules.elastic.update({'username': GLOBALS.elasticsearch.auth.users.so_elastic_user.user, 'password': GLOBALS.elasticsearch.auth.users.so_elastic_user.pass}) %}
 
+{% if GLOBALS.postgres is defined and GLOBALS.postgres.auth is defined %}
+{% do SOCDEFAULTS.soc.config.server.modules.postgres.update({'username': GLOBALS.postgres.auth.users.so_postgres_user.user, 'password': GLOBALS.postgres.auth.users.so_postgres_user.pass}) %}
+{% endif %}
+
 {% do SOCDEFAULTS.soc.config.server.modules.influxdb.update({'hostUrl': 'https://' ~ GLOBALS.influxdb_host ~ ':8086'}) %}
 {% do SOCDEFAULTS.soc.config.server.modules.influxdb.update({'token': INFLUXDB_TOKEN}) %}
 {% for tool in SOCDEFAULTS.soc.config.server.client.tools %}

--- a/salt/soc/defaults.yaml
+++ b/salt/soc/defaults.yaml
@@ -1491,6 +1491,14 @@ soc:
           org: Security Onion
           bucket: telegraf/so_short_term
           verifyCert: false
+        postgres:
+          hostUrl: so-postgres
+          port: 5432
+          username:
+          password:
+          dbname: securityonion
+          sslMode: require
+          assistantEnabled: true
         playbook:
           autoUpdateEnabled: true
           playbookImportFrequencySeconds: 86400

--- a/salt/vars/eval.map.jinja
+++ b/salt/vars/eval.map.jinja
@@ -1,4 +1,5 @@
 {% from 'vars/elasticsearch.map.jinja' import ELASTICSEARCH_GLOBALS %}
+{% from 'vars/postgres.map.jinja' import POSTGRES_GLOBALS %}
 {% from 'vars/sensor.map.jinja' import SENSOR_GLOBALS %}
 
 {% set ROLE_GLOBALS = {} %}
@@ -6,6 +7,7 @@
 {% set EVAL_GLOBALS =
    [
      ELASTICSEARCH_GLOBALS,
+     POSTGRES_GLOBALS,
      SENSOR_GLOBALS
    ]
 %}

--- a/salt/vars/import.map.jinja
+++ b/salt/vars/import.map.jinja
@@ -1,4 +1,5 @@
 {% from 'vars/elasticsearch.map.jinja' import ELASTICSEARCH_GLOBALS %}
+{% from 'vars/postgres.map.jinja' import POSTGRES_GLOBALS %}
 {% from 'vars/sensor.map.jinja' import SENSOR_GLOBALS %}
 
 {% set ROLE_GLOBALS = {} %}
@@ -6,6 +7,7 @@
 {% set IMPORT_GLOBALS =
    [
      ELASTICSEARCH_GLOBALS,
+     POSTGRES_GLOBALS,
      SENSOR_GLOBALS
    ]
 %}

--- a/salt/vars/manager.map.jinja
+++ b/salt/vars/manager.map.jinja
@@ -1,12 +1,14 @@
 {% from 'vars/elasticsearch.map.jinja' import ELASTICSEARCH_GLOBALS %}
 {% from 'vars/logstash.map.jinja' import LOGSTASH_GLOBALS %}
+{% from 'vars/postgres.map.jinja' import POSTGRES_GLOBALS %}
 
 {% set ROLE_GLOBALS = {} %}
 
 {% set MANAGER_GLOBALS =
    [
      ELASTICSEARCH_GLOBALS,
-     LOGSTASH_GLOBALS
+     LOGSTASH_GLOBALS,
+     POSTGRES_GLOBALS
    ]
 %}
 

--- a/salt/vars/managersearch.map.jinja
+++ b/salt/vars/managersearch.map.jinja
@@ -1,12 +1,14 @@
 {% from 'vars/elasticsearch.map.jinja' import ELASTICSEARCH_GLOBALS %}
 {% from 'vars/logstash.map.jinja' import LOGSTASH_GLOBALS %}
+{% from 'vars/postgres.map.jinja' import POSTGRES_GLOBALS %}
 
 {% set ROLE_GLOBALS = {} %}
 
 {% set MANAGERSEARCH_GLOBALS =
    [
      ELASTICSEARCH_GLOBALS,
-     LOGSTASH_GLOBALS
+     LOGSTASH_GLOBALS,
+     POSTGRES_GLOBALS
    ]
 %}
 

--- a/salt/vars/postgres.map.jinja
+++ b/salt/vars/postgres.map.jinja
@@ -1,0 +1,16 @@
+{# Copyright Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+   or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+   https://securityonion.net/license; you may not use this file except in compliance with the
+   Elastic License 2.0. #}
+
+{% import 'vars/init.map.jinja' as INIT %}
+
+{%
+  set POSTGRES_GLOBALS = {
+    'postgres': {}
+  }
+%}
+
+{% if salt['file.file_exists']('/opt/so/saltstack/local/pillar/postgres/auth.sls') %}
+{%   do POSTGRES_GLOBALS.postgres.update({'auth': INIT.PILLAR.postgres.auth}) %}
+{% endif %}

--- a/salt/vars/standalone.map.jinja
+++ b/salt/vars/standalone.map.jinja
@@ -1,5 +1,6 @@
 {% from 'vars/elasticsearch.map.jinja' import ELASTICSEARCH_GLOBALS %}
 {% from 'vars/logstash.map.jinja' import LOGSTASH_GLOBALS %}
+{% from 'vars/postgres.map.jinja' import POSTGRES_GLOBALS %}
 {% from 'vars/sensor.map.jinja' import SENSOR_GLOBALS %}
 
 {% set ROLE_GLOBALS = {} %}
@@ -8,6 +9,7 @@
    [
      ELASTICSEARCH_GLOBALS,
      LOGSTASH_GLOBALS,
+     POSTGRES_GLOBALS,
      SENSOR_GLOBALS
    ]
 %}


### PR DESCRIPTION
## Summary
- Create vars/postgres.map.jinja for postgres auth globals
- Add POSTGRES_GLOBALS to all manager-type role vars (manager, eval, standalone, managersearch, import)
- Add postgres module config to soc/defaults.yaml (hostUrl, port, dbname, sslMode, assistantEnabled)
- Inject so_postgres credentials from auth pillar into soc/defaults.map.jinja

## Test plan
- [ ] Verify sensoroni.json contains postgres module config with credentials after highstate
- [ ] Verify SOC starts and connects to postgres successfully
- [ ] Verify assistant chat sessions work end-to-end via postgres