### PR TITLE
Serve /kernelrepo through nginx so minions can reach the kernel repo

### DIFF
--- a/salt/nginx/etc/nginx.conf
+++ b/salt/nginx/etc/nginx.conf
@@ -323,6 +323,16 @@ http {
 			autoindex_localtime on;
 		}
 
+		location /kernelrepo/ {
+			allow all;
+			sendfile on;
+			sendfile_max_chunk 1m;
+			autoindex on;
+			autoindex_exact_size off;
+			autoindex_format html;
+			autoindex_localtime on;
+		}
+
 		location /influxdb/ {
 			auth_request          /auth/sessions/whoami;
 			rewrite               /influxdb/api/(.*) /api/$1 break;


### PR DESCRIPTION
Follow-up to #16000 / #16011.

The `/nsm/kernelrepo:/opt/socore/html/kernelrepo:ro` bind mount (added in #16000) exposed the kernel repo files inside the `so-nginx` container, but the nginx config only had a `location /repo/` block — there was no `/kernelrepo/`. External (minion) requests to `/kernelrepo/` therefore fell through to the SOC web app and were served `index.html`, so dnf on minions failed with:

```
Failed to download metadata for repo 'securityonionkernel': repomd.xml parser error: Parse error at line: 1 (xmlParseStartTag: invalid element name)
```

(`localhost` on the manager served the file fine; only externally-routed path requests hit the SPA fallback, which is why it wasn't obvious.)

This adds a `location /kernelrepo/` block mirroring `/repo/` so the kernel repo is routable for minions. `skip_if_unavailable=1` had already kept this non-fatal; this makes the repo actually reachable.