### PR TITLE
Fix agentMapping defaults: displayName values and DetectionEngineer key

### DIFF
--- a/salt/soc/defaults.yaml
+++ b/salt/soc/defaults.yaml
@@ -1530,9 +1530,9 @@ soc:
               healthTimeoutSeconds: 5
           agentic: false
           agentMapping:
-            Orchestrator: sonnet
-            Investigator: sonnet
-            Detection Engineer: sonnet
+            Orchestrator: Claude Sonnet
+            Investigator: Claude Sonnet
+            Detection Engineer: Claude Sonnet
         onionconfig:
           saltstackDir: /opt/so/saltstack
           bypassEnabled: false


### PR DESCRIPTION
Two related corrections to the stock `agentMapping` block, which touch the same lines.

## 1. Values: model displayName, not id

`agentMapping` values are model **displayNames** (the canonical selector), not model ids. `Orchestrator`/`Investigator`/`DetectionEngineer` now map to `Claude Sonnet` instead of `sonnet`. The id form only resolves via the legacy `id@adapter` fallback, so using the displayName makes agent-to-model resolution unambiguous and consistent with the non-agentic selector path.

## 2. Key: drop the space in "Detection Engineer"

The agent name doubles as the `agentMapping` config key and therefore a segment of the SOC setting id (`...assistant.agentMapping.Detection Engineer`). The embedded space made that identifier awkward to target in config, so the agent is renamed to `DetectionEngineer` (matching the single-token style of the other agents), in both `defaults.yaml` and the `soc_soc.yaml` annotation.

## Coordination

Requires securityonion-soc#1234, which renames the agent in code. These must land together — otherwise `validateAgentMappings` finds no mapping for the agent and drops it from agentic mode.

No back-compat alias: any deployment overriding this agent must update its pillar to the new key.