### PR TITLE
soup: drop --local from postgres.telegraf_users reconcile

### DIFF
--- a/salt/manager/tools/sbin/soup
+++ b/salt/manager/tools/sbin/soup
@@ -536,7 +536,10 @@ post_to_3.1.0() {
     [[ -n "$mid" ]] || continue
     /usr/sbin/so-telegraf-cred add "$mid" || echo "  warning: so-telegraf-cred add $mid failed" >&2
   done
-  salt-call --local state.apply postgres.telegraf_users queue=True || true
+  # Run through the master (not --local) so state compilation uses the
+  # master's configured file_roots; the manager's /etc/salt/minion has no
+  # file_roots of its own and --local would fail with "No matching sls found".
+  salt-call state.apply postgres.telegraf_users queue=True || true
 
   POSTVERSION=3.1.0
 }


### PR DESCRIPTION
## Summary
- `post_to_3.1.0` runs `salt-call --local state.apply postgres.telegraf_users` to create DB roles for the Telegraf pillars just populated by the `so-telegraf-cred add` backfill loop.
- The manager's `/etc/salt/minion` (written by `so-functions:configure_minion`) has no `file_roots`, so `--local` falls back to Salt's default `/srv/salt` and fails with `No matching sls found for 'postgres.telegraf_users' in env 'base'`.
- `|| true` was silently swallowing the error, so the per-minion DB roles never actually got created during soup — Telegraf on each minion would then fail to authenticate to Postgres.
- Dropping `--local` routes state compilation through salt-master, whose `file_roots` already points at the default/local salt trees. This matches the pattern used at `soup:1335` (`salt-call state.apply salt.minion`).

## Test plan
- [ ] On a manager with accepted minions and empty per-minion Telegraf pillar entries, run soup. Confirm `salt-call state.apply postgres.telegraf_users` in `post_to_3.1.0` succeeds with no "No matching sls found" error.
- [ ] After soup, connect to Postgres as admin and verify a `so_telegraf_<minion_id>` role exists for each accepted minion.
- [ ] On each minion, verify Telegraf can authenticate to Postgres (no auth failures in `/opt/so/log/telegraf/telegraf.log` or equivalent).
- [ ] Re-running soup (or just `salt-call state.apply postgres.telegraf_users queue=True`) on the manager is idempotent.