### PR TITLE
PostgreSQL: prevent password log leak + self-heal SOC database bootstrap

### DIFF
--- a/salt/logrotate/defaults.yaml
+++ b/salt/logrotate/defaults.yaml
@@ -150,6 +150,16 @@ logrotate:
       - extension .log
       - dateext
       - dateyesterday
+    /opt/so/log/postgres/*_x_log:
+      - daily
+      - rotate 14
+      - missingok
+      - copytruncate
+      - compress
+      - create
+      - extension .log
+      - dateext
+      - dateyesterday
     /opt/so/log/telegraf/*_x_log:
       - daily
       - rotate 14

--- a/salt/logrotate/soc_logrotate.yaml
+++ b/salt/logrotate/soc_logrotate.yaml
@@ -91,6 +91,13 @@ logrotate:
       multiline: True
       global: True
       forcedType: "[]string"
+    "/opt/so/log/postgres/*_x_log":
+      description: List of logrotate options for this file.
+      title: /opt/so/log/postgres/*.log
+      advanced: True
+      multiline: True
+      global: True
+      forcedType: "[]string"
     "/opt/so/log/telegraf/*_x_log":
       description: List of logrotate options for this file.
       title: /opt/so/log/telegraf/*.log

--- a/salt/manager/tools/sbin/soup
+++ b/salt/manager/tools/sbin/soup
@@ -880,31 +880,6 @@ recollate_postgres() {
   echo ""
 }
 
-bootstrap_so_soc_database() {
-  # init-db.sh is mounted into so-postgres at /docker-entrypoint-initdb.d/init-db.sh
-  # and runs automatically only on a fresh data directory. Hosts upgrading from
-  # 3.1.0 already have /nsm/postgres populated, so the so_soc bootstrap block
-  # added in 3.2 never fires. Re-run the script explicitly; it's idempotent.
-  echo "Bootstrapping database via init-db.sh."
-  # The postgres image has no USER directive, so `docker exec` defaults to
-  # root, and the container env intentionally omits POSTGRES_USER (the upstream
-  # entrypoint defaults it transiently during first-init only). Recreate both
-  # so psql inside init-db.sh resolves the connect user correctly.
-  local exec_cmd="docker exec -u postgres -e POSTGRES_USER=postgres so-postgres bash /docker-entrypoint-initdb.d/init-db.sh"
-  if ! /usr/sbin/so-postgres-wait; then
-    FINAL_MESSAGE_QUEUE+=("WARNING: so-postgres was not ready during the 3.2.0 upgrade; the so_soc database may not have been bootstrapped. Re-run manually: $exec_cmd")
-    return 0
-  fi
-  if ! $exec_cmd; then
-    FINAL_MESSAGE_QUEUE+=("WARNING: init-db.sh failed inside so-postgres during the 3.2.0 upgrade; the database may not have been bootstrapped. Re-run manually: $exec_cmd")
-    return 0
-  fi
-  echo "Database bootstrap complete."
-
-  echo "Restarting so-soc container to pick up database changes"
-  docker restart so-soc
-}
-
 scrub_postgres_log_passwords() {
   # Before 3.2 PostgreSQL could log the full CREATE/ALTER ROLE ... PASSWORD
   # statement -- with the plaintext password -- to postgres.log whenever such a
@@ -1013,7 +988,9 @@ post_to_3.2.0() {
   # Recollate due to image OS rebase
   recollate_postgres
 
-  bootstrap_so_soc_database
+  # The SOC database (so_postgres role, schema/db grants, so_telegraf) is
+  # bootstrapped idempotently by the postgres.enabled highstate that runs
+  # before this postupgrade step, so no explicit bootstrap call is needed here.
 
   # Purge any plaintext passwords a pre-3.2 postgres logged on DDL errors.
   scrub_postgres_log_passwords

--- a/salt/manager/tools/sbin/soup
+++ b/salt/manager/tools/sbin/soup
@@ -881,12 +881,7 @@ recollate_postgres() {
 }
 
 scrub_postgres_log_passwords() {
-  # Before 3.2 PostgreSQL could log the full CREATE/ALTER ROLE ... PASSWORD
-  # statement -- with the plaintext password -- to postgres.log whenever such a
-  # DDL errored, because log_min_error_statement defaulted to 'error'. The leak
-  # is fixed going forward (the provisioning scripts now SET log_min_error_statement
-  # = panic), but any already-logged secret persists in the on-disk log. Purge it
-  # here. Only the manager runs so-postgres, so this is a local scrub.
+  # Purge plaintext passwords a pre-3.2 postgres could log on DDL errors.
   local log=/opt/so/log/postgres/postgres.log
   [[ -f "$log" ]] || return 0
   if ! grep -qai "PASSWORD '" "$log" 2>/dev/null; then
@@ -896,9 +891,7 @@ scrub_postgres_log_passwords() {
   echo "Removing leaked password statements from $log."
   local tmp
   tmp=$(mktemp)
-  # Drop every line carrying a PASSWORD literal, then rewrite in place with
-  # `cat >` so the file keeps its inode -- postgres holds it open via redirected
-  # stderr and must keep logging to the same file.
+  # Rewrite in place (cat >) to keep the inode postgres is writing to.
   grep -avi "PASSWORD '" "$log" > "$tmp" 2>/dev/null || true
   cat "$tmp" > "$log"
   rm -f "$tmp"
@@ -988,11 +981,7 @@ post_to_3.2.0() {
   # Recollate due to image OS rebase
   recollate_postgres
 
-  # The SOC database (so_postgres role, schema/db grants, so_telegraf) is
-  # bootstrapped idempotently by the postgres.enabled highstate that runs
-  # before this postupgrade step, so no explicit bootstrap call is needed here.
-
-  # Purge any plaintext passwords a pre-3.2 postgres logged on DDL errors.
+  # SOC database bootstrap is handled by the postgres.enabled highstate.
   scrub_postgres_log_passwords
 
   # Generate 9.3.7 elastic agent installers

--- a/salt/manager/tools/sbin/soup
+++ b/salt/manager/tools/sbin/soup
@@ -905,6 +905,30 @@ bootstrap_so_soc_database() {
   docker restart so-soc
 }
 
+scrub_postgres_log_passwords() {
+  # Before 3.2 PostgreSQL could log the full CREATE/ALTER ROLE ... PASSWORD
+  # statement -- with the plaintext password -- to postgres.log whenever such a
+  # DDL errored, because log_min_error_statement defaulted to 'error'. The leak
+  # is fixed going forward (the provisioning scripts now SET log_min_error_statement
+  # = panic), but any already-logged secret persists in the on-disk log. Purge it
+  # here. Only the manager runs so-postgres, so this is a local scrub.
+  local log=/opt/so/log/postgres/postgres.log
+  [[ -f "$log" ]] || return 0
+  if ! grep -qai "PASSWORD '" "$log" 2>/dev/null; then
+    echo "No leaked passwords found in $log."
+    return 0
+  fi
+  echo "Removing leaked password statements from $log."
+  local tmp
+  tmp=$(mktemp)
+  # Drop every line carrying a PASSWORD literal, then rewrite in place with
+  # `cat >` so the file keeps its inode -- postgres holds it open via redirected
+  # stderr and must keep logging to the same file.
+  grep -avi "PASSWORD '" "$log" > "$tmp" 2>/dev/null || true
+  cat "$tmp" > "$log"
+  rm -f "$tmp"
+}
+
 # Existing grids should keep ILM unless an admin explicitly opts in to DLM.
 pin_elasticsearch_data_retention_method() {
   local elasticsearch_file=/opt/so/saltstack/local/pillar/elasticsearch/soc_elasticsearch.sls
@@ -990,6 +1014,9 @@ post_to_3.2.0() {
   recollate_postgres
 
   bootstrap_so_soc_database
+
+  # Purge any plaintext passwords a pre-3.2 postgres logged on DDL errors.
+  scrub_postgres_log_passwords
 
   # Generate 9.3.7 elastic agent installers
   echo "Regenerating Elastic Agent Installers"

--- a/salt/postgres/enabled.sls
+++ b/salt/postgres/enabled.sls
@@ -85,6 +85,26 @@ so-postgres:
       - x509: postgres_crt
       - x509: postgres_key
 
+postgres_wait_ready:
+  cmd.run:
+    - name: /usr/sbin/so-postgres-wait
+    - require:
+      - docker_container: so-postgres
+      - file: postgres_sbin
+
+# Re-run the SOC database bootstrap on every highstate so a cluster left
+# partially initialized -- e.g. the container was restarted mid first-init by a
+# watch trigger, so docker-entrypoint-initdb.d never completed -- self-heals:
+# the so_postgres role, its schema/database grants, and the so_telegraf database
+# are all reconciled idempotently. init-db.sh is idempotent and race-safe.
+# POSTGRES_USER is injected because the container env intentionally omits it.
+postgres_bootstrap_soc_db:
+  cmd.run:
+    - name: docker exec -u postgres -e POSTGRES_USER=postgres so-postgres bash /docker-entrypoint-initdb.d/init-db.sh
+    - require:
+      - cmd: postgres_wait_ready
+      - file: postgresinitdb
+
 delete_so-postgres_so-status.disabled:
   file.uncomment:
     - name: /opt/so/conf/so-status/so-status.conf

--- a/salt/postgres/enabled.sls
+++ b/salt/postgres/enabled.sls
@@ -92,12 +92,9 @@ postgres_wait_ready:
       - docker_container: so-postgres
       - file: postgres_sbin
 
-# Re-run the SOC database bootstrap on every highstate so a cluster left
-# partially initialized -- e.g. the container was restarted mid first-init by a
-# watch trigger, so docker-entrypoint-initdb.d never completed -- self-heals:
-# the so_postgres role, its schema/database grants, and the so_telegraf database
-# are all reconciled idempotently. init-db.sh is idempotent and race-safe.
-# POSTGRES_USER is injected because the container env intentionally omits it.
+# Reconcile the SOC database (role, grants, so_telegraf) every highstate so a
+# partially-initialized cluster self-heals. POSTGRES_USER is injected because
+# the container env omits it.
 postgres_bootstrap_soc_db:
   cmd.run:
     - name: docker exec -u postgres -e POSTGRES_USER=postgres so-postgres bash /docker-entrypoint-initdb.d/init-db.sh

--- a/salt/postgres/files/init-db.sh
+++ b/salt/postgres/files/init-db.sh
@@ -8,6 +8,10 @@ if [ -z "${SO_POSTGRES_PASS:-}" ] && [ -n "${SO_POSTGRES_PASS_FILE:-}" ] && [ -r
     SO_POSTGRES_PASS="$(< "$SO_POSTGRES_PASS_FILE")"
 fi
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    -- Shield the plaintext password below from postgres.log if this DDL errors:
+    -- log_min_error_statement defaults to 'error', which would append a STATEMENT line
+    -- containing the full CREATE/ALTER ROLE ... PASSWORD text. panic suppresses that.
+    SET log_min_error_statement = panic;
     DO \$\$
     BEGIN
         IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '${SO_POSTGRES_USER}') THEN

--- a/salt/postgres/files/init-db.sh
+++ b/salt/postgres/files/init-db.sh
@@ -8,16 +8,10 @@ if [ -z "${SO_POSTGRES_PASS:-}" ] && [ -n "${SO_POSTGRES_PASS_FILE:-}" ] && [ -r
     SO_POSTGRES_PASS="$(< "$SO_POSTGRES_PASS_FILE")"
 fi
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
-    -- Shield the plaintext password below from postgres.log if this DDL errors:
-    -- log_min_error_statement defaults to 'error', which would append a STATEMENT line
-    -- containing the full CREATE/ALTER ROLE ... PASSWORD text. panic suppresses that.
+    -- Keep the password out of postgres.log if this DDL errors.
     SET log_min_error_statement = panic;
-    -- Race-safe upsert: try CREATE, and if the role was created concurrently
-    -- (another session re-entering init) fall back to ALTER. Catching the
-    -- exception -- rather than an IF NOT EXISTS check -- avoids a TOCTOU window
-    -- where CREATE ROLE would abort the whole script with a duplicate-key error
-    -- and skip the grants below. Both SQLSTATEs are covered: duplicate_object
-    -- (role already exists) and unique_violation (racy pg_authid index insert).
+    -- Idempotent, race-safe upsert: CREATE, falling back to ALTER if the role
+    -- already exists or is created concurrently.
     DO \$\$
     BEGIN
         BEGIN

--- a/salt/postgres/files/init-db.sh
+++ b/salt/postgres/files/init-db.sh
@@ -12,13 +12,19 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
     -- log_min_error_statement defaults to 'error', which would append a STATEMENT line
     -- containing the full CREATE/ALTER ROLE ... PASSWORD text. panic suppresses that.
     SET log_min_error_statement = panic;
+    -- Race-safe upsert: try CREATE, and if the role was created concurrently
+    -- (another session re-entering init) fall back to ALTER. Catching the
+    -- exception -- rather than an IF NOT EXISTS check -- avoids a TOCTOU window
+    -- where CREATE ROLE would abort the whole script with a duplicate-key error
+    -- and skip the grants below. Both SQLSTATEs are covered: duplicate_object
+    -- (role already exists) and unique_violation (racy pg_authid index insert).
     DO \$\$
     BEGIN
-        IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '${SO_POSTGRES_USER}') THEN
+        BEGIN
             EXECUTE format('CREATE ROLE %I WITH LOGIN PASSWORD %L', '${SO_POSTGRES_USER}', '${SO_POSTGRES_PASS}');
-        ELSE
-            EXECUTE format('ALTER ROLE %I WITH PASSWORD %L', '${SO_POSTGRES_USER}', '${SO_POSTGRES_PASS}');
-        END IF;
+        EXCEPTION WHEN duplicate_object OR unique_violation THEN
+            EXECUTE format('ALTER ROLE %I WITH LOGIN PASSWORD %L', '${SO_POSTGRES_USER}', '${SO_POSTGRES_PASS}');
+        END;
     END
     \$\$;
     GRANT ALL ON SCHEMA public TO "$SO_POSTGRES_USER";

--- a/salt/postgres/telegraf_users.sls
+++ b/salt/postgres/telegraf_users.sls
@@ -8,22 +8,15 @@
 {%   from 'vars/globals.map.jinja' import GLOBALS %}
 {%   from 'telegraf/map.jinja' import TELEGRAFMERGED %}
 
-{# postgres_wait_ready below requires `docker_container: so-postgres`, which is
-   declared in postgres.enabled. Include it here so state.apply postgres.telegraf_users
-   on its own (e.g. from orch.deploy_newnode) still has that ID in scope. Salt
-   de-duplicates the circular include. #}
+{# postgres_wait_ready and the so-postgres container are declared in
+   postgres.enabled; include it so the require references below resolve and so
+   state.apply postgres.telegraf_users on its own (e.g. from orch.deploy_newnode)
+   still has those IDs in scope. Salt de-duplicates the circular include. #}
 include:
   - postgres.enabled
 
 {% set TG_OUT = TELEGRAFMERGED.output | upper %}
 {% if TG_OUT in ['POSTGRES', 'BOTH'] %}
-
-postgres_wait_ready:
-  cmd.run:
-    - name: /usr/sbin/so-postgres-wait
-    - require:
-      - docker_container: so-postgres
-      - file: postgres_sbin
 
 # Ensure the shared Telegraf database exists. init-db.sh only runs on a
 # fresh data dir, so hosts upgraded onto an existing /nsm/postgres volume

--- a/salt/postgres/telegraf_users.sls
+++ b/salt/postgres/telegraf_users.sls
@@ -8,10 +8,8 @@
 {%   from 'vars/globals.map.jinja' import GLOBALS %}
 {%   from 'telegraf/map.jinja' import TELEGRAFMERGED %}
 
-{# postgres_wait_ready and the so-postgres container are declared in
-   postgres.enabled; include it so the require references below resolve and so
-   state.apply postgres.telegraf_users on its own (e.g. from orch.deploy_newnode)
-   still has those IDs in scope. Salt de-duplicates the circular include. #}
+{# postgres.enabled declares the so-postgres container and postgres_wait_ready
+   that the requires below reference. Salt de-duplicates the circular include. #}
 include:
   - postgres.enabled
 

--- a/salt/postgres/tools/sbin/so-telegraf-postgres
+++ b/salt/postgres/tools/sbin/so-telegraf-postgres
@@ -71,6 +71,10 @@ EOSQL
       -v role_user="$ROLE_USER" \
       -v role_pass="$ROLE_PASS" \
       -U postgres -d so_telegraf <<'EOSQL'
+-- Shield the plaintext password below from postgres.log if this DDL errors:
+-- log_min_error_statement defaults to 'error', which would append a STATEMENT line
+-- containing the full CREATE/ALTER ROLE ... PASSWORD text. panic suppresses that.
+SET log_min_error_statement = panic;
 SELECT format(
   CASE WHEN EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = :'role_user')
        THEN 'ALTER ROLE %I WITH LOGIN PASSWORD %L'

--- a/salt/postgres/tools/sbin/so-telegraf-postgres
+++ b/salt/postgres/tools/sbin/so-telegraf-postgres
@@ -71,9 +71,7 @@ EOSQL
       -v role_user="$ROLE_USER" \
       -v role_pass="$ROLE_PASS" \
       -U postgres -d so_telegraf <<'EOSQL'
--- Shield the plaintext password below from postgres.log if this DDL errors:
--- log_min_error_statement defaults to 'error', which would append a STATEMENT line
--- containing the full CREATE/ALTER ROLE ... PASSWORD text. panic suppresses that.
+-- Keep the password out of postgres.log if this DDL errors.
 SET log_min_error_statement = panic;
 SELECT format(
   CASE WHEN EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = :'role_user')


### PR DESCRIPTION
This branch has two related PostgreSQL robustness fixes.

---

## 1. Prevent plaintext passwords in postgres.log

`log_min_error_statement` defaults to `error`, so whenever a `CREATE/ALTER ROLE ... PASSWORD` statement **errors**, PostgreSQL writes the full statement — including the plaintext password — to `/opt/so/log/postgres/postgres.log` (redirected container stderr, in the standard, world-readable `/opt/so/log` tree). The password is only written on an error, so not every grid is affected, but any that hit a provisioning error have plaintext on disk.

- **Stop the leak** — `SET log_min_error_statement = panic;` before the password-bearing DDL in `init-db.sh` and `so-telegraf-postgres`. Errors no longer emit the `STATEMENT:` line; the `ERROR:` message itself (no password) still logs.
- **Rotate postgres.log** — add a `logrotate` stanza for `/opt/so/log/postgres/*.log` matching every other service (daily, keep 14, `copytruncate`, compress).
- **Scrub already-leaked secrets** — `scrub_postgres_log_passwords` in `soup`, called from `post_to_3.2.0`, drops any `PASSWORD '…'` line from `postgres.log` in place (inode-preserving).

## 2. Self-heal the SOC database bootstrap

A fresh `standalone-azure` install left PostgreSQL partially initialized and SOC broken: the `so_postgres` role existed but its schema grants and the `so_telegraf` database were missing → `permission denied for schema public`. Cause: `init-db.sh` runs only on fresh `PGDATA`, and a `CREATE ROLE` duplicate-key **race** (container restarted mid first-init by a `watch` trigger) tripped `set -e` + `ON_ERROR_STOP=1`, aborting the script before the grants and `so_telegraf` creation ran. Nothing re-ran it.

- **Race-safe init-db.sh** — role upsert now tries `CREATE ROLE` and falls back to `ALTER` on `duplicate_object`/`unique_violation`, so a concurrent creator no longer aborts the script. The whole script is idempotent.
- **Reconcile every highstate** — moved `postgres_wait_ready` into `postgres/enabled.sls` and added `postgres_bootstrap_soc_db`, which re-runs `init-db.sh` on every highstate so a partially-initialized cluster self-heals. Removed the now-duplicate `postgres_wait_ready` from `telegraf_users.sls`.
- **Dropped `bootstrap_so_soc_database` from soup** — the highstates soup runs before `postupgrade_changes` now reconcile the SOC DB, making the one-shot bootstrap (and its `docker restart so-soc` nudge) redundant; SOC's own retry loop recovers once grants land.

Note: the `FATAL: no pg_hba.conf entry for host "172.17.1.1" ... no encryption` seen in the logs is benign — SOC uses `sslMode: "allow"`, which probes cleartext first (rejected by the `hostssl`-only `pg_hba.conf`) then retries over SSL. It is not the breakage.

## Testing

- `bash -n` passes for `soup` and `init-db.sh`.
- Log scrub verified on a sample: removes `PASSWORD '…'` lines (incl. SQL-escaped `''`), keeps `ERROR:`/benign lines, preserves inode.
- Generated bootstrap SQL rendered to confirm `$$` quoting and the new `EXCEPTION` block are well-formed.
- On a grid, verify: race-safe upsert takes the `ALTER` path with no error and grants still run; after `REVOKE ALL ON SCHEMA public` + `DROP DATABASE so_telegraf`, a highstate re-grants and recreates `so_telegraf`; `state.show_sls postgres.enabled` compiles with no duplicate-ID for `postgres_wait_ready`; fresh install comes up healthy.