### PR TITLE
run elastic agent regen installer script in post_to_3.2.0

### DIFF
--- a/salt/manager/tools/sbin/soup
+++ b/salt/manager/tools/sbin/soup
@@ -769,6 +769,8 @@ bootstrap_so_soc_database() {
 }
 
 up_to_3.2.0() {
+  fix_logstash_0013_lumberjack_pipeline_name
+
   INSTALLEDVERSION=3.2.0
 }
 
@@ -1566,13 +1568,7 @@ EOF
 
 # Keeping this block in case we need to do a hotfix that requires salt update
 apply_hotfix() {
-    if [[ "$INSTALLEDVERSION" == "3.1.0" ]] ; then
-       # Do not remove this fix_logstash_0013_lumberjack_pipeline_name in future hotfixes without first validating older
-       #  installs referencing "so/0013_input_lumberjack_fleet.conf" via pillar are upgradable
-       fix_logstash_0013_lumberjack_pipeline_name
-    else
-        echo "No actions required. ($INSTALLEDVERSION/$HOTFIXVERSION)"
-    fi
+    echo "No actions required. ($INSTALLEDVERSION/$HOTFIXVERSION)"
 }
 
 failed_soup_restore_items() {

--- a/salt/manager/tools/sbin/soup
+++ b/salt/manager/tools/sbin/soup
@@ -777,6 +777,10 @@ up_to_3.2.0() {
 post_to_3.2.0() {
   bootstrap_so_soc_database
 
+  # Including agent regen script here since it was missed in post_to_3.1.0
+  echo "Regenerating Elastic Agent Installers"
+  /sbin/so-elastic-agent-gen-installers
+
   POSTVERSION=3.2.0
 }
 


### PR DESCRIPTION
In 3.1.0 upgrade to ES 9.3.3 the new elastic agent files were put in place, but installers were not regenerated. Grid nodes will automatically be upgraded to 9.3.3 via highstate. Existing deployed endpoints as usual require selecting them for upgrade via Elastic Fleet. Newly deployed agents will install at prior version 9.0.8 and require upgrade via Elastic Fleet