### PR TITLE
Install UEK8 in so-kernel-upgrade when no UEK kernel is present

### DIFF
--- a/salt/common/tools/sbin/so-kernel-upgrade
+++ b/salt/common/tools/sbin/so-kernel-upgrade
@@ -8,7 +8,7 @@
 # so-kernel-upgrade — install the UEK8 (6.x) kernel and make it the boot default.
 #
 # Security Onion is moving off the EL9 stock kernel (RHCK, 5.14) and UEK7 (5.15) onto UEK8
-# (6.x). Three things have to happen, and none of them are automatic:
+# (6.x). Three things have to happen, and the tool has to drive each one:
 #
 #   1. Populate. The manager mirrors the UEK8 packages into /nsm/kernelrepo via so-repo-sync,
 #      and serves them to the grid over https://<manager>/kernelrepo. Until that sync runs the
@@ -17,13 +17,17 @@
 #      'dnf update' to upgrade. A node on UEK7 does have kernel-uek installed, so
 #      'dnf install kernel-uek' reports "Nothing to do" and exits 0 without installing 6.x.
 #      Both cases need an explicit install of the UEK8 NEVRA.
-#   3. Boot it. Installing kernel-uek-core adds a UEK8 boot entry but does NOT make it the
-#      default: kernel-install/grubby only auto-promote within the running kernel's flavor
-#      lineage, and we're crossing from 5.x to the 6.x UEK flavor. So even with
-#      UPDATEDEFAULT=yes and DEFAULTKERNEL=kernel-uek-core the box keeps booting the old
-#      kernel until grubby is told otherwise.
+#   3. Boot it. Whether a newly installed UEK8 kernel becomes the boot default depends on the
+#      RUNNING kernel's flavor. kernel-install/grubby (with UPDATEDEFAULT=yes) only auto-promote
+#      within the running kernel's flavor lineage:
+#        - From UEK7 (5.x, kernel-uek) the install stays in the kernel-uek lineage and IS
+#          auto-promoted, so no grubby change is needed -- just make sure the repo is populated
+#          and install UEK8.
+#        - From the stock EL9 kernel (RHCK, 5.14, no UEK) it is a flavor CROSS that is NOT
+#          auto-promoted, so the box keeps booting RHCK until grubby is told otherwise.
+#      This tool inspects the running kernel and only runs 'grubby --set-default' for RHCK.
 #
-# Every one of those failure modes is silent by default. This tool does all three and fails
+# Every one of those failure modes is silent by default. This tool handles each case and fails
 # loudly when it cannot, rather than reporting success while changing nothing.
 #
 # Manager vs minion: only the manager owns /nsm/kernelrepo, so only the manager can populate
@@ -60,6 +64,19 @@ find_uek8() {
         | sed -n 's/^kernel="\(.*\)"$/\1/p' \
         | grep -E '/vmlinuz-6\.[0-9]+.*uek' \
         | sort -V | tail -1
+}
+
+# Classify the RUNNING kernel (uname -r) -- this, not what's installed, is what decides whether
+# a UEK8 install auto-promotes to the boot default:
+#   uek8  6.x UEK    already on the target line; nothing to do
+#   uek7  5.x UEK    a UEK8 install stays in the kernel-uek lineage and auto-promotes (no grubby)
+#   rhck  5.14 EL9   crossing into the UEK flavor does NOT auto-promote (needs grubby --set-default)
+running_flavor() {
+    case "$(uname -r)" in
+        6.*uek*) echo uek8 ;;
+        *uek*)   echo uek7 ;;
+        *)       echo rhck ;;
+    esac
 }
 
 # Newest UEK8 kernel-uek NEVRA offered by the kernel repo, empty if the repo has none.
@@ -127,50 +144,96 @@ ensure_kernel_repo() {
         || die "so-repo-sync completed but $KERNEL_REPO still offers no UEK8 $KERNEL_PKG"
 }
 
-target="$(find_uek8)"
-
-if [ -z "$target" ]; then
-    log "no UEK8 kernel installed (running $(uname -r))"
-
-    ensure_kernel_repo
-    nevra="$(uek8_available)"
-
-    # Install the explicit NEVRA, not the bare package name. On a UEK7 node 'dnf install
-    # kernel-uek' sees kernel-uek-5.15 already installed, prints "Nothing to do" and exits 0.
-    log "installing $nevra from $KERNEL_REPO"
-    dnf -y install "$nevra" || die "failed to install $nevra"
-
-    target="$(find_uek8)"
-    [ -n "$target" ] || die "$nevra installed but no 6.x UEK boot entry appeared -- check 'grubby --info=ALL'"
-    log "installed UEK8 kernel: $target"
-fi
-
-# Keep future kernel updates on the UEK line rather than falling back to RHCK. Oracle ships
-# this file; only rewrite it when it's actually pointing somewhere else.
-if [ -f /etc/sysconfig/kernel ] && ! grep -q '^DEFAULTKERNEL=kernel-uek-core$' /etc/sysconfig/kernel; then
-    log "setting DEFAULTKERNEL=kernel-uek-core in /etc/sysconfig/kernel"
-    sed -i 's/^DEFAULTKERNEL=.*/DEFAULTKERNEL=kernel-uek-core/' /etc/sysconfig/kernel
-fi
-
 reboot_notice() {
     [ "$(uname -r)" = "$(basename "$1" | sed 's/^vmlinuz-//')" ] \
         || log "REBOOT REQUIRED to start using the UEK8 kernel (currently running $(uname -r))."
 }
 
