### PR TITLE
Add UEK8 kernel repo support across install and grid

### DIFF
--- a/salt/manager/files/mirror-kernel.txt
+++ b/salt/manager/files/mirror-kernel.txt
@@ -1,0 +1,2 @@
+https://repo.securityonion.net/file/so-repo/prod/3/oracle/9-uek8
+https://repo-alt.securityonion.net/prod/3/oracle/9-uek8

--- a/salt/manager/files/repodownload.conf
+++ b/salt/manager/files/repodownload.conf
@@ -11,3 +11,8 @@ name=Security Onion Repo repo
 mirrorlist=file:///opt/so/conf/reposync/mirror.txt
 enabled=1
 gpgcheck=1
+[securityonionkernel]
+name=Security Onion Repo repo
+mirrorlist=file:///opt/so/conf/reposync/mirror-kernel.txt
+enabled=1
+gpgcheck=1

--- a/salt/manager/init.sls
+++ b/salt/manager/init.sls
@@ -96,6 +96,18 @@ kernelrepo_dir:
       - group
     - show_changes: False
 
+# Ensure /nsm/kernelrepo is always a valid (if empty) repo before it is ever assigned to
+# a client. Without repodata/repomd.xml an enabled file:///nsm/kernelrepo repo makes every
+# dnf operation fail; so-repo-sync only populates it after the highstate, so seed an empty
+# repo here. Only runs when repodata is missing, so it won't clobber a synced repo.
+kernelrepo_init_empty:
+  cmd.run:
+    - name: createrepo /nsm/kernelrepo
+    - unless: 'test -e /nsm/kernelrepo/repodata/repomd.xml'
+    - require:
+      - file: kernelrepo_dir
+      - pkg: install_createrepo
+
 manager_sbin:
   file.recurse:
     - name: /usr/sbin

--- a/salt/manager/init.sls
+++ b/salt/manager/init.sls
@@ -86,6 +86,16 @@ repo_dir:
       - group
     - show_changes: False
 
+kernelrepo_dir:
+  file.directory:
+    - name: /nsm/kernelrepo
+    - user: socore
+    - group: socore
+    - recurse:
+      - user
+      - group
+    - show_changes: False
+
 manager_sbin:
   file.recurse:
     - name: /usr/sbin
@@ -119,6 +129,13 @@ so-repo-mirrorlist:
   file.managed:
     - name: /opt/so/conf/reposync/mirror.txt
     - source: salt://manager/files/mirror.txt
+    - user: socore
+    - group: socore
+
+so-repo-kernel-mirrorlist:
+  file.managed:
+    - name: /opt/so/conf/reposync/mirror-kernel.txt
+    - source: salt://manager/files/mirror-kernel.txt
     - user: socore
     - group: socore
 

--- a/salt/manager/tools/sbin/so-repo-sync
+++ b/salt/manager/tools/sbin/so-repo-sync
@@ -14,5 +14,12 @@ curl --retry 5 --retry-delay 60 -A "reposync/$(sync_options)" https://sigs.secur
 dnf reposync --norepopath -g --delete -m -c /opt/so/conf/reposync/repodownload.conf --repoid=securityonionsync --download-metadata -p /nsm/repo/
 createrepo /nsm/repo
 
-dnf reposync --norepopath -g --delete -m -c /opt/so/conf/reposync/repodownload.conf --repoid=securityonionkernel --download-metadata -p /nsm/kernelrepo/
-createrepo /nsm/kernelrepo
+# The kernel repo section is deployed to repodownload.conf by the manager highstate, which
+# runs AFTER this script during soup. On the first upgrade to a kernel-aware version the
+# on-disk config still predates the section, so guard on its presence to avoid dnf's
+# "Unknown repo: 'securityonionkernel'" aborting the sync (set -e). The next sync after the
+# highstate deploys the section will pick it up.
+if grep -q '^\[securityonionkernel\]' /opt/so/conf/reposync/repodownload.conf; then
+  dnf reposync --norepopath -g --delete -m -c /opt/so/conf/reposync/repodownload.conf --repoid=securityonionkernel --download-metadata -p /nsm/kernelrepo/
+  createrepo /nsm/kernelrepo
+fi

