### PR TITLE
Open postgres in DOCKER-USER firewall everywhere influxdb is open

### DIFF
--- a/salt/firewall/defaults.yaml
+++ b/salt/firewall/defaults.yaml
@@ -398,6 +398,7 @@ firewall:
                 - elasticsearch_rest
                 - docker_registry
                 - influxdb
+                - postgres
                 - sensoroni
                 - yum
                 - beats_5044
@@ -410,6 +411,7 @@ firewall:
               portgroups:
                 - docker_registry
                 - influxdb
+                - postgres
                 - sensoroni
                 - yum
                 - beats_5044
@@ -427,6 +429,7 @@ firewall:
                 - yum
                 - docker_registry
                 - influxdb
+                - postgres
                 - sensoroni
             searchnode:
               portgroups:
@@ -437,6 +440,7 @@ firewall:
                 - yum
                 - docker_registry
                 - influxdb
+                - postgres
                 - elastic_agent_control
                 - elastic_agent_data
                 - elastic_agent_update
@@ -450,6 +454,7 @@ firewall:
                 - yum
                 - docker_registry
                 - influxdb
+                - postgres
                 - elastic_agent_control
                 - elastic_agent_data
                 - elastic_agent_update
@@ -459,6 +464,7 @@ firewall:
                 - yum
                 - docker_registry
                 - influxdb
+                - postgres
                 - elastic_agent_control
                 - elastic_agent_data
                 - elastic_agent_update
@@ -492,6 +498,7 @@ firewall:
               portgroups:
                 - docker_registry
                 - influxdb
+                - postgres
                 - sensoroni
                 - yum
                 - elastic_agent_control
@@ -502,6 +509,7 @@ firewall:
                 - yum
                 - docker_registry
                 - influxdb
+                - postgres
                 - elastic_agent_control
                 - elastic_agent_data
                 - elastic_agent_update
@@ -610,6 +618,7 @@ firewall:
                 - elasticsearch_rest
                 - docker_registry
                 - influxdb
+                - postgres
                 - sensoroni
                 - yum
                 - beats_5044
@@ -622,6 +631,7 @@ firewall:
               portgroups:
                 - docker_registry
                 - influxdb
+                - postgres
                 - sensoroni
                 - yum
                 - beats_5044
@@ -639,6 +649,7 @@ firewall:
                 - yum
                 - docker_registry
                 - influxdb
+                - postgres
                 - sensoroni
             searchnode:
               portgroups:
@@ -649,6 +660,7 @@ firewall:
                 - yum
                 - docker_registry
                 - influxdb
+                - postgres
                 - elastic_agent_control
                 - elastic_agent_data
                 - elastic_agent_update
@@ -662,6 +674,7 @@ firewall:
                 - yum
                 - docker_registry
                 - influxdb
+                - postgres
                 - elastic_agent_control
                 - elastic_agent_data
                 - elastic_agent_update
@@ -671,6 +684,7 @@ firewall:
                 - yum
                 - docker_registry
                 - influxdb
+                - postgres
                 - elastic_agent_control
                 - elastic_agent_data
                 - elastic_agent_update
@@ -702,6 +716,7 @@ firewall:
               portgroups:
                 - docker_registry
                 - influxdb
+                - postgres
                 - sensoroni
                 - yum
                 - elastic_agent_control
@@ -712,6 +727,7 @@ firewall:
                 - yum
                 - docker_registry
                 - influxdb
+                - postgres
                 - elastic_agent_control
                 - elastic_agent_data
                 - elastic_agent_update
@@ -820,6 +836,7 @@ firewall:
                 - elasticsearch_rest
                 - docker_registry
                 - influxdb
+                - postgres
                 - sensoroni
                 - yum
                 - beats_5044
@@ -832,6 +849,7 @@ firewall:
               portgroups:
                 - docker_registry
                 - influxdb
+                - postgres
                 - sensoroni
                 - yum
                 - beats_5044
@@ -849,6 +867,7 @@ firewall:
                 - yum
                 - docker_registry
                 - influxdb
+                - postgres
                 - sensoroni
             searchnode:
               portgroups:
@@ -858,6 +877,7 @@ firewall:
                 - yum
                 - docker_registry
                 - influxdb
+                - postgres
                 - elastic_agent_control
                 - elastic_agent_data
                 - elastic_agent_update
@@ -870,6 +890,7 @@ firewall:
                 - yum
                 - docker_registry
                 - influxdb
+                - postgres
                 - elastic_agent_control
                 - elastic_agent_data
                 - elastic_agent_update
@@ -879,6 +900,7 @@ firewall:
                 - yum
                 - docker_registry
                 - influxdb
+                - postgres
                 - elastic_agent_control
                 - elastic_agent_data
                 - elastic_agent_update
@@ -912,6 +934,7 @@ firewall:
               portgroups:
                 - docker_registry
                 - influxdb
+                - postgres
                 - sensoroni
                 - yum
                 - elastic_agent_control
@@ -922,6 +945,7 @@ firewall:
                 - yum
                 - docker_registry
                 - influxdb