-current="$(grubby --default-kernel 2>/dev/null)"
-if [ "$current" = "$target" ]; then
-    log "UEK8 kernel is already the boot default: $target"
-    reboot_notice "$target"
+# Keep future kernel updates on the UEK line rather than falling back to RHCK. Oracle ships
+# /etc/sysconfig/kernel; only rewrite it when it's actually pointing somewhere else.
+set_default_kernel_conf() {
+    if [ -f /etc/sysconfig/kernel ] && ! grep -q '^DEFAULTKERNEL=kernel-uek-core$' /etc/sysconfig/kernel; then
+        log "setting DEFAULTKERNEL=kernel-uek-core in /etc/sysconfig/kernel"
+        sed -i 's/^DEFAULTKERNEL=.*/DEFAULTKERNEL=kernel-uek-core/' /etc/sysconfig/kernel
+    fi
+}
+
+# Make sure a UEK8 kernel is installed, leaving its boot entry in INSTALLED_UEK8. If one is
+# already present we leave the repo alone -- it may be disabled or empty and we don't need it
+# just to flip the boot default. Otherwise install the explicit NEVRA, not the bare package
+# name: on a UEK7 node 'dnf install kernel-uek' sees 5.15 already present, prints "Nothing to
+# do" and exits 0 without installing 6.x.
+ensure_uek8_installed() {
+    INSTALLED_UEK8="$(find_uek8)"
+    if [ -n "$INSTALLED_UEK8" ]; then
+        log "UEK8 kernel already installed: $INSTALLED_UEK8"
+        return 0
+    fi
+
+    ensure_kernel_repo
+    local nevra; nevra="$(uek8_available)"
+    log "installing $nevra from $KERNEL_REPO"
+    dnf -y install "$nevra" || die "failed to install $nevra"
+
+    INSTALLED_UEK8="$(find_uek8)"
+    [ -n "$INSTALLED_UEK8" ] || die "$nevra installed but no 6.x UEK boot entry appeared -- check 'grubby --info=ALL'"
+    log "installed UEK8 kernel: $INSTALLED_UEK8"
+}
+
+case "$(running_flavor)" in
+uek8)
+    # Already on the 6.x UEK line. A plain 'dnf update' keeps this node current within the
+    # lineage and auto-promotes newer builds, so there is nothing for this tool to do.
+    log "already running a UEK8 kernel ($(uname -r)); nothing to do."
     exit 0
-fi
+    ;;
 
-log "current default kernel: ${current:-unknown}"
-log "switching boot default to UEK8 kernel: $target"
-grubby --set-default="$target" || die "grubby --set-default failed for $target"
+uek7)
+    # On a 5.x UEK kernel. Installing UEK8 stays inside the kernel-uek lineage, so dnf/grubby
+    # (UPDATEDEFAULT=yes) auto-promote it and we do NOT touch grubby. A node still on UEK7
+    # usually means the kernel repo was empty when it last updated, so populate it and install.
+    log "running UEK7 kernel ($(uname -r)); the kernel repo was likely not yet populated when"
+    log "this node last updated. Populating it and installing UEK8 -- the update stays on the"
+    log "kernel-uek line, so it becomes the boot default automatically (no grubby change needed)."
+    set_default_kernel_conf
+    ensure_uek8_installed
 
-# Verify the change actually took before claiming success.
-now="$(grubby --default-kernel 2>/dev/null)"
-[ "$now" = "$target" ] || die "default kernel is still '${now:-unknown}' after set-default"
+    now="$(grubby --default-kernel 2>/dev/null)"
+    if [ "$now" = "$INSTALLED_UEK8" ]; then
+        log "boot default auto-promoted to UEK8 kernel: $INSTALLED_UEK8"
+    else
+        log "WARNING: expected the UEK8 kernel to auto-promote but the default is still"
+        log "'${now:-unknown}'. Run 'grubby --set-default=$INSTALLED_UEK8' to force it."
+    fi
+    reboot_notice "$INSTALLED_UEK8"
+    ;;
 
