### PR TITLE
Fix init-users.sh password escaping for special characters

### DIFF
--- a/salt/postgres/files/init-users.sh
+++ b/salt/postgres/files/init-users.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
 set -e
 
-# Create application user for SOC platform access
-# This script runs on first database initialization only
+# Create or update application user for SOC platform access
+# This script runs on first database initialization via docker-entrypoint-initdb.d
+# The password is properly escaped to handle special characters
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
     DO \$\$
     BEGIN
-        IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '$SO_POSTGRES_USER') THEN
-            CREATE ROLE "$SO_POSTGRES_USER" WITH LOGIN PASSWORD '$SO_POSTGRES_PASS';
+        IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '${SO_POSTGRES_USER}') THEN
+            EXECUTE format('CREATE ROLE %I WITH LOGIN PASSWORD %L', '${SO_POSTGRES_USER}', '${SO_POSTGRES_PASS}');
+        ELSE
+            EXECUTE format('ALTER ROLE %I WITH PASSWORD %L', '${SO_POSTGRES_USER}', '${SO_POSTGRES_PASS}');
         END IF;
     END
     \$\$;


### PR DESCRIPTION
## Summary
- Use format() with %L for SQL literal escaping instead of raw string interpolation
- ALTER ROLE if user already exists to keep password in sync with pillar

## Test plan
- [ ] Verify init-users.sh handles passwords with special characters (@?#:/)