### PR TITLE
duplicate repo name in so-repo-sync

### DIFF
--- a/salt/manager/files/repodownload.conf
+++ b/salt/manager/files/repodownload.conf
@@ -11,8 +11,8 @@ name=Security Onion Repo repo
 mirrorlist=file:///opt/so/conf/reposync/mirror.txt
 enabled=1
 gpgcheck=1
-[securityonionkernel]
-name=Security Onion Repo repo
+[securityonionkernelsync]
+name=Security Onion Kernel Repo repo
 mirrorlist=file:///opt/so/conf/reposync/mirror-kernel.txt
 enabled=1
 gpgcheck=1

--- a/salt/manager/tools/sbin/so-repo-sync
+++ b/salt/manager/tools/sbin/so-repo-sync
@@ -17,9 +17,9 @@ createrepo /nsm/repo
 # The kernel repo section is deployed to repodownload.conf by the manager highstate, which
 # runs AFTER this script during soup. On the first upgrade to a kernel-aware version the
 # on-disk config still predates the section, so guard on its presence to avoid dnf's
-# "Unknown repo: 'securityonionkernel'" aborting the sync (set -e). The next sync after the
+# "Unknown repo: 'securityonionkernelsync'" aborting the sync (set -e). The next sync after the
 # highstate deploys the section will pick it up.
-if grep -q '^\[securityonionkernel\]' /opt/so/conf/reposync/repodownload.conf; then
-  dnf reposync --norepopath -g --delete -m -c /opt/so/conf/reposync/repodownload.conf --repoid=securityonionkernel --download-metadata -p /nsm/kernelrepo/
+if grep -q '^\[securityonionkernelsync\]' /opt/so/conf/reposync/repodownload.conf; then
+  dnf reposync --norepopath -g --delete -m -c /opt/so/conf/reposync/repodownload.conf --repoid=securityonionkernelsync --download-metadata -p /nsm/kernelrepo/
   createrepo /nsm/kernelrepo
 fi


### PR DESCRIPTION
```
[root@manager onion]# su socore -c "so-repo-sync > /dev/null"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
Repository securityonionkernel is listed more than once in the configuration
```