### PR TITLE
Create so_telegraf DB from Salt and pin pg_partman schema

### DIFF
--- a/salt/postgres/telegraf_users.sls
+++ b/salt/postgres/telegraf_users.sls
@@ -10,6 +10,19 @@
 {% set TG_OUT = (GLOBALS.telegraf_output | default('INFLUXDB')) | upper %}
 {% if TG_OUT in ['POSTGRES', 'BOTH'] %}
 
+# Ensure the shared Telegraf database exists. init-users.sh only runs on a
+# fresh data dir, so hosts upgraded onto an existing /nsm/postgres volume
+# would otherwise never get so_telegraf.
+postgres_create_telegraf_db:
+  cmd.run:
+    - name: |
+        docker exec -i so-postgres psql -v ON_ERROR_STOP=1 -U postgres -d postgres <<'EOSQL'
+        SELECT 'CREATE DATABASE so_telegraf'
+        WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'so_telegraf')\gexec
+        EOSQL
+    - require:
+      - docker_container: so-postgres
+
 # Provision the shared group role and schema once. Every per-minion role is a
 # member of so_telegraf, and each Telegraf connection does SET ROLE so_telegraf
 # (via options='-c role=so_telegraf' in the connection string) so tables created
@@ -28,7 +41,8 @@ postgres_telegraf_group_role:
         GRANT CONNECT ON DATABASE so_telegraf TO so_telegraf;
         CREATE SCHEMA IF NOT EXISTS telegraf AUTHORIZATION so_telegraf;
         GRANT USAGE, CREATE ON SCHEMA telegraf TO so_telegraf;
-        CREATE EXTENSION IF NOT EXISTS pg_partman;
+        CREATE SCHEMA IF NOT EXISTS partman;
+        CREATE EXTENSION IF NOT EXISTS pg_partman SCHEMA partman;
         CREATE EXTENSION IF NOT EXISTS pg_cron;
         -- Hourly partman maintenance. cron.schedule is idempotent by jobname.
         SELECT cron.schedule(
@@ -38,7 +52,7 @@ postgres_telegraf_group_role:
         );
         EOSQL
     - require:
-      - docker_container: so-postgres
+      - cmd: postgres_create_telegraf_db
 
 {%   set users = salt['pillar.get']('postgres:auth:users', {}) %}
 {%   for key, entry in users.items() %}


### PR DESCRIPTION
## Summary
- Adds a `postgres_create_telegraf_db` state so the `so_telegraf` database is created idempotently on every state.apply. Previously this DB only got created by `init-users.sh` on a fresh data dir, so hosts upgraded onto an existing `/nsm/postgres` volume never got it and `postgres.telegraf_users` failed with `database "so_telegraf" does not exist`.
- Pins `pg_partman` to the `partman` schema (`CREATE EXTENSION ... SCHEMA partman`) so `partman.part_config` reliably resolves in the retention reconcile step.

## Test plan
- [ ] Apply `postgres` state on a host with a pre-existing `/nsm/postgres` volume and confirm `so_telegraf` is created without errors
- [ ] Apply on a fresh install and confirm no regression in the init-users.sh path
- [ ] Confirm `partman.part_config` is populated and the retention reconcile UPDATE succeeds
- [ ] Verify the hourly `telegraf-partman-maintenance` pg_cron job is scheduled