### PR TITLE
Only load postgres module on manager nodes

### DIFF
--- a/salt/soc/defaults.map.jinja
+++ b/salt/soc/defaults.map.jinja
@@ -25,7 +25,7 @@
 {% do SOCDEFAULTS.soc.config.server.modules.elastic.update({'username': GLOBALS.elasticsearch.auth.users.so_elastic_user.user, 'password': GLOBALS.elasticsearch.auth.users.so_elastic_user.pass}) %}
 
 {% if GLOBALS.postgres is defined and GLOBALS.postgres.auth is defined %}
-{% do SOCDEFAULTS.soc.config.server.modules.postgres.update({'hostUrl': GLOBALS.manager_ip, 'username': GLOBALS.postgres.auth.users.so_postgres_user.user, 'password': GLOBALS.postgres.auth.users.so_postgres_user.pass}) %}
+{% do SOCDEFAULTS.soc.config.server.modules.update({'postgres': {'hostUrl': GLOBALS.manager_ip, 'port': 5432, 'username': GLOBALS.postgres.auth.users.so_postgres_user.user, 'password': GLOBALS.postgres.auth.users.so_postgres_user.pass, 'dbname': 'securityonion', 'sslMode': 'require', 'assistantEnabled': true}}) %}
 {% endif %}
 
 {% do SOCDEFAULTS.soc.config.server.modules.influxdb.update({'hostUrl': 'https://' ~ GLOBALS.influxdb_host ~ ':8086'}) %}

--- a/salt/soc/defaults.yaml
+++ b/salt/soc/defaults.yaml
@@ -1491,14 +1491,6 @@ soc:
           org: Security Onion
           bucket: telegraf/so_short_term
           verifyCert: false
-        postgres:
-          hostUrl: so-postgres
-          port: 5432
-          username:
-          password:
-          dbname: securityonion
-          sslMode: require
-          assistantEnabled: true
         playbook:
           autoUpdateEnabled: true
           playbookImportFrequencySeconds: 86400


### PR DESCRIPTION
## Summary
- Remove postgres module config from soc/defaults.yaml (shared by all nodes)
- Create the config block only in defaults.map.jinja when postgres auth pillar exists (manager-type nodes only)
- Prevents sensors and other non-manager nodes from trying to connect to postgres

## Test plan
- [ ] Manager node: sensoroni.json contains postgres module with credentials
- [ ] Sensor node: sensoroni.json has no postgres module section
- [ ] Sensor sensoroni starts without postgres errors