### PR TITLE
Make so-postgres-backup fail-safe against silent corruption

### DIFF
--- a/salt/postgres/tools/sbin/so-postgres-backup
+++ b/salt/postgres/tools/sbin/so-postgres-backup
@@ -7,15 +7,29 @@
 
 . /usr/sbin/so-common
 
+# Without pipefail, a pipeline's exit status is gzip's. A failed pg_dumpall would
+# otherwise be masked by a successful gzip, silently producing a valid .gz that
+# holds a truncated dump.
+set -o pipefail
+
 # Backups contain role password hashes and full chat data; keep them 0600.
 umask 0077
 
 TODAY=$(date '+%Y_%m_%d')
 BACKUPDIR=/nsm/backup
 BACKUPFILE="$BACKUPDIR/so-postgres-backup-$TODAY.sql.gz"
+TMPFILE="$BACKUPFILE.tmp"
 MAXBACKUPS=7
+LOGFILE=/opt/so/log/postgres/backup.log
 
-mkdir -p $BACKUPDIR
+log() {
+  echo "$(date '+%Y-%m-%d %H:%M:%S') $*" >> "$LOGFILE"
+}
+
+mkdir -p "$BACKUPDIR"
+
+# Remove any temp files left behind by a previously crashed run
+rm -f "$BACKUPDIR"/so-postgres-backup-*.sql.gz.tmp
 
 # Skip if already backed up today
 if [ -f "$BACKUPFILE" ]; then
@@ -27,13 +41,33 @@ if ! docker ps --format '{{.Names}}' | grep -q '^so-postgres$'; then
   exit 0
 fi
 
-# Dump all databases and roles, compress
-docker exec so-postgres pg_dumpall -U postgres | gzip > "$BACKUPFILE"
+# Always clean up the temp file on exit; the success path clears this trap
+# after the atomic rename so the finished backup is not deleted.
+trap 'rm -f "$TMPFILE"' EXIT
 
-# Retention cleanup
-NUMBACKUPS=$(find $BACKUPDIR -type f -name "so-postgres-backup*" | wc -l)
+# Dump all databases and roles, compress. Write to a temp file so the final
+# filename only ever appears for a complete, verified backup.
+if ! docker exec so-postgres pg_dumpall -U postgres | gzip > "$TMPFILE"; then
+  log "ERROR: pg_dumpall/gzip failed; backup aborted"
+  exit 1
+fi
+
+# Verify the compressed stream is intact before publishing it
+if ! gzip -t "$TMPFILE"; then
+  log "ERROR: backup failed gzip integrity check; backup aborted"
+  exit 1
+fi
+
+# Atomically publish the verified backup
+mv "$TMPFILE" "$BACKUPFILE"
+trap - EXIT
+log "OK: wrote $BACKUPFILE"
+
+# Retention cleanup (only reached after a successful backup). The glob is
+# restricted to finished backups so an in-progress .tmp can never be counted.
+NUMBACKUPS=$(find "$BACKUPDIR" -type f -name "so-postgres-backup-*.sql.gz" | wc -l)
 while [ "$NUMBACKUPS" -gt "$MAXBACKUPS" ]; do
-  OLDEST=$(find $BACKUPDIR -type f -name "so-postgres-backup*" -printf '%T+ %p\n' | sort | head -n 1 | awk -F" " '{print $2}')
+  OLDEST=$(find "$BACKUPDIR" -type f -name "so-postgres-backup-*.sql.gz" -printf '%T+ %p\n' | sort | head -n 1 | awk -F" " '{print $2}')
   rm -f "$OLDEST"
-  NUMBACKUPS=$(find $BACKUPDIR -type f -name "so-postgres-backup*" | wc -l)
+  NUMBACKUPS=$(find "$BACKUPDIR" -type f -name "so-postgres-backup-*.sql.gz" | wc -l)
 done


### PR DESCRIPTION
## Problem

`salt/postgres/tools/sbin/so-postgres-backup` dumped postgres with:

```bash
docker exec so-postgres pg_dumpall -U postgres | gzip > "$BACKUPFILE"
```

A bash pipeline's exit status is that of the last command (`gzip`). If `pg_dumpall` failed or was killed mid-stream (container restart, OOM, transient error), `gzip` still compressed the partial output and exited `0` — producing a *valid `.gz` containing a truncated SQL dump*, written straight to the final filename.

Worse, the corruption then became permanent and spread:

- The idempotency check (`if [ -f "$BACKUPFILE" ]`) blocked any retry for the rest of the day.
- The corrupt file counted toward `MAXBACKUPS=7` retention, so each bad run evicted the oldest *good* backup. After 7 bad days, every valid backup was gone.
- The cron entry redirects all output to `/dev/null`, so failures were never surfaced.

Net effect: corruption was only discoverable at restore time.

## Fix

- `set -o pipefail` so a failed `pg_dumpall` fails the pipeline.
- Dump to a `.tmp` file and atomically `mv` to the final name only after success — the final filename appears only for a complete backup.
- `gzip -t` integrity check before publishing.
- `trap`-based cleanup of the temp file on abnormal exit; stale temps from a prior crash are swept at startup.
- Retention runs only after a successful backup, with the `find` glob restricted to finished backups (`so-postgres-backup-*.sql.gz`) so an in-progress `.tmp` can never be counted or deleted.
- Timestamped OK/ERROR outcomes logged to `/opt/so/log/postgres/backup.log` (cron's `/dev/null` redirect previously hid everything).

## Testing

- `bash -n` syntax check passes.
- Happy path: backup file is created `0600`, passes `gzip -t`, log shows `OK`.
- Simulated dump failure: non-zero exit, no final backup file created, temp file cleaned up, log shows `ERROR`, prior good backups untouched.
- Idempotency and retention behavior verified.