### PR TITLE
soup: bootstrap postgres pillar stubs and secret on 3.0.0 upgrade

### DIFF
--- a/salt/manager/tools/sbin/soup
+++ b/salt/manager/tools/sbin/soup
@@ -477,7 +477,44 @@ elasticsearch_backup_index_templates() {
   tar -czf /nsm/backup/3.0.0_elasticsearch_index_templates.tar.gz -C /opt/so/conf/elasticsearch/templates/index/ .
 }
 
+ensure_postgres_local_pillar() {
+  # Postgres was added as a service after 3.0.0, so the new pillar/top.sls
+  # references postgres.soc_postgres / postgres.adv_postgres unconditionally.
+  # Managers upgrading from 3.0.0 have no /opt/so/saltstack/local/pillar/postgres/
+  # (make_some_dirs only runs at install time), so the stubs must be created
+  # here before salt-master restarts against the new top.sls.
+  echo "Ensuring postgres local pillar stubs exist."
+  local dir=/opt/so/saltstack/local/pillar/postgres
+  mkdir -p "$dir"
+  [[ -f "$dir/soc_postgres.sls" ]] || touch "$dir/soc_postgres.sls"
+  [[ -f "$dir/adv_postgres.sls" ]] || touch "$dir/adv_postgres.sls"
+  chown -R socore:socore "$dir"
+}
+
+ensure_postgres_secret() {
+  # On a fresh install, generate_passwords + secrets_pillar seed
+  # secrets:postgres_pass in /opt/so/saltstack/local/pillar/secrets.sls. That
+  # code path is skipped on upgrade (secrets.sls already exists from 3.0.0
+  # with import_pass/influx_pass but no postgres_pass), so the postgres
+  # container's POSTGRES_PASSWORD_FILE and SOC's PG_ADMIN_PASS would be empty
+  # after highstate. Generate one now if missing.
+  local secrets_file=/opt/so/saltstack/local/pillar/secrets.sls
+  if [[ ! -f "$secrets_file" ]]; then
+    echo "WARNING: $secrets_file missing; skipping postgres_pass backfill."
+    return 0
+  fi
+  if so-yaml.py get -r "$secrets_file" secrets.postgres_pass >/dev/null 2>&1; then
+    echo "secrets.postgres_pass already set; leaving as-is."
+    return 0
+  fi
+  echo "Seeding secrets.postgres_pass in $secrets_file."
+  so-yaml.py add "$secrets_file" secrets.postgres_pass "$(get_random_value)"
+  chown socore:socore "$secrets_file"
+}
+
 up_to_3.1.0() {
+  ensure_postgres_local_pillar
+  ensure_postgres_secret
   determine_elastic_agent_upgrade
   elasticsearch_backup_index_templates
   # Clear existing component template state file.


### PR DESCRIPTION
## Summary
- Adds `ensure_postgres_local_pillar` and `ensure_postgres_secret` helpers to `up_to_3.1.0()` in `soup` so managers upgrading from 3.0.0 don't hit a pillar render failure or end up with an empty postgres super-user password.
- `pillar/top.sls` now references `postgres.soc_postgres` / `postgres.adv_postgres` unconditionally, but `make_some_dirs` only runs at install time — on a 3.0.0 install the local pillar tree has no `postgres/` dir, so salt-master fails `state.show_top` immediately after `copy_new_files` + `masterlock` + restart.
- `secrets_pillar` is also a no-op on upgrade (`secrets.sls` already exists from 3.0.0 with `import_pass`/`influx_pass`), so `secrets:postgres_pass` never gets seeded; the postgres container's `POSTGRES_PASSWORD_FILE` and SOC's `PG_ADMIN_PASS` would be empty after highstate.
- Both helpers are idempotent and run before `masterlock`, mirroring the `make_some_dirs` / `secrets_pillar` patterns from install. `so-yaml.py` is used for the secret backfill per repo convention.

## Test plan
- [ ] On a 3.0.0 manager with no `/opt/so/saltstack/local/pillar/postgres/` and no `secrets:postgres_pass` in `secrets.sls`, run `soup`. Confirm the salt-master readiness loop passes on the first try (no `postgres.soc_postgres not available` errors) and `check_pillar_items` reports clean.
- [ ] After soup, verify `/opt/so/saltstack/local/pillar/postgres/{soc_postgres.sls,adv_postgres.sls}` exist, are empty, and are owned by `socore:socore`.
- [ ] Verify `so-yaml.py get -r /opt/so/saltstack/local/pillar/secrets.sls secrets.postgres_pass` returns a non-empty 20-char alnum value and that `/opt/so/conf/postgres/secrets/postgres_password` matches it after highstate.
- [ ] Confirm the postgres container starts cleanly and SOC connects with `postgres` admin credentials.
- [ ] Regression: on a manager where `postgres_pass` is already set in `secrets.sls`, re-running `up_to_3.1.0` leaves the existing value untouched (`ensure_postgres_secret` short-circuits).
- [ ] Regression: re-running `ensure_postgres_local_pillar` when the dir + stubs already exist is a no-op and preserves any user-added content in the `.sls` files.