### PR TITLE
Fix premature fail_setup function call in so-setup

### DIFF
--- a/setup/so-setup
+++ b/setup/so-setup
@@ -9,14 +9,17 @@
 # Make sure you are root before doing anything
 uid="$(id -u)"
 if [ "$uid" -ne 0 ]; then
-	echo "This script must be run using sudo!"
-	fail_setup
+	echo "This script must be run using sudo!" >&2
+	exit 1
 fi
 
 # Save the original argument array since we modify it
 original_args=("$@")
 
-cd "$(dirname "$0")" || fail_setup
+cd "$(dirname "$0")" || {
+	echo "Unable to change to setup directory" >&2
+	exit 1
+}
 
 echo "Getting started..."
 


### PR DESCRIPTION
## Description

The `so-setup` script can currently call the `fail_setup` function in the initial non-root check and setup directory change before `setup/so-functions` has been sourced.

This PR modifies the non-root check and directory change condition to exit directly, as these error conditions are early and straightforward to the user.

## Related Issues

[Issue 16004](https://github.com/Security-Onion-Solutions/securityonion/issues/16004)

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/Security-Onion-Solutions/securityonion/blob/3/main/CONTRIBUTING.md) file.
- [x] I have read and agree to the terms of the [Contributor License Agreement](https://securityonionsolutions.com/cla)

## Questions or Comments

Fix will likely need to be replicated to earlier SO versions for `so-setup`.