### PR TITLE
so-log-check: exclude psql ON_ERROR_STOP flag

### DIFF
--- a/salt/common/tools/sbin/so-log-check
+++ b/salt/common/tools/sbin/so-log-check
@@ -229,6 +229,7 @@ if [[ $EXCLUDE_KNOWN_ERRORS == 'Y' ]]; then
     EXCLUDED_ERRORS="$EXCLUDED_ERRORS|tcp 127.0.0.1:6791: bind: address already in use" # so-elastic-fleet agent restarting. Seen starting w/ 8.18.8 https://github.com/elastic/kibana/issues/201459
     EXCLUDED_ERRORS="$EXCLUDED_ERRORS|TransformTask\] \[logs-(tychon|aws_billing|microsoft_defender_endpoint).*user so_kibana lacks the required permissions \[logs-\1" # Known issue with 3 integrations using kibana_system role vs creating unique api creds with proper permissions.
     EXCLUDED_ERRORS="$EXCLUDED_ERRORS|manifest unknown"             # appears in so-dockerregistry log for so-tcpreplay following docker upgrade to 29.2.1-1
+    EXCLUDED_ERRORS="$EXCLUDED_ERRORS|-v ON_ERROR_STOP=1"            # psql invocation flag from so-postgres init script, not an actual error
 fi
 
 RESULT=0


### PR DESCRIPTION
## Summary

The psql invocation flag `-v ON_ERROR_STOP=1` used by `so-postgres`'s `init-users.sh` contains the token `ERROR`, which trips `so-log-check`'s error regex and produces a false positive. Added to `EXCLUDED_ERRORS`.

## Test plan

- [ ] Trigger `so-postgres` init (fresh container) so `-v ON_ERROR_STOP=1` appears in `/opt/so/log/postgres/`
- [ ] Run `sudo so-log-check` and confirm no false positive from the psql flag