### PR TITLE
drop postgres module from soc defaults injection

### DIFF
--- a/salt/soc/defaults.map.jinja
+++ b/salt/soc/defaults.map.jinja
@@ -24,11 +24,6 @@
 
 {% do SOCDEFAULTS.soc.config.server.modules.elastic.update({'username': GLOBALS.elasticsearch.auth.users.so_elastic_user.user, 'password': GLOBALS.elasticsearch.auth.users.so_elastic_user.pass}) %}
 
-{% if GLOBALS.postgres is defined and GLOBALS.postgres.auth is defined %}
-{%   set PG_ADMIN_PASS = salt['pillar.get']('secrets:postgres_pass', '') %}
-{% do SOCDEFAULTS.soc.config.server.modules.update({'postgres': {'hostUrl': GLOBALS.manager_ip, 'port': 5432, 'username': GLOBALS.postgres.auth.users.so_postgres_user.user, 'password': GLOBALS.postgres.auth.users.so_postgres_user.pass, 'adminUser': 'postgres', 'adminPassword': PG_ADMIN_PASS, 'dbname': 'securityonion', 'sslMode': 'require', 'assistantEnabled': true, 'esHostUrl': 'https://' ~ GLOBALS.manager_ip ~ ':9200', 'esUsername': GLOBALS.elasticsearch.auth.users.so_elastic_user.user, 'esPassword': GLOBALS.elasticsearch.auth.users.so_elastic_user.pass, 'esVerifyCert': false}}) %}
-{% endif %}
-
 {% do SOCDEFAULTS.soc.config.server.modules.influxdb.update({'hostUrl': 'https://' ~ GLOBALS.influxdb_host ~ ':8086'}) %}
 {% do SOCDEFAULTS.soc.config.server.modules.influxdb.update({'token': INFLUXDB_TOKEN}) %}
 {% for tool in SOCDEFAULTS.soc.config.server.client.tools %}


### PR DESCRIPTION
## Summary

- The soc binary on `3/dev` does not register a `postgres` module yet, so the jinja injection in `salt/soc/defaults.map.jinja` causes soc to abort at launch with `Module does not exist: postgres` / `Aborting module launch due to initialization error`.
- The soc-side postgres module is staged on `feature/postgres` (`server/modules/postgres/`, registered in `server/modules/modules.go`) but is not landing this release.
- Drop the injection block (5 lines) so soc's modules map no longer references `postgres`. The `salt/postgres/` state, pillars, and `top.sls` includes are intentionally unchanged — the postgres container still provisions; only the soc-side module-config injection is removed.

## Test plan

- [ ] Run a highstate on a manager (or refresh soc config and restart the soc container).
- [ ] Confirm soc starts cleanly and `journalctl -u so-soc` (or container logs) no longer contain `Module does not exist: postgres`.
- [ ] Confirm soc web UI loads and other modules (elastic, influxdb, cases, etc.) come up as before.