### PR TITLE
Map default agents to model displayName, not id

### DIFF
--- a/salt/soc/defaults.yaml
+++ b/salt/soc/defaults.yaml
@@ -1530,9 +1530,9 @@ soc:
               healthTimeoutSeconds: 5
           agentic: false
           agentMapping:
-            Orchestrator: sonnet
-            Investigator: sonnet
-            Detection Engineer: sonnet
+            Orchestrator: Claude Sonnet
+            Investigator: Claude Sonnet
+            Detection Engineer: Claude Sonnet
         onionconfig:
           saltstackDir: /opt/so/saltstack
           bypassEnabled: false


### PR DESCRIPTION
Aligns the stock `agentMapping` defaults with the documented contract: values are model **displayNames** (the canonical selector), not model ids.

`Orchestrator`/`Investigator`/`Detection Engineer` now map to `Claude Sonnet` (the model's `displayName`) instead of `sonnet` (its `id`). The id form only resolved via the legacy `id@adapter` fallback, which pinned the adapter to a hardcoded `SOAI` default and broke agentic mode on deployments that renamed the adapter (e.g. `SOAIDEV`/`SOAIPROD`).

Companion to securityonion-soc#1226, which fixes the underlying resolution so both forms work; this change makes the default config consistent with the intended contract.