### PR TITLE
Wait for TCP-ready postgres, not the init-phase Unix socket

### DIFF
--- a/salt/postgres/telegraf_users.sls
+++ b/salt/postgres/telegraf_users.sls
@@ -11,19 +11,22 @@
 {% if TG_OUT in ['POSTGRES', 'BOTH'] %}
 
 # docker_container.running returns as soon as the container starts, but on
-# first-init docker-entrypoint.sh runs init scripts and then restarts
-# postgres, so the next docker exec can hit "the database system is shutting
-# down". Wait for pg_isready before any psql work.
+# first-init docker-entrypoint.sh starts a temporary postgres with
+# `listen_addresses=''` to run /docker-entrypoint-initdb.d scripts, then
+# shuts it down before exec'ing the real CMD. A default pg_isready check
+# (Unix socket) passes during that ephemeral phase and races the shutdown
+# with "the database system is shutting down". Checking TCP readiness on
+# 127.0.0.1 only succeeds after the final postgres binds the port.
 postgres_wait_ready:
   cmd.run:
     - name: |
         for i in $(seq 1 60); do
-          if docker exec so-postgres pg_isready -U postgres -q 2>/dev/null; then
+          if docker exec so-postgres pg_isready -h 127.0.0.1 -U postgres -q 2>/dev/null; then
             exit 0
           fi
           sleep 2
         done
-        echo "so-postgres did not become ready within 120s" >&2
+        echo "so-postgres did not accept TCP connections within 120s" >&2
         exit 1
     - require:
       - docker_container: so-postgres


### PR DESCRIPTION
## Summary
The prior `postgres_wait_ready` state used the default `pg_isready` (Unix socket) to gate downstream `psql` execs. On a fresh install, `docker-entrypoint.sh` starts a temporary postgres with `listen_addresses=''` to run the `/docker-entrypoint-initdb.d/*` scripts. That ephemeral phase makes the socket-based check pass, and Salt's next `docker exec ... psql` races the temp-server shutdown with `FATAL: the database system is shutting down`. Switch the probe to `pg_isready -h 127.0.0.1` so it only succeeds once the final postgres binds TCP.

## Test plan
- [ ] Fresh install (empty `/nsm/postgres`): `state.apply postgres` runs clean, setup log contains no `the database system is shutting down`
- [ ] Warm re-apply: `postgres_wait_ready` exits on the first iteration
- [ ] `docker restart so-postgres` then re-apply: readiness gate still holds