--- a/salt/manager/tools/sbin/so-repo-sync
+++ b/salt/manager/tools/sbin/so-repo-sync
@@ -10,5 +10,9 @@ NOROOT=1
 set -e
 
 curl --retry 5 --retry-delay 60 -A "reposync/$(sync_options)" https://sigs.securityonion.net/checkup --output /tmp/checkup
+
 dnf reposync --norepopath -g --delete -m -c /opt/so/conf/reposync/repodownload.conf --repoid=securityonionsync --download-metadata -p /nsm/repo/
 createrepo /nsm/repo
+
+dnf reposync --norepopath -g --delete -m -c /opt/so/conf/reposync/repodownload.conf --repoid=securityonionkernel --download-metadata -p /nsm/kernelrepo/
+createrepo /nsm/kernelrepo

--- a/salt/nginx/enabled.sls
+++ b/salt/nginx/enabled.sls
@@ -59,6 +59,7 @@ so-nginx:
       - /opt/so/conf/navigator/layers/:/opt/socore/html/navigator/assets/so:ro
       - /opt/so/conf/navigator/config.json:/opt/socore/html/navigator/assets/config.json:ro
       - /nsm/repo:/opt/socore/html/repo:ro
+      - /nsm/kernelrepo:/opt/socore/html/kernelrepo:ro
       - /nsm/rules:/nsm/rules:ro
       {%   if NGINXMERGED.external_suricata %}
       - /opt/so/rules/nids/suri:/surirules:ro

--- a/salt/repo/client/oracle.sls
+++ b/salt/repo/client/oracle.sls
@@ -57,6 +57,22 @@ so_repo:
     - enabled: 1
     - gpgcheck: 1
 
+so_kernel_repo:
+  pkgrepo.managed:
+    - name: securityonionkernel
+    - humanname: Security Onion Kernel Repo
+  {% if GLOBALS.is_manager %}
+    - baseurl: file:///nsm/kernelrepo/
+  {% else %}
+    - baseurl: https://{{ GLOBALS.repo_host }}/kernelrepo
+  {% endif %}
+    - enabled: 1
+    - gpgcheck: 1
+    # Only assign the kernel repo once physical NIC names are pinned by MAC, so the
+    # UEK8 kernel update can't renumber interfaces SO binds by name (see pin_nic_names
+    # in salt/common/init.sls, which drops this marker via /usr/sbin/so-nic-pin).
+    - onlyif: 'test -e /opt/so/state/nic_names_pinned'
+
 {% endif %}
   
 # TODO: Add a pillar entry for custom repos

--- a/salt/repo/client/oracle.sls
+++ b/salt/repo/client/oracle.sls
@@ -68,6 +68,10 @@ so_kernel_repo:
   {% endif %}
     - enabled: 1
     - gpgcheck: 1
+    # Supplementary kernel repo: tolerate it being empty/unreachable (e.g. before the
+    # manager has populated /nsm/kernelrepo) so a missing repomd.xml can't make every
+    # dnf/pkg operation on the grid fail.
+    - skip_if_unavailable: 1
     # Only assign the kernel repo once physical NIC names are pinned by MAC, so the
     # UEK8 kernel update can't renumber interfaces SO binds by name (see pin_nic_names
     # in salt/common/init.sls, which drops this marker via /usr/sbin/so-nic-pin).

--- a/setup/so-functions
+++ b/setup/so-functions
@@ -886,6 +886,7 @@ create_repo() {
 	title "Create the repo directory"
 	logCmd "dnf -y install yum-utils createrepo_c"
 	logCmd "createrepo /nsm/repo"
+	logCmd "createrepo /nsm/kernelrepo"
 }
 
 
