### PR TITLE
Switch boot default to UEK8 kernel and gate kernel repo on salt version

### DIFF
--- a/salt/common/tools/sbin/so-kernel-upgrade
+++ b/salt/common/tools/sbin/so-kernel-upgrade
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# Copyright Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+# https://securityonion.net/license; you may not use this file except in compliance with the
+# Elastic License 2.0.
+#
+# so-kernel-upgrade — switch the boot default to the installed UEK8 (6.x) kernel.
+#
+# Security Onion is moving off the EL9 stock kernel / UEK7 (5.x) onto UEK8 (6.x).
+# Installing the kernel-uek-core package adds a UEK8 boot entry but does NOT make it the
+# default: kernel-install/grubby only auto-promote a new kernel within the running
+# kernel's flavor lineage, and we're crossing from a 5.x kernel to the new 6.x UEK flavor.
+# So even with UPDATEDEFAULT=yes and DEFAULTKERNEL=kernel-uek-core the box keeps booting
+# the old kernel. This tool finds the newest installed 6.x UEK kernel and makes it the
+# GRUB default via grubby so the next boot comes up on UEK8.
+#
+# Idempotent: if the UEK8 kernel is already the default it does nothing. It only sets the
+# boot default; it does NOT reboot — the admin reboots the node on their own schedule.
+
+log() { echo "[so-kernel-upgrade] $*"; }
+
+[ "$(id -u)" -eq 0 ] || { log "must run as root"; exit 1; }
+command -v grubby >/dev/null 2>&1 || { log "grubby not found"; exit 1; }
+
+# Newest installed UEK8 (6.x) kernel known to the bootloader. UEK8 vmlinuz paths look like
+# /boot/vmlinuz-6.12.0-203.76.7.5.el9uek.x86_64; the 5.x UEK7 and 5.14 RHCK won't match.
+target="$(grubby --info=ALL 2>/dev/null \
+    | sed -n 's/^kernel="\(.*\)"$/\1/p' \
+    | grep -E '/vmlinuz-6\.[0-9]+.*uek' \
+    | sort -V | tail -1)"
+
+if [ -z "$target" ]; then
+    log "no installed 6.x UEK (UEK8) kernel found — confirm the kernel repo is assigned and"
+    log "'dnf update' has installed kernel-uek-core. Nothing to do."
+    exit 0
+fi
+
+current="$(grubby --default-kernel 2>/dev/null)"
+if [ "$current" = "$target" ]; then
+    log "UEK8 kernel is already the boot default: $target"
+    exit 0
+fi
+
+log "current default kernel: ${current:-unknown}"
+log "switching boot default to UEK8 kernel: $target"
+grubby --set-default="$target" || { log "ERROR: grubby --set-default failed for $target"; exit 1; }
+
+# Verify the change actually took before claiming success.
+now="$(grubby --default-kernel 2>/dev/null)"
+if [ "$now" != "$target" ]; then
+    log "ERROR: default kernel is still '${now:-unknown}' after set-default"
+    exit 1
+fi
+
+log "boot default is now $target"
+log "REBOOT REQUIRED to start using the UEK8 kernel (currently running $(uname -r))."

--- a/salt/repo/client/oracle.sls
+++ b/salt/repo/client/oracle.sls
@@ -6,6 +6,10 @@
 {% from 'repo/client/map.jinja' import REPOPATH with context %}
 {% from 'vars/globals.map.jinja' import GLOBALS %}
 
+{% import_yaml 'salt/minion.defaults.yaml' as saltversion %}
+{% set saltversion = saltversion.salt.minion.version %}
+{% set INSTALLEDSALTVERSION = grains.saltversion %}
+
 {% set role = grains.id.split('_') | last %}
 {% set MANAGER = salt['grains.get']('master') %}
 {% if grains['os'] == 'OEL' %}
@@ -57,6 +61,11 @@ so_repo:
     - enabled: 1
     - gpgcheck: 1
 
+# Only assign the kernel repo once this node's running salt matches the version this
+# SO release ships. During a soup the grid is mid-salt-upgrade; gating here keeps the
+# UEK8 kernel repo (and the kernel update it enables) from activating until the node is
+# fully on the target salt, the same way other states defer across the upgrade window.
+{% if saltversion | string == INSTALLEDSALTVERSION | string %}
 so_kernel_repo:
   pkgrepo.managed:
     - name: securityonionkernel
@@ -76,6 +85,7 @@ so_kernel_repo:
     # UEK8 kernel update can't renumber interfaces SO binds by name (see pin_nic_names
     # in salt/common/init.sls, which drops this marker via /usr/sbin/so-nic-pin).
     - onlyif: 'test -e /opt/so/state/nic_names_pinned'
+{% endif %}
 
 {% endif %}
   


### PR DESCRIPTION
Follow-up to #16000 (UEK8 kernel repo support). Two changes:

### `so-kernel-upgrade` — make the UEK8 kernel the boot default
Installing `kernel-uek-core` adds a UEK8 (6.x) boot entry but does **not** make it the default: `grubby`/`kernel-install` only auto-promote a new kernel within the running kernel's flavor lineage, and we cross from a 5.x kernel (RHCK / UEK7) to the new UEK8 flavor. Even with `UPDATEDEFAULT=yes` and `DEFAULTKERNEL=kernel-uek-core` the box keeps booting the old kernel.

The new `salt/common/tools/sbin/so-kernel-upgrade` finds the newest installed 6.x UEK kernel and `grubby --set-default`s it. It is:
- **idempotent** — no-op if the UEK8 kernel is already the default
- **verified** — confirms the default actually changed before reporting success
- **non-disruptive** — sets the boot default only; does not reboot (admin reboots on their schedule)

Deploys to `/usr/sbin` via the existing `common/tools/sbin` recurse. Not yet wired into any state — available to run manually.

### Gate `so_kernel_repo` on the running salt version
During a soup the grid is mid-salt-upgrade. The kernel repo (and the UEK8 update it enables) should not activate until the node is fully on the target salt. `salt/repo/client/oracle.sls` now assigns `so_kernel_repo` only when `grains.saltversion` matches `salt.minion.version` from `minion.defaults.yaml`, the same way other states defer across the upgrade window. The main `so_repo` is unchanged; this stacks on the existing NIC-pin `onlyif` gate.