### PR TITLE
run elastic agent regen installer script in post_to_3.2.0

### DIFF
--- a/salt/backup/tools/sbin/so-config-backup.jinja
+++ b/salt/backup/tools/sbin/so-config-backup.jinja
@@ -25,9 +25,11 @@ if [ ! -f $BACKUPFILE ]; then
   # Create empty backup file
   tar -cf $BACKUPFILE -T /dev/null
 
-  # Loop through all paths defined in global.sls, and append them to backup file
+  # Loop through all paths defined in global.sls, and append them to backup file if they exist
   {%- for LOCATION in BACKUPLOCATIONS %}
-  tar -rf $BACKUPFILE "${EXCLUSIONS[@]}" {{ LOCATION }}
+  if [[ -d {{ LOCATION }} || -f {{ LOCATION }} ]]; then
+    tar -rf $BACKUPFILE "${EXCLUSIONS[@]}" {{ LOCATION }}
+  fi
   {%- endfor %}
 
 fi

--- a/salt/manager/tools/sbin/soup
+++ b/salt/manager/tools/sbin/soup
@@ -762,6 +762,8 @@ bootstrap_so_soc_database() {
 }
 
 up_to_3.2.0() {
+  fix_logstash_0013_lumberjack_pipeline_name
+
   INSTALLEDVERSION=3.2.0
 }
 
@@ -1559,13 +1561,7 @@ EOF
 
 # Keeping this block in case we need to do a hotfix that requires salt update
 apply_hotfix() {
-    if [[ "$INSTALLEDVERSION" == "3.1.0" ]] ; then
-       # Do not remove this fix_logstash_0013_lumberjack_pipeline_name in future hotfixes without first validating older
-       #  installs referencing "so/0013_input_lumberjack_fleet.conf" via pillar are upgradable
-       fix_logstash_0013_lumberjack_pipeline_name
-    else
-        echo "No actions required. ($INSTALLEDVERSION/$HOTFIXVERSION)"
-    fi
+    echo "No actions required. ($INSTALLEDVERSION/$HOTFIXVERSION)"
 }
 
 failed_soup_restore_items() {

--- a/salt/manager/tools/sbin/soup
+++ b/salt/manager/tools/sbin/soup
@@ -188,13 +188,6 @@ airgap_update_dockers() {
   fi
 }
 
-backup_old_states_pillars() {
-
-	tar czf /nsm/backup/$(echo $INSTALLEDVERSION)_$(date +%Y%m%d-%H%M%S)_soup_default_states_pillars.tar.gz /opt/so/saltstack/default/
-	tar czf /nsm/backup/$(echo $INSTALLEDVERSION)_$(date +%Y%m%d-%H%M%S)_soup_local_states_pillars.tar.gz /opt/so/saltstack/local/
-
-}
-
 update_registry() {
   docker stop so-dockerregistry
   docker rm so-dockerregistry
@@ -1670,7 +1663,8 @@ main() {
     echo "Applying $HOTFIXVERSION hotfix"
     # since we don't run the backup.config_backup state on import we wont snapshot previous version states and pillars
     if [[ ! "$MINION_ROLE" == "import" ]]; then
-      backup_old_states_pillars
+        echo "Running so-config-backup script."
+        /sbin/so-config-backup
     fi
     copy_new_files
     create_local_directories "/opt/so/saltstack/default"
@@ -1726,8 +1720,8 @@ main() {
     # since we don't run the backup.config_backup state on import we wont snapshot previous version states and pillars
     if [[ ! "$MINION_ROLE" == "import" ]]; then
       echo ""
-      echo "Creating snapshots of default and local Salt states and pillars and saving to /nsm/backup/"
-      backup_old_states_pillars
+      echo "Running so-config-backup script."
+      /sbin/so-config-backup
     fi
 
     echo ""

--- a/salt/manager/tools/sbin/soup
+++ b/salt/manager/tools/sbin/soup
@@ -770,6 +770,10 @@ up_to_3.2.0() {
 post_to_3.2.0() {
   bootstrap_so_soc_database
 
+  # Including agent regen script here since it was missed in post_to_3.1.0
+  echo "Regenerating Elastic Agent Installers"
+  /sbin/so-elastic-agent-gen-installers
+
   POSTVERSION=3.2.0
 }
 


### PR DESCRIPTION
In 3.1.0 upgrade to ES 9.3.3 the new elastic agent files were put in place, but installers were not regenerated. Grid nodes will automatically be upgraded to 9.3.3 via highstate. Existing deployed endpoints as usual require selecting them for upgrade via Elastic Fleet. Newly deployed agents will install at prior version 9.0.8 and require upgrade via Elastic Fleet