@@ -1812,11 +1813,24 @@ securityonion_repo() {
 			echo "mirrorlist=file:///etc/yum/mirror.txt" >> /etc/yum.repos.d/securityonion.repo
 			echo "enabled=1" >> /etc/yum.repos.d/securityonion.repo
 			echo "gpgcheck=1" >> /etc/yum.repos.d/securityonion.repo
+			echo "https://repo.securityonion.net/file/so-repo/prod/3/oracle/9-uek8" > /etc/yum/mirror-kernel.txt
+			echo "https://so-repo-east.s3.us-east-005.backblazeb2.com/prod/3/oracle/9-uek8" >> /etc/yum/mirror-kernel.txt
+			echo "[securityonionkernel]" >> /etc/yum.repos.d/securityonion.repo
+			echo "name=Security Onion Kernel Repo repo" >> /etc/yum.repos.d/securityonion.repo
+			echo "mirrorlist=file:///etc/yum/mirror-kernel.txt" >> /etc/yum.repos.d/securityonion.repo
+			echo "enabled=1" >> /etc/yum.repos.d/securityonion.repo
+			echo "gpgcheck=1" >> /etc/yum.repos.d/securityonion.repo
 			logCmd "dnf repolist"
 		else
 			echo "[securityonion]" > /etc/yum.repos.d/securityonion.repo
 			echo "name=Security Onion Repo" >> /etc/yum.repos.d/securityonion.repo
 			echo "baseurl=https://$MSRV/repo" >> /etc/yum.repos.d/securityonion.repo
+			echo "enabled=1" >> /etc/yum.repos.d/securityonion.repo
+			echo "gpgcheck=1" >> /etc/yum.repos.d/securityonion.repo
+			echo "sslverify=0" >> /etc/yum.repos.d/securityonion.repo
+			echo "[securityonionkernel]" >> /etc/yum.repos.d/securityonion.repo
+			echo "name=Security Onion Kernel Repo" >> /etc/yum.repos.d/securityonion.repo
+			echo "baseurl=https://$MSRV/kernelrepo" >> /etc/yum.repos.d/securityonion.repo
 			echo "enabled=1" >> /etc/yum.repos.d/securityonion.repo
 			echo "gpgcheck=1" >> /etc/yum.repos.d/securityonion.repo
 			echo "sslverify=0" >> /etc/yum.repos.d/securityonion.repo
@@ -1829,10 +1843,21 @@ securityonion_repo() {
 		echo "enabled=1" >> /etc/yum.repos.d/securityonion.repo
 		echo "gpgcheck=1" >> /etc/yum.repos.d/securityonion.repo
 		echo "sslverify=0" >> /etc/yum.repos.d/securityonion.repo
+		echo "[securityonionkernel]" >> /etc/yum.repos.d/securityonion.repo
+		echo "name=Security Onion Kernel Repo" >> /etc/yum.repos.d/securityonion.repo
+		echo "baseurl=https://$MSRV/kernelrepo" >> /etc/yum.repos.d/securityonion.repo
+		echo "enabled=1" >> /etc/yum.repos.d/securityonion.repo
+		echo "gpgcheck=1" >> /etc/yum.repos.d/securityonion.repo
+		echo "sslverify=0" >> /etc/yum.repos.d/securityonion.repo
 	elif [[ $waitforstate ]]; then
 		echo "[securityonion]" > /etc/yum.repos.d/securityonion.repo
 		echo "name=Security Onion Repo" >> /etc/yum.repos.d/securityonion.repo
 		echo "baseurl=file:///nsm/repo/" >> /etc/yum.repos.d/securityonion.repo
+		echo "enabled=1" >> /etc/yum.repos.d/securityonion.repo
+		echo "gpgcheck=1" >> /etc/yum.repos.d/securityonion.repo
+		echo "[securityonionkernel]" >> /etc/yum.repos.d/securityonion.repo
+		echo "name=Security Onion Kernel Repo" >> /etc/yum.repos.d/securityonion.repo
+		echo "baseurl=file:///nsm/kernelrepo/" >> /etc/yum.repos.d/securityonion.repo
 		echo "enabled=1" >> /etc/yum.repos.d/securityonion.repo
 		echo "gpgcheck=1" >> /etc/yum.repos.d/securityonion.repo
 	fi
@@ -1850,9 +1875,12 @@ repo_sync_local() {
 	# Sync the repo from the SO repo locally.
 	info "Adding Repo Download Configuration"
 	mkdir -p /nsm/repo
+	mkdir -p /nsm/kernelrepo
 	mkdir -p /opt/so/conf/reposync/cache
 	echo "https://repo.securityonion.net/file/so-repo/prod/3/oracle/9" > /opt/so/conf/reposync/mirror.txt
 	echo "https://repo-alt.securityonion.net/prod/3/oracle/9" >> /opt/so/conf/reposync/mirror.txt
+	echo "https://repo.securityonion.net/file/so-repo/prod/3/oracle/9-uek8" > /opt/so/conf/reposync/mirror-kernel.txt
+	echo "https://repo-alt.securityonion.net/prod/3/oracle/9-uek8" >> /opt/so/conf/reposync/mirror-kernel.txt
 	echo "[main]" > /opt/so/conf/reposync/repodownload.conf
 	echo "gpgcheck=1" >> /opt/so/conf/reposync/repodownload.conf
 	echo "installonly_limit=3" >> /opt/so/conf/reposync/repodownload.conf
@@ -1866,12 +1894,18 @@ repo_sync_local() {
 	echo "mirrorlist=file:///opt/so/conf/reposync/mirror.txt" >> /opt/so/conf/reposync/repodownload.conf
 	echo "enabled=1" >> /opt/so/conf/reposync/repodownload.conf
 	echo "gpgcheck=1" >> /opt/so/conf/reposync/repodownload.conf
+	echo "[securityonionkernel]" >> /opt/so/conf/reposync/repodownload.conf
+	echo "name=Security Onion Kernel Repo repo" >> /opt/so/conf/reposync/repodownload.conf
+	echo "mirrorlist=file:///opt/so/conf/reposync/mirror-kernel.txt" >> /opt/so/conf/reposync/repodownload.conf
+	echo "enabled=1" >> /opt/so/conf/reposync/repodownload.conf
+	echo "gpgcheck=1" >> /opt/so/conf/reposync/repodownload.conf
 
 	logCmd "dnf repolist"
 
 	if [[ ! $is_airgap ]]; then
 		curl --retry 5 --retry-delay 60 -A "netinstall/$SOVERSION/$OS/$(uname -r)/1" https://sigs.securityonion.net/checkup --output /tmp/install
 		retry 5 60 "dnf reposync --norepopath -g --delete -m -c /opt/so/conf/reposync/repodownload.conf --repoid=securityonionsync --download-metadata -p /nsm/repo/" >> "$setup_log" 2>&1 || fail_setup
+		retry 5 60 "dnf reposync --norepopath -g --delete -m -c /opt/so/conf/reposync/repodownload.conf --repoid=securityonionkernel --download-metadata -p /nsm/kernelrepo/" >> "$setup_log" 2>&1 || fail_setup
 		# After the download is complete run createrepo
 		create_repo
 	fi
@@ -2228,6 +2262,13 @@ update_sudoers_for_testing() {
 }
 
 update_packages() {
+	# Pin physical NIC names by MAC BEFORE pulling packages, so the UEK8 kernel that
+	# the update below installs can't renumber the interfaces SO binds by name. Doing
+	# it here (instead of waiting for the common highstate) also drops the
+	# /opt/so/state/nic_names_pinned marker that gates the kernel repo, so the kernel
+	# repo is assigned on the very first highstate and the kernel isn't downgraded and
+	# then re-upgraded. Run-once: so-nic-pin no-ops if the marker already exists.
+	logCmd "bash ../salt/common/tools/sbin/so-nic-pin"
 	logCmd "dnf repolist"
 	logCmd "dnf -y update --allowerasing --exclude=salt*,docker*,containerd*"
 	RMREPOFILES=("oracle-linux-ol9.repo" "uek-ol9.repo" "virt-ol9.repo")

--- a/setup/so-functions
+++ b/setup/so-functions
@@ -1820,6 +1820,9 @@ securityonion_repo() {
 			echo "mirrorlist=file:///etc/yum/mirror-kernel.txt" >> /etc/yum.repos.d/securityonionkernel.repo
 			echo "enabled=1" >> /etc/yum.repos.d/securityonionkernel.repo
 			echo "gpgcheck=1" >> /etc/yum.repos.d/securityonionkernel.repo
+			# Supplementary kernel repo: tolerate it being empty/unreachable so a missing
+			# repomd.xml can't make every dnf operation fail before the repo is populated.
+			echo "skip_if_unavailable=1" >> /etc/yum.repos.d/securityonionkernel.repo
 			logCmd "dnf repolist"
 		else
 			echo "[securityonion]" > /etc/yum.repos.d/securityonion.repo
@@ -1834,6 +1837,7 @@ securityonion_repo() {
 			echo "enabled=1" >> /etc/yum.repos.d/securityonionkernel.repo
 			echo "gpgcheck=1" >> /etc/yum.repos.d/securityonionkernel.repo
 			echo "sslverify=0" >> /etc/yum.repos.d/securityonionkernel.repo
+			echo "skip_if_unavailable=1" >> /etc/yum.repos.d/securityonionkernel.repo
 			logCmd "dnf repolist"
 		fi
 	elif [[ ! $waitforstate ]]; then
@@ -1849,6 +1853,7 @@ securityonion_repo() {
 		echo "enabled=1" >> /etc/yum.repos.d/securityonionkernel.repo
 		echo "gpgcheck=1" >> /etc/yum.repos.d/securityonionkernel.repo
 		echo "sslverify=0" >> /etc/yum.repos.d/securityonionkernel.repo
+		echo "skip_if_unavailable=1" >> /etc/yum.repos.d/securityonionkernel.repo
 	elif [[ $waitforstate ]]; then
 		echo "[securityonion]" > /etc/yum.repos.d/securityonion.repo
 		echo "name=Security Onion Repo" >> /etc/yum.repos.d/securityonion.repo
@@ -1860,6 +1865,7 @@ securityonion_repo() {
 		echo "baseurl=file:///nsm/kernelrepo/" >> /etc/yum.repos.d/securityonionkernel.repo
 		echo "enabled=1" >> /etc/yum.repos.d/securityonionkernel.repo
 		echo "gpgcheck=1" >> /etc/yum.repos.d/securityonionkernel.repo
+		echo "skip_if_unavailable=1" >> /etc/yum.repos.d/securityonionkernel.repo
 	fi
 	logCmd "dnf repolist all"
 	if [[ $waitforstate ]]; then

--- a/setup/so-functions
+++ b/setup/so-functions
@@ -1815,11 +1815,11 @@ securityonion_repo() {
 			echo "gpgcheck=1" >> /etc/yum.repos.d/securityonion.repo
 			echo "https://repo.securityonion.net/file/so-repo/prod/3/oracle/9-uek8" > /etc/yum/mirror-kernel.txt
 			echo "https://so-repo-east.s3.us-east-005.backblazeb2.com/prod/3/oracle/9-uek8" >> /etc/yum/mirror-kernel.txt
-			echo "[securityonionkernel]" >> /etc/yum.repos.d/securityonion.repo
-			echo "name=Security Onion Kernel Repo repo" >> /etc/yum.repos.d/securityonion.repo
-			echo "mirrorlist=file:///etc/yum/mirror-kernel.txt" >> /etc/yum.repos.d/securityonion.repo
-			echo "enabled=1" >> /etc/yum.repos.d/securityonion.repo
-			echo "gpgcheck=1" >> /etc/yum.repos.d/securityonion.repo
+			echo "[securityonionkernel]" > /etc/yum.repos.d/securityonionkernel.repo
+			echo "name=Security Onion Kernel Repo repo" >> /etc/yum.repos.d/securityonionkernel.repo
+			echo "mirrorlist=file:///etc/yum/mirror-kernel.txt" >> /etc/yum.repos.d/securityonionkernel.repo
+			echo "enabled=1" >> /etc/yum.repos.d/securityonionkernel.repo
+			echo "gpgcheck=1" >> /etc/yum.repos.d/securityonionkernel.repo
 			logCmd "dnf repolist"
 		else
 			echo "[securityonion]" > /etc/yum.repos.d/securityonion.repo
@@ -1828,12 +1828,12 @@ securityonion_repo() {
 			echo "enabled=1" >> /etc/yum.repos.d/securityonion.repo
 			echo "gpgcheck=1" >> /etc/yum.repos.d/securityonion.repo
 			echo "sslverify=0" >> /etc/yum.repos.d/securityonion.repo
-			echo "[securityonionkernel]" >> /etc/yum.repos.d/securityonion.repo
-			echo "name=Security Onion Kernel Repo" >> /etc/yum.repos.d/securityonion.repo
-			echo "baseurl=https://$MSRV/kernelrepo" >> /etc/yum.repos.d/securityonion.repo
-			echo "enabled=1" >> /etc/yum.repos.d/securityonion.repo
-			echo "gpgcheck=1" >> /etc/yum.repos.d/securityonion.repo
-			echo "sslverify=0" >> /etc/yum.repos.d/securityonion.repo
+			echo "[securityonionkernel]" > /etc/yum.repos.d/securityonionkernel.repo
+			echo "name=Security Onion Kernel Repo" >> /etc/yum.repos.d/securityonionkernel.repo
+			echo "baseurl=https://$MSRV/kernelrepo" >> /etc/yum.repos.d/securityonionkernel.repo
+			echo "enabled=1" >> /etc/yum.repos.d/securityonionkernel.repo
+			echo "gpgcheck=1" >> /etc/yum.repos.d/securityonionkernel.repo
+			echo "sslverify=0" >> /etc/yum.repos.d/securityonionkernel.repo
 			logCmd "dnf repolist"
 		fi
 	elif [[ ! $waitforstate ]]; then
@@ -1843,23 +1843,23 @@ securityonion_repo() {
 		echo "enabled=1" >> /etc/yum.repos.d/securityonion.repo
 		echo "gpgcheck=1" >> /etc/yum.repos.d/securityonion.repo
 		echo "sslverify=0" >> /etc/yum.repos.d/securityonion.repo
-		echo "[securityonionkernel]" >> /etc/yum.repos.d/securityonion.repo
-		echo "name=Security Onion Kernel Repo" >> /etc/yum.repos.d/securityonion.repo
-		echo "baseurl=https://$MSRV/kernelrepo" >> /etc/yum.repos.d/securityonion.repo
-		echo "enabled=1" >> /etc/yum.repos.d/securityonion.repo
-		echo "gpgcheck=1" >> /etc/yum.repos.d/securityonion.repo
-		echo "sslverify=0" >> /etc/yum.repos.d/securityonion.repo
+		echo "[securityonionkernel]" > /etc/yum.repos.d/securityonionkernel.repo
+		echo "name=Security Onion Kernel Repo" >> /etc/yum.repos.d/securityonionkernel.repo
+		echo "baseurl=https://$MSRV/kernelrepo" >> /etc/yum.repos.d/securityonionkernel.repo
+		echo "enabled=1" >> /etc/yum.repos.d/securityonionkernel.repo
+		echo "gpgcheck=1" >> /etc/yum.repos.d/securityonionkernel.repo
+		echo "sslverify=0" >> /etc/yum.repos.d/securityonionkernel.repo
 	elif [[ $waitforstate ]]; then
 		echo "[securityonion]" > /etc/yum.repos.d/securityonion.repo
 		echo "name=Security Onion Repo" >> /etc/yum.repos.d/securityonion.repo
 		echo "baseurl=file:///nsm/repo/" >> /etc/yum.repos.d/securityonion.repo
 		echo "enabled=1" >> /etc/yum.repos.d/securityonion.repo
 		echo "gpgcheck=1" >> /etc/yum.repos.d/securityonion.repo
-		echo "[securityonionkernel]" >> /etc/yum.repos.d/securityonion.repo
-		echo "name=Security Onion Kernel Repo" >> /etc/yum.repos.d/securityonion.repo
-		echo "baseurl=file:///nsm/kernelrepo/" >> /etc/yum.repos.d/securityonion.repo
-		echo "enabled=1" >> /etc/yum.repos.d/securityonion.repo
-		echo "gpgcheck=1" >> /etc/yum.repos.d/securityonion.repo
+		echo "[securityonionkernel]" > /etc/yum.repos.d/securityonionkernel.repo
+		echo "name=Security Onion Kernel Repo" >> /etc/yum.repos.d/securityonionkernel.repo
+		echo "baseurl=file:///nsm/kernelrepo/" >> /etc/yum.repos.d/securityonionkernel.repo
+		echo "enabled=1" >> /etc/yum.repos.d/securityonionkernel.repo
+		echo "gpgcheck=1" >> /etc/yum.repos.d/securityonionkernel.repo
 	fi
 	logCmd "dnf repolist all"
 	if [[ $waitforstate ]]; then


### PR DESCRIPTION
## Summary

Brings the Oracle **UEK8 kernel repo** (`9-uek8`) to full parity with the main package repo so the grid can pull a newer kernel. Prior WIP only wired the kernel repo into the highstate-time sync; this completes the install bootstrap, manager state, nginx serving, and client consumption — including minions and airgap — and gates the kernel repo on NIC pinning.

## Changes

- **`setup/so-functions`**
  - `securityonion_repo()` now emits a `[securityonionkernel]` section in every branch: `mirrorlist=file:///etc/yum/mirror-kernel.txt` (non-airgap), `https://$MSRV/kernelrepo` (airgap/minion), `file:///nsm/kernelrepo/` (manager-local).
  - `repo_sync_local()` writes `mirror-kernel.txt`, adds the kernel section to `repodownload.conf`, syncs into `/nsm/kernelrepo`; `create_repo()` builds its metadata.
  - `update_packages()` runs `so-nic-pin` **before** the `dnf update` that pulls the kernel, freezing interface names and dropping the `/opt/so/state/nic_names_pinned` marker so the kernel isn't downgraded then re-upgraded on the first highstate.
- **`salt/manager/init.sls`** — create `/nsm/kernelrepo`, deploy `mirror-kernel.txt`.
- **`salt/nginx/enabled.sls`** — serve `/nsm/kernelrepo` at `https://<repo_host>/kernelrepo`.
- **`salt/repo/client/oracle.sls`** — add `so_kernel_repo`, gated by `onlyif test -e /opt/so/state/nic_names_pinned` (kernel repo only; main repo ungated).
- **`salt/manager/files/`** — new `mirror-kernel.txt`; `repodownload.conf` + `so-repo-sync` carry the `securityonionkernel` repoid.

## Why NIC pinning gates the kernel repo

Enabling the UEK8 kernel repo triggers a kernel update, and a kernel change can renumber the physical NICs that SO binds by name. `so-nic-pin` pins them by MAC first (run-once, marker-gated), so the kernel repo is only assigned once names are frozen.

## Testing

- `bash -n setup/so-functions` passes.
- Recommended on a real OEL box: `salt-call --local state.show_sls repo.client` / `manager` render cleanly; fresh install shows both `securityonionsync` and `securityonionkernel` in `dnf repolist`, `/nsm/kernelrepo` populated with `repodata/`, nginx serving the kernel repo, and a minion picking it up via `repo_host`.