### PR TITLE
Ensure python3-pyyaml is installed before continuing setup

### DIFF
--- a/setup/so-functions
+++ b/setup/so-functions
@@ -1701,6 +1701,24 @@ remove_package() {
 	fi
 }
 
+ensure_pyyaml() {
+	title "Ensuring python3-pyyaml is installed"
+	if rpm -q python3-pyyaml >/dev/null 2>&1; then
+		info "python3-pyyaml already installed"
+		return 0
+	fi
+	info "python3-pyyaml not found, attempting to install"
+	set -o pipefail
+	dnf -y install python3-pyyaml 2>&1 | tee -a "$setup_log"
+	local result=$?
+	set +o pipefail
+	if [[ $result -ne 0 ]] || ! rpm -q python3-pyyaml >/dev/null 2>&1; then
+		error "Failed to install python3-pyyaml (exit=$result)"
+		fail_setup
+	fi
+	info "python3-pyyaml installed successfully"
+}
+
 # When updating the salt version, also update the version in securityonion-builds/images/iso-task/Dockerfile and salt/salt/master.defaults.yaml and salt/salt/minion.defaults.yaml
 # CAUTION! SALT VERSION UDDATES - READ BELOW
 # When updating the salt version, also update the version in:

--- a/setup/so-setup
+++ b/setup/so-setup
@@ -66,6 +66,9 @@ set_timezone
 # Let's see what OS we are dealing with here
 detect_os
 
+# Ensure python3-pyyaml is available before any code that may need so-yaml/PyYAML
+ensure_pyyaml
+
 
 # Check to see if this is the setup type of "desktop".
 is_desktop=


### PR DESCRIPTION
## Summary
- Add `ensure_pyyaml()` helper in `setup/so-functions` that checks for `python3-pyyaml` via `rpm -q` and attempts `dnf -y install python3-pyyaml` if missing, capturing the real exit status (mirrors the `set -o pipefail` pattern already used in `verify_setup`).
- Call `ensure_pyyaml` in `setup/so-setup` immediately after `detect_os`, so the package is guaranteed to be present before any code that relies on `so-yaml.py` runs and before `securityonion_repo` strips out the default Oracle Linux 9 repos.
- Fail setup (`fail_setup`) if the package is still missing after the install attempt.

## Why
`salt/manager/tools/sbin/so-yaml.py` (and the project convention "When manipulating pillars in code, always use so-yaml") requires PyYAML at runtime. Today, `python3-pyyaml` is only installed via `salt/common/packages.sls`, which doesn't apply until salt is bootstrapped and a state run completes. This change makes the package an explicit early prerequisite of so-setup.

## Test plan
- [x] On an OL9 system with `python3-pyyaml` already installed, run `so-setup` and confirm the log shows `python3-pyyaml already installed`.
- [x] Remove the package on a fresh OL9 VM with default repos, run `so-setup`, and confirm the install branch runs and setup proceeds.
- [x] Simulate an install failure (disable default repos and remove the package), run `so-setup`, and confirm `fail_setup` is invoked and `/root/failure` is touched.
- [x] ISO / airgap install: confirm the package is already present (baked in by `packages.sls` at image build) so the helper is a no-op.
- [x] Reinstall path (`/root/accept_changes` exists): confirm helper runs once and is a no-op.
- [x] `bash -n setup/so-setup setup/so-functions` passes.