### PR TITLE
so-telegraf-cred: make executable and harden error handling

### DIFF
--- a/salt/manager/tools/sbin/so-telegraf-cred
+++ b/salt/manager/tools/sbin/so-telegraf-cred
@@ -21,11 +21,11 @@ usage() {
 }
 
 seed_creds_file() {
-    mkdir -p "$(dirname "$CREDS")"
+    mkdir -p "$(dirname "$CREDS")" || return 1
     if [[ ! -f "$CREDS" ]]; then
-        (umask 027 && printf 'telegraf:\n  postgres_creds: {}\n' > "$CREDS")
+        (umask 027 && printf 'telegraf:\n  postgres_creds: {}\n' > "$CREDS") || return 1
         chown socore:socore "$CREDS" 2>/dev/null || true
-        chmod 640 "$CREDS"
+        chmod 640 "$CREDS" || return 1
     fi
 }
 
@@ -36,7 +36,7 @@ MID=$2
 case "$OP" in
     add)
         SAFE=$(echo "$MID" | tr '.-' '__' | tr '[:upper:]' '[:lower:]')
-        seed_creds_file
+        seed_creds_file || exit 1
         if so-yaml.py get -r "$CREDS" "telegraf.postgres_creds.${MID}.user" >/dev/null 2>&1; then
             exit 0
         fi

--- a/salt/manager/tools/sbin/so-yaml.py
+++ b/salt/manager/tools/sbin/so-yaml.py
@@ -39,9 +39,16 @@ def showUsage(args):
 
 
 def loadYaml(filename):
-    file = open(filename, "r")
-    content = file.read()
-    return yaml.safe_load(content)
+    try:
+        with open(filename, "r") as file:
+            content = file.read()
+            return yaml.safe_load(content)
+    except FileNotFoundError:
+        print(f"File not found: {filename}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error reading file {filename}: {e}", file=sys.stderr)
+        sys.exit(1)
 
 
 def writeYaml(filename, content):

--- a/salt/manager/tools/sbin/so-yaml_test.py
+++ b/salt/manager/tools/sbin/so-yaml_test.py
@@ -973,3 +973,21 @@ class TestReplaceListObject(unittest.TestCase):
 
         expected = "key1:\n- id: '1'\n  status: updated\n- id: '2'\n  status: inactive\n"
         self.assertEqual(actual, expected)
+
+
+class TestLoadYaml(unittest.TestCase):
+
+    def test_load_yaml_missing_file(self):
+        with patch('sys.exit', new=MagicMock()) as sysmock:
+            with patch('sys.stderr', new=StringIO()) as mock_stderr:
+                soyaml.loadYaml("/tmp/so-yaml_test-does-not-exist.yaml")
+                sysmock.assert_called_with(1)
+                self.assertIn("File not found:", mock_stderr.getvalue())
+
+    def test_load_yaml_read_error(self):
+        with patch('sys.exit', new=MagicMock()) as sysmock:
+            with patch('sys.stderr', new=StringIO()) as mock_stderr:
+                with patch('builtins.open', side_effect=PermissionError("denied")):
+                    soyaml.loadYaml("/tmp/so-yaml_test-unreadable.yaml")
+                    sysmock.assert_called_with(1)
+                    self.assertIn("Error reading file", mock_stderr.getvalue())


### PR DESCRIPTION
## Summary
- Mark `salt/manager/tools/sbin/so-telegraf-cred` executable (was 644). Without the execute bit, `so-telegraf-cred add "$MINION_ID"` in `so-minion`'s `add_telegraf_to_minion` fails with "Permission denied" and logs `Failed to provision postgres telegraf cred for <minion>`.
- Bail early in `seed_creds_file` if `mkdir`/`printf`/`chmod` fail, and replace the stray `return 1` (at script scope) with `exit 1`.
- In `so-yaml.py`, use a `with` block in `loadYaml` and surface a clear stderr message with the filename on `FileNotFoundError`/other read errors instead of an unhandled traceback.

## Test plan
- [ ] Run `so-minion add` for a manager/standalone and confirm no "Failed to provision postgres telegraf cred" error
- [ ] Verify `/opt/so/saltstack/local/pillar/telegraf/creds.sls` is created with mode 640, owner socore:socore, and contains `telegraf.postgres_creds.<minion>.user` / `.pass`
- [ ] Re-run `so-telegraf-cred add <minion>` and confirm it is a no-op (cred stable)
- [ ] `so-telegraf-cred remove <minion>` clears the entry