### PR TITLE
Use manager IP for postgres host in SOC config

### DIFF
--- a/salt/soc/defaults.map.jinja
+++ b/salt/soc/defaults.map.jinja
@@ -25,7 +25,7 @@
 {% do SOCDEFAULTS.soc.config.server.modules.elastic.update({'username': GLOBALS.elasticsearch.auth.users.so_elastic_user.user, 'password': GLOBALS.elasticsearch.auth.users.so_elastic_user.pass}) %}
 
 {% if GLOBALS.postgres is defined and GLOBALS.postgres.auth is defined %}
-{% do SOCDEFAULTS.soc.config.server.modules.postgres.update({'username': GLOBALS.postgres.auth.users.so_postgres_user.user, 'password': GLOBALS.postgres.auth.users.so_postgres_user.pass}) %}
+{% do SOCDEFAULTS.soc.config.server.modules.postgres.update({'hostUrl': GLOBALS.manager_ip, 'username': GLOBALS.postgres.auth.users.so_postgres_user.user, 'password': GLOBALS.postgres.auth.users.so_postgres_user.pass}) %}
 {% endif %}
 
 {% do SOCDEFAULTS.soc.config.server.modules.influxdb.update({'hostUrl': 'https://' ~ GLOBALS.influxdb_host ~ ':8086'}) %}


### PR DESCRIPTION
## Summary
- Inject `GLOBALS.manager_ip` as postgres hostUrl instead of container hostname
- SOC connects via host network, not Docker bridge, so needs the manager IP

## Test plan
- [ ] After highstate, sensoroni.json shows manager IP for postgres hostUrl
- [ ] SOC connects to postgres successfully via manager IP