-log "boot default is now $target"
-reboot_notice "$target"
+rhck)
+    # On the stock EL9 kernel (5.14, no UEK installed). Crossing from RHCK into the UEK flavor
+    # does NOT auto-promote -- kernel-install/grubby only auto-promote within the running
+    # kernel's flavor lineage -- so after installing we must set the boot default explicitly.
+    log "running stock EL9 (RHCK) kernel ($(uname -r)); installing UEK8 and setting it as the"
+    log "boot default explicitly (a RHCK->UEK flavor change does not auto-promote)."
+    set_default_kernel_conf
+    ensure_uek8_installed
+    target="$INSTALLED_UEK8"
+
+    current="$(grubby --default-kernel 2>/dev/null)"
+    if [ "$current" = "$target" ]; then
+        log "UEK8 kernel is already the boot default: $target"
+        reboot_notice "$target"
+        exit 0
+    fi
+
+    log "current default kernel: ${current:-unknown}"
+    log "switching boot default to UEK8 kernel: $target"
+    grubby --set-default="$target" || die "grubby --set-default failed for $target"
+
+    # Verify the change actually took before claiming success.
+    now="$(grubby --default-kernel 2>/dev/null)"
+    [ "$now" = "$target" ] || die "default kernel is still '${now:-unknown}' after set-default"
+
+    log "boot default is now $target"
+    reboot_notice "$target"
+    ;;
+esac

--- a/salt/common/tools/sbin/so-kernel-upgrade
+++ b/salt/common/tools/sbin/so-kernel-upgrade
@@ -39,7 +39,11 @@
 
 . /usr/sbin/so-common
 
+# Client-side repo id (what dnf enables on this node, from repo/client/oracle.sls) vs the
+# reposync-side section in repodownload.conf that the manager mirrors from (mirrors the
+# securityonion/securityonionsync split for the main repo).
 KERNEL_REPO="securityonionkernel"
+KERNEL_REPO_SYNC="securityonionkernelsync"
 KERNEL_PKG="kernel-uek"
 KERNEL_REPO_DIR="/nsm/kernelrepo"
 REPOSYNC_CONF="/opt/so/conf/reposync/repodownload.conf"
