### PR TITLE
use -verify flag during grid agent install to ensure agent health

### DIFF
--- a/salt/elasticfleet/install_agent_grid.sls
+++ b/salt/elasticfleet/install_agent_grid.sls
@@ -14,20 +14,23 @@
 
 pull_agent_installer:
   file.managed:
-    - name: /opt/so/so-elastic-agent_linux_amd64
+    - name: /opt/so/log/agents/so-elastic-agent_linux_amd64
     - source: salt://elasticfleet/files/so_agent-installers/so-elastic-agent_linux_amd64
     - mode: 755
     - makedirs: True
 
 run_installer:
   cmd.run:
-    - name: ./so-elastic-agent_linux_amd64 -token={{ GRIDNODETOKEN }} -force
-    - cwd: /opt/so
+    {# Run agent installer and wait for it to report healthy status #}
+    - name: ./so-elastic-agent_linux_amd64 -token={{ GRIDNODETOKEN }} -force -verify
+    - cwd: /opt/so/log/agents
     - retry:
         attempts: 3
         interval: 20
+    - require:
+      - file: pull_agent_installer
 
 cleanup_agent_installer:
   file.absent:
-    - name: /opt/so/so-elastic-agent_linux_amd64
+    - name: /opt/so/log/agents/so-elastic-agent_linux_amd64
 {% endif %}


### PR DESCRIPTION
Installed agent passing health check
```
          ID: run_installer
    Function: cmd.run
        Name: ./so-elastic-agent_linux_amd64 -token=YkZXSXNKWUJ3ZzFrNVNlcHdiRXk6R2lGWHcyMDlTYkNBOWpDNThBeHVDZw== -force -verify
      Result: True
     Comment: Command "./so-elastic-agent_linux_amd64 -token=YkZXSXNKWUJ3ZzFrNVNlcHdiRXk6R2lGWHcyMDlTYkNBOWpDNThBeHVDZw== -force -verify" run
     Started: 22:53:13.596531
    Duration: 12402.262 ms
     Changes:   
              ----------
              pid:
                  3894294
              retcode:
                  0
              stderr:
              stdout:
                  
                  Installation initiated, view install log for further details.
                  
                  
                  Installation completed successfully.
```

Installed agent failing health check results in state failing (after retries) 
```
          ID: run_installer
    Function: cmd.run
        Name: ./so-elastic-agent_linux_amd64 -token=YkZXSXNKWUJ3ZzFrNVNlcHdiRXk6R2lGWHcyMDlTYkNBOWpDNThBeHVDZw== -force -verify
      Result: False
     Comment: Attempt 1: Returned a result of "False", with the following comment: "Command "./so-elastic-agent_linux_amd64 -token=YkZXSXNKWUJ3ZzFrNVNlcHdiRXk6R2lGWHcyMDlTYkNBOWpDNThBeHVDZw== -force -verify" run"
              Attempt 2: Returned a result of "False", with the following comment: "Command "./so-elastic-agent_linux_amd64 -token=YkZXSXNKWUJ3ZzFrNVNlcHdiRXk6R2lGWHcyMDlTYkNBOWpDNThBeHVDZw== -force -verify" run"
              Command "./so-elastic-agent_linux_amd64 -token=YkZXSXNKWUJ3ZzFrNVNlcHdiRXk6R2lGWHcyMDlTYkNBOWpDNThBeHVDZw== -force -verify" run
     Started: 22:48:54.495178
    Duration: 112321.369 ms
     Changes:   
              ----------
              pid:
                  3887864
              retcode:
                  1
              stderr:
                  
                  
                  Installed Elastic Agent did not report healthy status within the verification timeout: timed out waiting for Elastic Agent to become healthy: ┌─ fleet
                  │  └─ status: (HEALTHY) Connected
                  └─ elastic-agent
                     └─ status: (STARTING) Waiting for initial configuration and composable variables
              stdout:
                  
                  Installation initiated, view install log for further details.

```