### PR TITLE
so-salt-minion-wait: report ready immediately when already ready

### DIFF
--- a/salt/salt/tools/sbin/so-salt-minion-wait
+++ b/salt/salt/tools/sbin/so-salt-minion-wait
@@ -47,7 +47,6 @@
 
 set -u
 
-INITIAL_SLEEP=3
 TIMEOUT=120
 MASTER_PORT=4506
 LOG_TAIL_LINES=10000
@@ -178,9 +177,7 @@ instance_ready() {
   return 0
 }
 
-sleep "$INITIAL_SLEEP"
-
-elapsed="$INITIAL_SLEEP"
+elapsed=0
 pids=""
 announced_pending=0
 while [ "$elapsed" -lt "$TIMEOUT" ]; do


### PR DESCRIPTION
Running the wait on a healthy, steady-state minion always reported readiness after a 3s floor:

  salt-minion (pid 4114640) ready after 3s

That floor came entirely from the unconditional sleep "$INITIAL_SLEEP" (3s) before the poll loop. The sleep is vestigial: it predates restart_pending and never even covered the restart race (see 89e6a746c -- "INITIAL_SLEEP=3 expired inside that window"). Salt restarts the unit with --no-block and the restart job is enqueued before service.restart returns, so an in-flight restart is visible to restart_pending on the first loop iteration; the sleep protects nothing now.

Drop the INITIAL_SLEEP constant and the pre-loop sleep and start elapsed at 0. The loop already sleeps at the bottom of each iteration, so the first readiness check now runs immediately: an already-ready minion returns "ready after 0s", while the restart path (guarded by restart_pending) and the mid-startup log gate are unchanged.