@@ -95,15 +99,15 @@ kernelrepo_rpm_count() {
 
 # The kernel repo starts life as valid-but-empty (kernelrepo_init_empty in
 # salt/manager/init.sls) and is filled by so-repo-sync. During a soup, so-repo-sync runs
-# BEFORE the highstate deploys the [securityonionkernel] section into repodownload.conf, so
+# BEFORE the highstate deploys the [securityonionkernelsync] section into repodownload.conf, so
 # the first kernel-aware soup leaves the repo empty until the next nightly sync.
 sync_kernel_repo() {
     if is_airgap; then
         log "airgap install: $KERNEL_REPO_DIR is populated from the airgap ISO, not by so-repo-sync."
         return 1
     fi
-    if ! grep -q "^\[${KERNEL_REPO}\]" "$REPOSYNC_CONF" 2>/dev/null; then
-        log "$REPOSYNC_CONF has no [${KERNEL_REPO}] section -- run a highstate to deploy it."
+    if ! grep -q "^\[${KERNEL_REPO_SYNC}\]" "$REPOSYNC_CONF" 2>/dev/null; then
+        log "$REPOSYNC_CONF has no [${KERNEL_REPO_SYNC}] section -- run a highstate to deploy it."
         return 1
     fi
 

--- a/salt/common/tools/sbin/so-kernel-upgrade
+++ b/salt/common/tools/sbin/so-kernel-upgrade
@@ -5,37 +5,56 @@
 # https://securityonion.net/license; you may not use this file except in compliance with the
 # Elastic License 2.0.
 #
-# so-kernel-upgrade — install the UEK8 (6.x) kernel if needed and make it the boot default.
+# so-kernel-upgrade — install the UEK8 (6.x) kernel and make it the boot default.
 #
-# Security Onion is moving off the EL9 stock kernel (RHCK, 5.14) / UEK7 (5.15) onto UEK8 (6.x).
-# Two separate things have to happen, and neither is automatic:
+# Security Onion is moving off the EL9 stock kernel (RHCK, 5.14) and UEK7 (5.15) onto UEK8
+# (6.x). Three things have to happen, and none of them are automatic:
 #
-#   1. Install it. A node running RHCK has no kernel-uek* package at all, so 'dnf update'
-#      never pulls UEK8 in — there is nothing to upgrade. The kernel-uek metapackage has to
-#      be installed explicitly from the securityonionkernel repo.
-#   2. Boot it. Installing kernel-uek-core adds a UEK8 boot entry but does NOT make it the
-#      default: kernel-install/grubby only auto-promote a new kernel within the running
-#      kernel's flavor lineage, and we're crossing from a 5.x kernel to the new 6.x UEK
-#      flavor. So even with UPDATEDEFAULT=yes and DEFAULTKERNEL=kernel-uek-core the box
-#      keeps booting the old kernel until grubby is told otherwise.
+#   1. Populate. The manager mirrors the UEK8 packages into /nsm/kernelrepo via so-repo-sync,
+#      and serves them to the grid over https://<manager>/kernelrepo. Until that sync runs the
+#      repo is valid but EMPTY -- dnf resolves it happily and installs nothing, with no error.
+#   2. Install. A node on RHCK has no kernel-uek* package at all, so there is nothing for
+#      'dnf update' to upgrade. A node on UEK7 does have kernel-uek installed, so
+#      'dnf install kernel-uek' reports "Nothing to do" and exits 0 without installing 6.x.
+#      Both cases need an explicit install of the UEK8 NEVRA.
+#   3. Boot it. Installing kernel-uek-core adds a UEK8 boot entry but does NOT make it the
+#      default: kernel-install/grubby only auto-promote within the running kernel's flavor
+#      lineage, and we're crossing from 5.x to the 6.x UEK flavor. So even with
+#      UPDATEDEFAULT=yes and DEFAULTKERNEL=kernel-uek-core the box keeps booting the old
+#      kernel until grubby is told otherwise.
 #
-# This tool does both, then points DEFAULTKERNEL at kernel-uek-core so later kernel updates
-# stay on the UEK line.
+# Every one of those failure modes is silent by default. This tool does all three and fails
+# loudly when it cannot, rather than reporting success while changing nothing.
+#
+# Manager vs minion: only the manager owns /nsm/kernelrepo, so only the manager can populate
+# it. If the repo is empty here, a manager runs so-repo-sync itself; a minion has no way to
+# fix it and exits non-zero telling the admin to sync the manager first.
 #
 # Idempotent: an already-installed, already-default UEK8 kernel is left alone. It only sets
-# the boot default; it does NOT reboot — the admin reboots the node on their own schedule.
+# the boot default; it does NOT reboot -- the admin reboots the node on their own schedule.
+
+. /usr/sbin/so-common
 
 KERNEL_REPO="securityonionkernel"
 KERNEL_PKG="kernel-uek"
+KERNEL_REPO_DIR="/nsm/kernelrepo"
+REPOSYNC_CONF="/opt/so/conf/reposync/repodownload.conf"
+GLOBAL_PILLAR="/opt/so/saltstack/local/pillar/global/soc_global.sls"
 
 log() { echo "[so-kernel-upgrade] $*"; }
+die() { echo "[so-kernel-upgrade] ERROR: $*" >&2; exit 1; }
 
-[ "$(id -u)" -eq 0 ] || { log "must run as root"; exit 1; }
-command -v grubby >/dev/null 2>&1 || { log "grubby not found"; exit 1; }
-command -v dnf >/dev/null 2>&1 || { log "dnf not found"; exit 1; }
+command -v grubby >/dev/null 2>&1 || die "grubby not found"
+command -v dnf >/dev/null 2>&1 || die "dnf not found"
+
+ARCH="$(rpm -E '%{_arch}')"
+
+is_airgap() {
+    [ -f "$GLOBAL_PILLAR" ] && grep -q 'airgap: *[Tt]rue' "$GLOBAL_PILLAR"
+}
 
 # Newest installed UEK8 (6.x) kernel known to the bootloader. UEK8 vmlinuz paths look like
-# /boot/vmlinuz-6.12.0-203.76.7.5.el9uek.x86_64; the 5.15 UEK7 and 5.14 RHCK won't match.
+# /boot/vmlinuz-6.12.0-204.92.4.2.el9uek.x86_64; UEK7 (5.15) and RHCK (5.14) won't match.
 find_uek8() {
     grubby --info=ALL 2>/dev/null \
         | sed -n 's/^kernel="\(.*\)"$/\1/p' \
@@ -43,28 +62,86 @@ find_uek8() {
         | sort -V | tail -1
 }
 
+# Newest UEK8 kernel-uek NEVRA offered by the kernel repo, empty if the repo has none.
+# Restricted to the kernel repo so a UEK7 kernel-uek in the main repo can't be picked up,
+# and filtered to 6.x so we never "succeed" by reinstalling the 5.15 we already have.
+uek8_available() {
+    dnf -q repoquery --disablerepo='*' --enablerepo="$KERNEL_REPO" \
+        --arch="$ARCH" --latest-limit=1 \
+        --qf '%{name}-%{evr}.%{arch}\n' "$KERNEL_PKG" 2>/dev/null \
+        | grep -E "^${KERNEL_PKG}-6\." | tail -1
+}
+
+kernelrepo_rpm_count() {
+    find "$KERNEL_REPO_DIR" -maxdepth 1 -name '*.rpm' 2>/dev/null | wc -l
+}
+
+# The kernel repo starts life as valid-but-empty (kernelrepo_init_empty in
+# salt/manager/init.sls) and is filled by so-repo-sync. During a soup, so-repo-sync runs
+# BEFORE the highstate deploys the [securityonionkernel] section into repodownload.conf, so
+# the first kernel-aware soup leaves the repo empty until the next nightly sync.
+sync_kernel_repo() {
+    if is_airgap; then
+        log "airgap install: $KERNEL_REPO_DIR is populated from the airgap ISO, not by so-repo-sync."
+        return 1
+    fi
+    if ! grep -q "^\[${KERNEL_REPO}\]" "$REPOSYNC_CONF" 2>/dev/null; then
+        log "$REPOSYNC_CONF has no [${KERNEL_REPO}] section -- run a highstate to deploy it."
+        return 1
+    fi
+
+    log "populating $KERNEL_REPO_DIR with so-repo-sync (mirrors upstream; can take several minutes)"
+    su socore -c '/usr/sbin/so-repo-sync' || { log "so-repo-sync failed"; return 1; }
+
+    dnf -q clean expire-cache >/dev/null 2>&1
+    return 0
+}
+
+# Make the kernel repo actually able to serve a UEK8 package, or fail trying.
+ensure_kernel_repo() {
+    # The repo is assigned by the repo.client highstate, and only once NICs are pinned by MAC
+    # (/opt/so/state/nic_names_pinned) so the kernel swap can't renumber interfaces SO binds
+    # by name. skip_if_unavailable=1 means a broken repo is silently ignored, so check first.
+    if ! dnf -q repolist --enabled 2>/dev/null | awk '{print $1}' | grep -qx "$KERNEL_REPO"; then
+        log "repo '$KERNEL_REPO' is not enabled on this node."
+        log "Run a highstate first; the repo is skipped until /opt/so/state/nic_names_pinned"
+        log "exists (run so-nic-pin) and this node's salt matches the version this release ships."
+        die "kernel repo unavailable"
+    fi
+
+    [ -n "$(uek8_available)" ] && return 0
+
+    log "repo '$KERNEL_REPO' is enabled but offers no UEK8 $KERNEL_PKG package"
+
+    if ! is_manager_node; then
+        log "This is a minion; it consumes the kernel repo from the manager and cannot populate it."
+        log "On the manager, run:  su socore -c /usr/sbin/so-repo-sync"
+        log "then re-run this script here."
+        die "manager's kernel repo is empty"
+    fi
+
+    log "this is a manager and $KERNEL_REPO_DIR holds $(kernelrepo_rpm_count) rpm(s)"
+    sync_kernel_repo || die "could not populate $KERNEL_REPO_DIR"
+
+    [ -n "$(uek8_available)" ] \
+        || die "so-repo-sync completed but $KERNEL_REPO still offers no UEK8 $KERNEL_PKG"
+}
+
 target="$(find_uek8)"
 
 if [ -z "$target" ]; then
-    log "no UEK8 kernel installed — installing $KERNEL_PKG from $KERNEL_REPO"
+    log "no UEK8 kernel installed (running $(uname -r))"
 
-    # The repo is assigned by the repo.client highstate, and only once NICs are pinned by MAC
-    # (/opt/so/state/nic_names_pinned) so the kernel swap can't renumber interfaces SO binds
-    # by name. Without the repo we'd silently pull nothing, so fail loudly instead.
-    if ! dnf -q repolist --enabled 2>/dev/null | awk '{print $1}' | grep -qx "$KERNEL_REPO"; then
-        log "ERROR: repo '$KERNEL_REPO' is not enabled on this node."
-        log "Run a highstate first; it is skipped until /opt/so/state/nic_names_pinned exists"
-        log "(run so-nic-pin) and this node's salt matches the version this release ships."
-        exit 1
-    fi
+    ensure_kernel_repo
+    nevra="$(uek8_available)"
 
-    dnf -y install "$KERNEL_PKG" || { log "ERROR: failed to install $KERNEL_PKG"; exit 1; }
+    # Install the explicit NEVRA, not the bare package name. On a UEK7 node 'dnf install
+    # kernel-uek' sees kernel-uek-5.15 already installed, prints "Nothing to do" and exits 0.
+    log "installing $nevra from $KERNEL_REPO"
+    dnf -y install "$nevra" || die "failed to install $nevra"
 
     target="$(find_uek8)"
-    if [ -z "$target" ]; then
-        log "ERROR: $KERNEL_PKG installed but no 6.x UEK boot entry appeared — check 'grubby --info=ALL'"
-        exit 1
-    fi
+    [ -n "$target" ] || die "$nevra installed but no 6.x UEK boot entry appeared -- check 'grubby --info=ALL'"
     log "installed UEK8 kernel: $target"
 fi
 
@@ -75,24 +152,25 @@ if [ -f /etc/sysconfig/kernel ] && ! grep -q '^DEFAULTKERNEL=kernel-uek-core$' /
     sed -i 's/^DEFAULTKERNEL=.*/DEFAULTKERNEL=kernel-uek-core/' /etc/sysconfig/kernel
 fi
 
+reboot_notice() {
+    [ "$(uname -r)" = "$(basename "$1" | sed 's/^vmlinuz-//')" ] \
+        || log "REBOOT REQUIRED to start using the UEK8 kernel (currently running $(uname -r))."
+}
+
 current="$(grubby --default-kernel 2>/dev/null)"
 if [ "$current" = "$target" ]; then
     log "UEK8 kernel is already the boot default: $target"
-    [ "$(uname -r)" = "$(basename "$target" | sed 's/^vmlinuz-//')" ] \
-        || log "REBOOT REQUIRED to start using it (currently running $(uname -r))."
+    reboot_notice "$target"
     exit 0
 fi
 
 log "current default kernel: ${current:-unknown}"
 log "switching boot default to UEK8 kernel: $target"
-grubby --set-default="$target" || { log "ERROR: grubby --set-default failed for $target"; exit 1; }
+grubby --set-default="$target" || die "grubby --set-default failed for $target"
 
 # Verify the change actually took before claiming success.
 now="$(grubby --default-kernel 2>/dev/null)"
-if [ "$now" != "$target" ]; then
-    log "ERROR: default kernel is still '${now:-unknown}' after set-default"
-    exit 1
-fi
+[ "$now" = "$target" ] || die "default kernel is still '${now:-unknown}' after set-default"
 
 log "boot default is now $target"
-log "REBOOT REQUIRED to start using the UEK8 kernel (currently running $(uname -r))."
+reboot_notice "$target"

--- a/salt/common/tools/sbin/so-kernel-upgrade
+++ b/salt/common/tools/sbin/so-kernel-upgrade
@@ -5,40 +5,81 @@
 # https://securityonion.net/license; you may not use this file except in compliance with the
 # Elastic License 2.0.
 #
-# so-kernel-upgrade — switch the boot default to the installed UEK8 (6.x) kernel.
+# so-kernel-upgrade — install the UEK8 (6.x) kernel if needed and make it the boot default.
 #
-# Security Onion is moving off the EL9 stock kernel / UEK7 (5.x) onto UEK8 (6.x).
-# Installing the kernel-uek-core package adds a UEK8 boot entry but does NOT make it the
-# default: kernel-install/grubby only auto-promote a new kernel within the running
-# kernel's flavor lineage, and we're crossing from a 5.x kernel to the new 6.x UEK flavor.
-# So even with UPDATEDEFAULT=yes and DEFAULTKERNEL=kernel-uek-core the box keeps booting
-# the old kernel. This tool finds the newest installed 6.x UEK kernel and makes it the
-# GRUB default via grubby so the next boot comes up on UEK8.
+# Security Onion is moving off the EL9 stock kernel (RHCK, 5.14) / UEK7 (5.15) onto UEK8 (6.x).
+# Two separate things have to happen, and neither is automatic:
 #
-# Idempotent: if the UEK8 kernel is already the default it does nothing. It only sets the
-# boot default; it does NOT reboot — the admin reboots the node on their own schedule.
+#   1. Install it. A node running RHCK has no kernel-uek* package at all, so 'dnf update'
+#      never pulls UEK8 in — there is nothing to upgrade. The kernel-uek metapackage has to
+#      be installed explicitly from the securityonionkernel repo.
+#   2. Boot it. Installing kernel-uek-core adds a UEK8 boot entry but does NOT make it the
+#      default: kernel-install/grubby only auto-promote a new kernel within the running
+#      kernel's flavor lineage, and we're crossing from a 5.x kernel to the new 6.x UEK
+#      flavor. So even with UPDATEDEFAULT=yes and DEFAULTKERNEL=kernel-uek-core the box
+#      keeps booting the old kernel until grubby is told otherwise.
+#
+# This tool does both, then points DEFAULTKERNEL at kernel-uek-core so later kernel updates
+# stay on the UEK line.
+#
+# Idempotent: an already-installed, already-default UEK8 kernel is left alone. It only sets
+# the boot default; it does NOT reboot — the admin reboots the node on their own schedule.
+
+KERNEL_REPO="securityonionkernel"
+KERNEL_PKG="kernel-uek"
 
 log() { echo "[so-kernel-upgrade] $*"; }
 
 [ "$(id -u)" -eq 0 ] || { log "must run as root"; exit 1; }
 command -v grubby >/dev/null 2>&1 || { log "grubby not found"; exit 1; }
+command -v dnf >/dev/null 2>&1 || { log "dnf not found"; exit 1; }
 
 # Newest installed UEK8 (6.x) kernel known to the bootloader. UEK8 vmlinuz paths look like
-# /boot/vmlinuz-6.12.0-203.76.7.5.el9uek.x86_64; the 5.x UEK7 and 5.14 RHCK won't match.
-target="$(grubby --info=ALL 2>/dev/null \
-    | sed -n 's/^kernel="\(.*\)"$/\1/p' \
-    | grep -E '/vmlinuz-6\.[0-9]+.*uek' \
-    | sort -V | tail -1)"
+# /boot/vmlinuz-6.12.0-203.76.7.5.el9uek.x86_64; the 5.15 UEK7 and 5.14 RHCK won't match.
+find_uek8() {
+    grubby --info=ALL 2>/dev/null \
+        | sed -n 's/^kernel="\(.*\)"$/\1/p' \
+        | grep -E '/vmlinuz-6\.[0-9]+.*uek' \
+        | sort -V | tail -1
+}
+
+target="$(find_uek8)"
 
 if [ -z "$target" ]; then
-    log "no installed 6.x UEK (UEK8) kernel found — confirm the kernel repo is assigned and"
-    log "'dnf update' has installed kernel-uek-core. Nothing to do."
-    exit 0
+    log "no UEK8 kernel installed — installing $KERNEL_PKG from $KERNEL_REPO"
+
+    # The repo is assigned by the repo.client highstate, and only once NICs are pinned by MAC
+    # (/opt/so/state/nic_names_pinned) so the kernel swap can't renumber interfaces SO binds
+    # by name. Without the repo we'd silently pull nothing, so fail loudly instead.
+    if ! dnf -q repolist --enabled 2>/dev/null | awk '{print $1}' | grep -qx "$KERNEL_REPO"; then
+        log "ERROR: repo '$KERNEL_REPO' is not enabled on this node."
+        log "Run a highstate first; it is skipped until /opt/so/state/nic_names_pinned exists"
+        log "(run so-nic-pin) and this node's salt matches the version this release ships."
+        exit 1
+    fi
+
+    dnf -y install "$KERNEL_PKG" || { log "ERROR: failed to install $KERNEL_PKG"; exit 1; }
+
+    target="$(find_uek8)"
+    if [ -z "$target" ]; then
+        log "ERROR: $KERNEL_PKG installed but no 6.x UEK boot entry appeared — check 'grubby --info=ALL'"
+        exit 1
+    fi
+    log "installed UEK8 kernel: $target"
+fi
+
+# Keep future kernel updates on the UEK line rather than falling back to RHCK. Oracle ships
+# this file; only rewrite it when it's actually pointing somewhere else.
+if [ -f /etc/sysconfig/kernel ] && ! grep -q '^DEFAULTKERNEL=kernel-uek-core$' /etc/sysconfig/kernel; then
+    log "setting DEFAULTKERNEL=kernel-uek-core in /etc/sysconfig/kernel"
+    sed -i 's/^DEFAULTKERNEL=.*/DEFAULTKERNEL=kernel-uek-core/' /etc/sysconfig/kernel
 fi
 
 current="$(grubby --default-kernel 2>/dev/null)"
 if [ "$current" = "$target" ]; then
     log "UEK8 kernel is already the boot default: $target"
+    [ "$(uname -r)" = "$(basename "$target" | sed 's/^vmlinuz-//')" ] \
+        || log "REBOOT REQUIRED to start using it (currently running $(uname -r))."
     exit 0
 fi
 

--- a/salt/manager/files/repodownload.conf
+++ b/salt/manager/files/repodownload.conf
@@ -11,8 +11,8 @@ name=Security Onion Repo repo
 mirrorlist=file:///opt/so/conf/reposync/mirror.txt
 enabled=1
 gpgcheck=1
-[securityonionkernel]
-name=Security Onion Repo repo
+[securityonionkernelsync]
+name=Security Onion Kernel Repo repo
 mirrorlist=file:///opt/so/conf/reposync/mirror-kernel.txt
 enabled=1
 gpgcheck=1

--- a/salt/manager/tools/sbin/so-repo-sync
+++ b/salt/manager/tools/sbin/so-repo-sync
@@ -17,9 +17,9 @@ createrepo /nsm/repo
 # The kernel repo section is deployed to repodownload.conf by the manager highstate, which
 # runs AFTER this script during soup. On the first upgrade to a kernel-aware version the
 # on-disk config still predates the section, so guard on its presence to avoid dnf's
-# "Unknown repo: 'securityonionkernel'" aborting the sync (set -e). The next sync after the
+# "Unknown repo: 'securityonionkernelsync'" aborting the sync (set -e). The next sync after the
 # highstate deploys the section will pick it up.
-if grep -q '^\[securityonionkernel\]' /opt/so/conf/reposync/repodownload.conf; then
-  dnf reposync --norepopath -g --delete -m -c /opt/so/conf/reposync/repodownload.conf --repoid=securityonionkernel --download-metadata -p /nsm/kernelrepo/
+if grep -q '^\[securityonionkernelsync\]' /opt/so/conf/reposync/repodownload.conf; then
+  dnf reposync --norepopath -g --delete -m -c /opt/so/conf/reposync/repodownload.conf --repoid=securityonionkernelsync --download-metadata -p /nsm/kernelrepo/
   createrepo /nsm/kernelrepo
 fi


### PR DESCRIPTION
## Problem

Security Onion is moving the grid off the EL9 stock kernel (RHCK, 5.14) and UEK7 (5.15) onto UEK8 (6.x). Getting a running node there is not automatic, and every failure mode along the way is silent:

- **Nothing installs the kernel.** Mirroring the packages and assigning a repo is not enough — a node on RHCK has no `kernel-uek*` package for `dnf update` to upgrade, and a node on UEK7 has `kernel-uek` already, so `dnf install kernel-uek` reports "Nothing to do" and exits 0.
- **Installing doesn't necessarily switch the boot default.** `kernel-install`/`grubby` only auto-promote a new kernel within the running kernel's flavor lineage. A UEK7→UEK8 update stays on the `kernel-uek` line and auto-promotes; a RHCK→UEK jump is a flavor cross that does **not**, so the box keeps booting RHCK until `grubby` is told otherwise.
- **The kernel swap can renumber NICs.** SO binds interfaces by name, so the kernel must not be allowed to change until physical NIC names are pinned by MAC.
- **An empty/missing kernel repo can brick dnf.** An enabled `file:///nsm/kernelrepo` repo with no `repomd.xml` makes every dnf operation on the grid fail.

## Change

Adds end-to-end UEK8 kernel-repo support across install and grid, plus a flavor-aware `so-kernel-upgrade` tool that installs UEK8 and makes it the boot default.

**`so-kernel-upgrade`** (new, `salt/common/tools/sbin/`) — inspects the **running** kernel and does only what that flavor needs:
- **UEK8** already running → no-op.
- **UEK7** → populate the repo if needed and install the UEK8 NEVRA; the update stays on the `kernel-uek` line and auto-promotes, so it does **not** touch grubby (verifies the promotion and warns with the manual command if it somehow didn't happen).
- **RHCK** → install the UEK8 NEVRA and set the boot default explicitly with `grubby --set-default`, since the flavor cross won't auto-promote.

It installs the explicit NEVRA (not the bare package name), points `DEFAULTKERNEL=kernel-uek-core` so later updates stay on the UEK line, and fails loudly when it can't populate/install rather than reporting success while changing nothing. Only the manager can populate `/nsm/kernelrepo`; a minion with an empty repo exits non-zero telling the admin to sync the manager first. Idempotent, and it never reboots — the admin reboots on their own schedule.

**Kernel repo plumbing:**
- `manager/init.sls` — creates `/nsm/kernelrepo`, seeds it as a valid-but-empty repo (`kernelrepo_init_empty`) so an unpopulated repo can't break dnf, and deploys `mirror-kernel.txt`.
- `manager/files/mirror-kernel.txt` — upstream `9-uek8` mirror list.
- `manager/files/repodownload.conf` + `manager/tools/sbin/so-repo-sync` — add a `[securityonionkernelsync]` reposync section and mirror it into `/nsm/kernelrepo`, guarded on the section being present (it's deployed by the highstate, which runs after `so-repo-sync` during a soup).
- `nginx` — serve `/kernelrepo` so minions can reach the manager's kernel repo.
- `repo/client/oracle.sls` — assign the client `securityonionkernel` repo, gated on **both** the node's running salt matching the shipped version **and** the `/opt/so/state/nic_names_pinned` marker; `skip_if_unavailable=1` so an empty repo can't brick dnf.
- `setup/so-functions` — add the kernel repo at install time, sync it, and pin NIC names (`so-nic-pin`) *before* pulling packages so the first highstate can assign the kernel repo without a downgrade/re-upgrade churn.

**Naming:** the reposync-side id is `securityonionkernelsync` and the client-side id is `securityonionkernel`, mirroring the existing `securityonionsync`/`securityonion` split for the main repo (the two roles previously collided on one name).

> Note: `setup/so-functions repo_sync_local()` still writes the setup-time `repodownload.conf` with `[securityonionkernel]`/`--repoid=securityonionkernel`. It's internally consistent for install (the file is later replaced by the highstate with the `securityonionkernelsync` section), but the names drift between setup and steady state — a follow-up could align them.

## Verification

- `bash -n` clean on `so-kernel-upgrade` and `so-repo-sync`.
- Running-kernel classification reviewed for all three states: `6.x…uek` → UEK8 (no-op), `5.x…uek` → UEK7 (install, auto-promote, no grubby), otherwise → RHCK (install + explicit grubby). The UEK8 boot-entry selector matches `/vmlinuz-6.x…uek` and correctly rejects the 5.15 UEK7 kernel despite the `uek` substring.
- Being validated on a live UEK7 manager: the populate path correctly refused to sync when the `[securityonionkernelsync]` section wasn't yet deployed and pointed at running a highstate — which is what surfaced the reposync/client naming split now fixed here.
