### PR TITLE
support minion node descriptions containing spaces

### DIFF
--- a/salt/manager/tools/sbin/so-minion
+++ b/salt/manager/tools/sbin/so-minion
@@ -132,8 +132,8 @@ function getinstallinfo() {
 		log "ERROR" "Failed to get install info from $MINION_ID"
 		return 1
 	fi
-	
-	export $(echo "$INSTALLVARS" | xargs)
+
+	while read -r var; do export "$var"; done <<< "$INSTALLVARS"
 	if [ $? -ne 0 ]; then
 		log "ERROR" "Failed to source install variables"
 		return 1

--- a/setup/so-setup
+++ b/setup/so-setup
@@ -219,6 +219,7 @@ if [ -n "$test_profile" ]; then
 	WEBUSER=onionuser@somewhere.invalid
 	WEBPASSWD1=0n10nus3r
 	WEBPASSWD2=0n10nus3r
+	NODE_DESCRIPTION="${HOSTNAME} - ${install_type}"
 
 	update_sudoers_for_testing
 fi


### PR DESCRIPTION
## Description

Minions should be able to have spaces in their description (entered during whiptail/setup).

## Related Issues


## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/Security-Onion-Solutions/securityonion/blob/3/main/CONTRIBUTING.md) file.
- [x] I have read and agree to the terms of the [Contributor License Agreement](https://securityonionsolutions.com/cla)

## Questions or Comments
