### PR TITLE
postgres follow-ups: fan manager cred + so-yaml.py replace fix

### DIFF
--- a/salt/manager/tools/sbin/so-yaml.py
+++ b/salt/manager/tools/sbin/so-yaml.py
@@ -285,7 +285,8 @@ def add(args):
 def removeKey(content, key):
     pieces = key.split(".", 1)
     if len(pieces) > 1:
-        removeKey(content[pieces[0]], pieces[1])
+        if pieces[0] in content:
+            removeKey(content[pieces[0]], pieces[1])
     else:
         content.pop(key, None)
 

--- a/salt/postgres/auth.sls
+++ b/salt/postgres/auth.sls
@@ -50,14 +50,27 @@ postgres_auth_pillar:
               {% endfor %}
     - show_changes: False
 
-  {# Fan a specific minion's telegraf cred out to its own pillar file. Only
-     runs when postgres_fanout_minion pillar is provided — otherwise this state
-     is a no-op. That keeps manager highstates from doing N so-yaml.py forks
-     when nothing changed. The reactor passes postgres_fanout_minion through
-     the orch on salt-key accept; soup handles bulk backfill separately. #}
+  {# Fan a specific minion's telegraf cred out to its own pillar file.
+     Two triggers populate the target list:
+       - grains.id (always) so the manager's own pillar is populated on every
+         postgres.auth run — otherwise the manager's telegraf has no cred on
+         a fresh install and can't write to its own postgres.
+       - pillar postgres_fanout_minion (when the reactor fires on a new
+         minion's salt-key accept).
+     The `unless` guard keeps re-runs idempotent, so this is one so-yaml.py
+     check per target, not per minion in the grid. Bulk backfill for
+     already-accepted minions lives in soup. #}
+  {% set fanout_targets = [] %}
+  {% if grains.id %}
+  {%-   do fanout_targets.append(grains.id) %}
+  {% endif %}
   {% set fanout_mid = salt['pillar.get']('postgres_fanout_minion') %}
-  {% if fanout_mid %}
-    {%- set safe = fanout_mid | replace('.','_') | replace('-','_') | lower %}
+  {% if fanout_mid and fanout_mid not in fanout_targets %}
+  {%-   do fanout_targets.append(fanout_mid) %}
+  {% endif %}
+
+  {% for mid in fanout_targets %}
+    {%- set safe = mid | replace('.','_') | replace('-','_') | lower %}
     {%- set key = 'telegraf_' ~ safe %}
     {%- set entry = telegraf_users.get(key) %}
     {%- if entry %}
@@ -66,7 +79,7 @@ postgres_telegraf_minion_pillar_{{ safe }}:
   cmd.run:
     - name: |
         set -e
-        PILLAR_FILE=/opt/so/saltstack/local/pillar/minions/{{ fanout_mid }}.sls
+        PILLAR_FILE=/opt/so/saltstack/local/pillar/minions/{{ mid }}.sls
         if [ ! -f "$PILLAR_FILE" ]; then
           echo '{}' > "$PILLAR_FILE"
           chown socore:socore "$PILLAR_FILE" 2>/dev/null || true
@@ -75,12 +88,12 @@ postgres_telegraf_minion_pillar_{{ safe }}:
         /usr/sbin/so-yaml.py replace "$PILLAR_FILE" postgres.telegraf.user '{{ entry.user }}'
         /usr/sbin/so-yaml.py replace "$PILLAR_FILE" postgres.telegraf.pass '{{ entry.pass }}'
     - unless: |
-        [ "$(/usr/sbin/so-yaml.py get -r /opt/so/saltstack/local/pillar/minions/{{ fanout_mid }}.sls postgres.telegraf.user 2>/dev/null)" = '{{ entry.user }}' ]
+        [ "$(/usr/sbin/so-yaml.py get -r /opt/so/saltstack/local/pillar/minions/{{ mid }}.sls postgres.telegraf.user 2>/dev/null)" = '{{ entry.user }}' ]
     - require:
       - file: postgres_auth_pillar
 
     {%- endif %}
-  {% endif %}
+  {% endfor %}
 {% else %}
 
 {{sls}}_state_not_allowed:

--- a/salt/telegraf/etc/telegraf.conf
+++ b/salt/telegraf/etc/telegraf.conf
@@ -96,7 +96,7 @@
   # insecure_skip_verify = false
 {%- endif %}
 
-{%- if TG_OUT in ['POSTGRES', 'BOTH'] %}
+{%- if TG_OUT in ['POSTGRES', 'BOTH'] and PG_USER and PG_PASS %}
 # Configuration for sending metrics to PostgreSQL.
 # options='-c role=so_telegraf' makes every connection SET ROLE to the shared
 # group role so tables created on first write are owned by so_telegraf, and


### PR DESCRIPTION
## Summary

Two follow-up fixes since the last bravo sync, needed for automated testing against the postgres feature:

- **Fan postgres telegraf cred for the manager on every auth run** (`d5dc28e52`).
  The reactor path only fans a minion's pillar when `salt-key -a` fires, which never happens for the manager itself. On a fresh install the manager's telegraf.conf was rendering `user= password=` (libpq then parses `password=` as the user, causing `FATAL: password authentication failed for user "password="`).
  - `salt/postgres/auth.sls`: add `grains.id` to the fan-out target list so the manager's own `postgres.telegraf.*` pillar is populated on every `postgres.auth` run.
  - `salt/telegraf/etc/telegraf.conf`: gate the `[[outputs.postgresql]]` block on `PG_USER` and `PG_PASS` being non-empty — if a minion hasn't received its pillar yet, skip the block so telegraf still runs the other outputs instead of erroring on a malformed connection string.

- **so-yaml.py: tolerate missing ancestors in removeKey** (`81c0f2b46`).
  `so-yaml.py replace` unconditionally calls `removeKey` before `addKey`, so running `replace` on a brand-new nested key whose parent doesn't exist (e.g. fanning `postgres.telegraf.user` into a minion pillar that has never had a `postgres` section) crashed with `KeyError: 'postgres'`. Made `removeKey` a no-op for missing ancestors, giving `remove` proper "remove-if-exists" semantics and letting `replace` work on new nested keys.

## Test plan

- [ ] `salt-call state.apply postgres.auth` on the manager populates `/opt/so/saltstack/local/pillar/minions/<manager_id>.sls` with `postgres.telegraf.{user,pass}` (verify `sudo salt-call pillar.get postgres:telegraf`).
- [ ] Next `salt-call state.apply telegraf` rerenders `/opt/so/conf/telegraf/etc/telegraf.conf` with a populated `[[outputs.postgresql]]` block.
- [ ] `sudo docker logs so-telegraf` no longer shows `password authentication failed for user "password="`.
- [ ] After ~1 minute, `sudo so-stats-show` returns CPU/memory/disk/load for the manager.
- [ ] Accepting a new minion still fans that minion's cred via the reactor path.