+                - postgres
                 - elastic_agent_control
                 - elastic_agent_data
                 - elastic_agent_update
@@ -1040,6 +1064,7 @@ firewall:
                 - elasticsearch_rest
                 - docker_registry
                 - influxdb
+                - postgres
                 - sensoroni
                 - yum
                 - beats_5044
@@ -1052,6 +1077,7 @@ firewall:
               portgroups:
                 - docker_registry
                 - influxdb
+                - postgres
                 - sensoroni
                 - yum
                 - beats_5044
@@ -1063,6 +1089,7 @@ firewall:
               portgroups:
                 - docker_registry
                 - influxdb
+                - postgres
                 - sensoroni
                 - yum
                 - beats_5044
@@ -1074,6 +1101,7 @@ firewall:
               portgroups:
                 - docker_registry
                 - influxdb
+                - postgres
                 - sensoroni
                 - yum
                 - redis
@@ -1083,6 +1111,7 @@ firewall:
               portgroups:
                 - docker_registry
                 - influxdb
+                - postgres
                 - sensoroni
                 - yum
                 - redis
@@ -1093,6 +1122,7 @@ firewall:
                 - yum
                 - docker_registry
                 - influxdb
+                - postgres
                 - elastic_agent_control
                 - elastic_agent_data
                 - elastic_agent_update
@@ -1129,6 +1159,7 @@ firewall:
               portgroups:
                 - docker_registry
                 - influxdb
+                - postgres
                 - sensoroni
                 - yum
                 - elastic_agent_control
@@ -1139,6 +1170,7 @@ firewall:
                 - yum
                 - docker_registry
                 - influxdb
+                - postgres
                 - elastic_agent_control
                 - elastic_agent_data
                 - elastic_agent_update

--- a/salt/firewall/defaults.yaml
+++ b/salt/firewall/defaults.yaml
@@ -1482,6 +1482,7 @@ firewall:
                 - kibana
                 - redis
                 - influxdb
+                - postgres
                 - elasticsearch_rest
                 - elasticsearch_node
                 - elastic_agent_control

--- a/salt/firewall/map.jinja
+++ b/salt/firewall/map.jinja
@@ -1,6 +1,5 @@
 {% from 'vars/globals.map.jinja' import GLOBALS %}
 {% from 'docker/docker.map.jinja' import DOCKERMERGED %}
-{% from 'telegraf/map.jinja' import TELEGRAFMERGED %}
 {% import_yaml 'firewall/defaults.yaml' as FIREWALL_DEFAULT %}
 
 {# add our ip to self #}
@@ -54,18 +53,6 @@
 {%     endif %}
 {%   endif %}
 
-{% endif %}
-
-{# Open Postgres (5432) to minion hostgroups when Telegraf is configured to write to Postgres #}
-{% set TG_OUT = TELEGRAFMERGED.output | upper %}
-{% if TG_OUT in ['POSTGRES', 'BOTH'] %}
-{%   if role.startswith('manager') or role == 'standalone' or role == 'eval' %}
-{%     for r in ['sensor', 'searchnode', 'heavynode', 'receiver', 'fleet', 'idh', 'desktop', 'import'] %}
-{%       if FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups[r] is defined %}
-{%         do FIREWALL_DEFAULT.firewall.role[role].chain["DOCKER-USER"].hostgroups[r].portgroups.append('postgres') %}
-{%       endif %}
-{%     endfor %}
-{%   endif %}
 {% endif %}
 
 {% set FIREWALL_MERGED = salt['pillar.get']('firewall', FIREWALL_DEFAULT.firewall, merge=True) %}


### PR DESCRIPTION
## Summary
- Static firewall defaults only listed `postgres` on each role's self-hostgroup. Distributed sensor/searchnode/heavynode/receiver/fleet/idh/desktop/hypervisor hostgroups had no path to the manager's so-postgres at all.
- A dynamic block in `salt/firewall/map.jinja` added `postgres` to those hostgroups only when `telegraf.output` was switched to `POSTGRES`/`BOTH`. Result: postgres was unreachable by default for every distributed deployment, plus the import all-in-one (which doesn't go through that branch at all).
- Mirror `influxdb` statically across `manager` / `managerhype` / `managersearch` / `standalone` (and the previously-missed `import`) on every hostgroup that already lists `influxdb`. Drop the now-redundant Telegraf-gated dynamic block from `firewall/map.jinja`.

## Audit
After this change, every `(role, hostgroup)` combo that lists `influxdb` also lists `postgres`. Verified with awk parity scan over `salt/firewall/defaults.yaml`.

## Test plan
- [ ] Fresh-install an import node — `iptables -L DOCKER-USER -n | grep 5432` shows the rule, soc/kratos connect to postgres without errors
- [ ] Fresh-install a distributed manager + sensor — sensor's Telegraf can reach manager's postgres on 5432 without flipping `telegraf.output`
- [ ] Fresh-install a managersearch + searchnode — same check from searchnode
- [ ] Highstate is clean across all manager-class roles (no jinja errors after dropping `TELEGRAFMERGED` import from `map.jinja`)