### PR TITLE
Fix Telegraf postgres template syntax, partman privileges, and idempotency

### DIFF
--- a/salt/postgres/files/init-users.sh
+++ b/salt/postgres/files/init-users.sh
@@ -20,7 +20,6 @@ EOSQL
 # Bootstrap the Telegraf metrics database. Per-minion roles + schemas are
 # reconciled on every state.apply by postgres/telegraf_users.sls; this block
 # only ensures the shared database exists on first initialization.
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
-    SELECT 'CREATE DATABASE so_telegraf'
-    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'so_telegraf')\gexec
-EOSQL
+if ! psql -U "$POSTGRES_USER" -tAc "SELECT 1 FROM pg_database WHERE datname='so_telegraf'" | grep -q 1; then
+    psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -c "CREATE DATABASE so_telegraf"
+fi

--- a/salt/postgres/telegraf_users.sls
+++ b/salt/postgres/telegraf_users.sls
@@ -65,10 +65,16 @@ postgres_telegraf_group_role:
         -- on first write of each metric, which needs USAGE on the partman
         -- schema, EXECUTE on its functions/procedures, and write access to
         -- partman.part_config so it can register new partitioned parents.
-        GRANT USAGE ON SCHEMA partman TO so_telegraf;
+        GRANT USAGE, CREATE ON SCHEMA partman TO so_telegraf;
         GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA partman TO so_telegraf;
         GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA partman TO so_telegraf;
         GRANT EXECUTE ON ALL PROCEDURES IN SCHEMA partman TO so_telegraf;
