### PR TITLE
Add postgres admin password to SOC config

### DIFF
--- a/salt/soc/defaults.map.jinja
+++ b/salt/soc/defaults.map.jinja
@@ -25,7 +25,8 @@
 {% do SOCDEFAULTS.soc.config.server.modules.elastic.update({'username': GLOBALS.elasticsearch.auth.users.so_elastic_user.user, 'password': GLOBALS.elasticsearch.auth.users.so_elastic_user.pass}) %}
 
 {% if GLOBALS.postgres is defined and GLOBALS.postgres.auth is defined %}
-{% do SOCDEFAULTS.soc.config.server.modules.update({'postgres': {'hostUrl': GLOBALS.manager_ip, 'port': 5432, 'username': GLOBALS.postgres.auth.users.so_postgres_user.user, 'password': GLOBALS.postgres.auth.users.so_postgres_user.pass, 'dbname': 'securityonion', 'sslMode': 'require', 'assistantEnabled': true}}) %}
+{%   set PG_ADMIN_PASS = salt['pillar.get']('secrets:postgres_pass', '') %}
+{% do SOCDEFAULTS.soc.config.server.modules.update({'postgres': {'hostUrl': GLOBALS.manager_ip, 'port': 5432, 'username': GLOBALS.postgres.auth.users.so_postgres_user.user, 'password': GLOBALS.postgres.auth.users.so_postgres_user.pass, 'adminUser': 'postgres', 'adminPassword': PG_ADMIN_PASS, 'dbname': 'securityonion', 'sslMode': 'require', 'assistantEnabled': true}}) %}
 {% endif %}
 
 {% do SOCDEFAULTS.soc.config.server.modules.influxdb.update({'hostUrl': 'https://' ~ GLOBALS.influxdb_host ~ ':8086'}) %}


### PR DESCRIPTION
## Summary
- Inject postgres superuser password from secrets pillar into SOC module config
- Required for schema migrations on PostgreSQL 15+ where only the DB owner can create tables

## Test plan
- [ ] After highstate, sensoroni.json contains adminPassword for postgres module