### PR TITLE
Set transport for ssl.established:false logs

### DIFF
--- a/salt/elasticsearch/files/ingest/zeek.ssl
+++ b/salt/elasticsearch/files/ingest/zeek.ssl
@@ -5,6 +5,7 @@
     { "remove":   { "field": ["host"],     "ignore_failure": true } },
     { "json":             { "field": "message",                 "target_field": "message2",             "ignore_failure": true  } },
     { "rename":         { "field": "message2.version",          "target_field": "ssl.version",          "ignore_missing": true  } },
+    { "set":      { "description": "Set transport for the community_id processor", "if": "ctx.ssl?.version == null || !ctx.ssl.version.startsWith('DTLS')", "field": "network.transport", "value": "tcp", "ignore_failure": true } },
     { "rename":         { "field": "message2.cipher",           "target_field": "ssl.cipher",           "ignore_missing": true  } },
     { "rename":         { "field": "message2.curve",            "target_field": "ssl.curve",            "ignore_missing": true  } },
     { "rename":         { "field": "message2.server_name",      "target_field": "ssl.server_name",              "ignore_missing": true  } },


### PR DESCRIPTION
Set transport so the community_id processor in zeek.common can backfill network.community_id on handshakes Zeek did not gen itself (it only creates community_id on ESTABLISHED sessions).  DTLS (UDP) records do log here as well, so this is filtered to exclude any DTLSv* version; QUIC is handled separately in zeek.quic.