+        -- partman creates per-parent template tables (partman.template_*) at
+        -- runtime; default privileges extend DML/sequence access to them.
+        ALTER DEFAULT PRIVILEGES IN SCHEMA partman
+            GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO so_telegraf;
+        ALTER DEFAULT PRIVILEGES IN SCHEMA partman
+            GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO so_telegraf;
         -- Hourly partman maintenance. cron.schedule is idempotent by jobname.
         SELECT cron.schedule(
           'telegraf-partman-maintenance',

--- a/salt/postgres/telegraf_users.sls
+++ b/salt/postgres/telegraf_users.sls
@@ -61,6 +61,14 @@ postgres_telegraf_group_role:
         CREATE SCHEMA IF NOT EXISTS partman;
         CREATE EXTENSION IF NOT EXISTS pg_partman SCHEMA partman;
         CREATE EXTENSION IF NOT EXISTS pg_cron;
+        -- Telegraf (running as so_telegraf) calls partman.create_parent()
+        -- on first write of each metric, which needs USAGE on the partman
+        -- schema, EXECUTE on its functions/procedures, and write access to
+        -- partman.part_config so it can register new partitioned parents.
+        GRANT USAGE ON SCHEMA partman TO so_telegraf;
+        GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA partman TO so_telegraf;
+        GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA partman TO so_telegraf;
+        GRANT EXECUTE ON ALL PROCEDURES IN SCHEMA partman TO so_telegraf;
         -- Hourly partman maintenance. cron.schedule is idempotent by jobname.
         SELECT cron.schedule(
           'telegraf-partman-maintenance',

--- a/salt/postgres/telegraf_users.sls
+++ b/salt/postgres/telegraf_users.sls
@@ -34,10 +34,9 @@ postgres_wait_ready:
 postgres_create_telegraf_db:
   cmd.run:
     - name: |
-        docker exec -i so-postgres psql -v ON_ERROR_STOP=1 -U postgres -d postgres <<'EOSQL'
-        SELECT 'CREATE DATABASE so_telegraf'
-        WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'so_telegraf')\gexec
-        EOSQL
+        if ! docker exec so-postgres psql -U postgres -tAc "SELECT 1 FROM pg_database WHERE datname='so_telegraf'" | grep -q 1; then
+          docker exec so-postgres psql -v ON_ERROR_STOP=1 -U postgres -c "CREATE DATABASE so_telegraf"
+        fi
     - require:
       - cmd: postgres_wait_ready
 

--- a/salt/telegraf/etc/telegraf.conf
+++ b/salt/telegraf/etc/telegraf.conf
@@ -110,13 +110,13 @@
   # Every metric table is a daily time-range partitioned parent managed by
   # pg_partman. Retention drops old partitions instead of row-by-row DELETEs.
   {% raw %}
-  # pg_partman.create_parent() splits p_parent_table on '.' and looks the
-  # parts up as raw identifiers, so the string literal must be
-  # 'schema.name', NOT '"schema"."name"'. {{ .table|quoteLiteral }} would
-  # emit the double-quoted form and partman fails with "Unable to find
-  # given parent table in system catalogs."
+  # pg_partman 5.x requires the control column (time) to be NOT NULL, so
+  # ALTER it before create_parent(). And create_parent() splits
+  # p_parent_table on '.' to look up raw identifiers, so the literal must
+  # be 'schema.name' (not '"schema"."name"' as .table|quoteLiteral emits).
   create_templates = [
     '''CREATE TABLE {{ .table }} ({{ .columns }}) PARTITION BY RANGE ("time")''',
+    '''ALTER TABLE {{ .table }} ALTER COLUMN "time" SET NOT NULL''',
     '''SELECT partman.create_parent(p_parent_table := {{ printf "%s.%s" .table.Schema .table.Name | quoteLiteral }}, p_control := 'time', p_type := 'range', p_interval := '1 day', p_premake := 3)'''
   ]
   {% endraw %}

--- a/salt/telegraf/etc/telegraf.conf
+++ b/salt/telegraf/etc/telegraf.conf
@@ -109,10 +109,12 @@
   fields_as_jsonb = true
   # Every metric table is a daily time-range partitioned parent managed by
   # pg_partman. Retention drops old partitions instead of row-by-row DELETEs.
+  {% raw %}
   create_templates = [
     '''CREATE TABLE {{ .table }} ({{ .columns }}) PARTITION BY RANGE ("time")''',
     '''SELECT partman.create_parent(p_parent_table := {{ .table|quoteLiteral }}, p_control := 'time', p_type := 'range', p_interval := '1 day', p_premake := 3)'''
   ]
+  {% endraw %}
 {%- endif %}
 
 ###############################################################################

--- a/salt/telegraf/etc/telegraf.conf
+++ b/salt/telegraf/etc/telegraf.conf
@@ -110,9 +110,14 @@
   # Every metric table is a daily time-range partitioned parent managed by
   # pg_partman. Retention drops old partitions instead of row-by-row DELETEs.
   {% raw %}
+  # pg_partman.create_parent() splits p_parent_table on '.' and looks the
+  # parts up as raw identifiers, so the string literal must be
+  # 'schema.name', NOT '"schema"."name"'. {{ .table|quoteLiteral }} would
+  # emit the double-quoted form and partman fails with "Unable to find
+  # given parent table in system catalogs."
   create_templates = [
     '''CREATE TABLE {{ .table }} ({{ .columns }}) PARTITION BY RANGE ("time")''',
-    '''SELECT partman.create_parent(p_parent_table := {{ .table|quoteLiteral }}, p_control := 'time', p_type := 'range', p_interval := '1 day', p_premake := 3)'''
+    '''SELECT partman.create_parent(p_parent_table := {{ printf "%s.%s" .table.Schema .table.Name | quoteLiteral }}, p_control := 'time', p_type := 'range', p_interval := '1 day', p_premake := 3)'''
   ]
   {% endraw %}
 {%- endif %}

--- a/salt/telegraf/etc/telegraf.conf
+++ b/salt/telegraf/etc/telegraf.conf
@@ -114,10 +114,15 @@
   # ALTER it before create_parent(). And create_parent() splits
   # p_parent_table on '.' to look up raw identifiers, so the literal must
   # be 'schema.name' (not '"schema"."name"' as .table|quoteLiteral emits).
+  # IF NOT EXISTS keeps the three templates idempotent so a Telegraf
+  # restart after any DB-side surgery re-runs them safely.
   create_templates = [
-    '''CREATE TABLE {{ .table }} ({{ .columns }}) PARTITION BY RANGE ("time")''',
+    '''CREATE TABLE IF NOT EXISTS {{ .table }} ({{ .columns }}) PARTITION BY RANGE ("time")''',
     '''ALTER TABLE {{ .table }} ALTER COLUMN "time" SET NOT NULL''',
-    '''SELECT partman.create_parent(p_parent_table := {{ printf "%s.%s" .table.Schema .table.Name | quoteLiteral }}, p_control := 'time', p_type := 'range', p_interval := '1 day', p_premake := 3)'''
+    '''SELECT partman.create_parent(p_parent_table := {{ printf "%s.%s" .table.Schema .table.Name | quoteLiteral }}, p_control := 'time', p_type := 'range', p_interval := '1 day', p_premake := 3) WHERE NOT EXISTS (SELECT 1 FROM partman.part_config WHERE parent_table = {{ printf "%s.%s" .table.Schema .table.Name | quoteLiteral }})'''
+  ]
+  tag_table_create_templates = [
+    '''CREATE TABLE IF NOT EXISTS {{ .table }} ({{ .columns }}, PRIMARY KEY (tag_id))'''
   ]
   {% endraw %}
 {%- endif %}

--- a/salt/telegraf/etc/telegraf.conf
+++ b/salt/telegraf/etc/telegraf.conf
@@ -110,8 +110,8 @@
   # Every metric table is a daily time-range partitioned parent managed by
   # pg_partman. Retention drops old partitions instead of row-by-row DELETEs.
   create_templates = [
-    '''CREATE TABLE {TABLE} ({COLUMNS}) PARTITION BY RANGE ("time")''',
-    '''SELECT partman.create_parent(p_parent_table := {TABLELITERAL}, p_control := 'time', p_type := 'range', p_interval := '1 day', p_premake := 3)'''
+    '''CREATE TABLE {{ .table }} ({{ .columns }}) PARTITION BY RANGE ("time")''',
+    '''SELECT partman.create_parent(p_parent_table := {{ .table|quoteLiteral }}, p_control := 'time', p_type := 'range', p_interval := '1 day', p_premake := 3)'''
   ]
 {%- endif %}
 


### PR DESCRIPTION
## Summary
- **Telegraf template syntax**: The mainline `outputs.postgresql` plugin uses Go text/template (`{{ .table }}`, `{{ .columns }}`), not uppercase tokens like `{TABLE}`. Switched to the correct syntax and wrapped in `{% raw %}` so Jinja leaves it alone.
- **pg_partman 5.x compatibility**: `p_parent_table` is split on `.` and looked up as raw identifiers, so the literal must be `'schema.name'`, not `'"schema"."name"'`. Added `ALTER COLUMN "time" SET NOT NULL` before `create_parent()` (5.x requires the control column be NOT NULL).
- **Partman privileges**: Granted `so_telegraf` USAGE + CREATE on the partman schema, DML on its tables, EXECUTE on functions/procedures, and `ALTER DEFAULT PRIVILEGES` for the per-parent template tables partman creates at runtime.
- **Idempotent DB creation**: Replaced the fragile `\gexec`-guarded `CREATE DATABASE` (which occasionally duplicated on re-apply) with an explicit shell conditional in both `init-users.sh` and `telegraf_users.sls`.
- **Idempotent templates**: `CREATE TABLE IF NOT EXISTS`, a `WHERE NOT EXISTS` guard on `create_parent()`, and an explicit `tag_table_create_templates` with `IF NOT EXISTS` so a Telegraf restart after any manual DB surgery recovers cleanly.

## Test plan
- [ ] Fresh install populates all `telegraf.*` and `telegraf.*_tag` tables
- [ ] `SELECT parent_table FROM partman.part_config WHERE parent_table LIKE 'telegraf.%'` has rows for every metric
- [ ] `docker logs so-telegraf` shows no `permission denied for schema partman`, no `relation "telegraf.*_tag" does not exist`, no `critical column "time"`
- [ ] `so-stats-show` returns stats
- [ ] Re-apply is idempotent (no duplicate-key errors, no schema drift)