### PR TITLE
Rename Detection Engineer agent key to DetectionEngineer

### DIFF
--- a/salt/soc/defaults.yaml
+++ b/salt/soc/defaults.yaml
@@ -1532,7 +1532,7 @@ soc:
           agentMapping:
             Orchestrator: sonnet
             Investigator: sonnet
-            Detection Engineer: sonnet
+            DetectionEngineer: sonnet
         onionconfig:
           saltstackDir: /opt/so/saltstack
           bypassEnabled: false

--- a/salt/soc/soc_soc.yaml
+++ b/salt/soc/soc_soc.yaml
@@ -786,7 +786,7 @@ soc:
             Investigator:
               description: This agent investigates alerts, explains events and records, and hunts through event data. It can also acknowledge alerts and escalate to cases.
               global: True
-            Detection Engineer:
+            DetectionEngineer:
               description: This agent manages detections and their overrides, including tuning noisy rules and authoring rule content.
               global: True
       client:


### PR DESCRIPTION
The agent name doubles as the `agentMapping` config key and therefore a segment of the SOC setting id (`...assistant.agentMapping.Detection Engineer`). The embedded space made that identifier awkward to target in config.

Renamed to `DetectionEngineer`, matching the single-token style of `Orchestrator` and `Investigator`, in both `defaults.yaml` and the `soc_soc.yaml` annotation.

## Coordination

Requires securityonion-soc#1234, which renames the agent in code. These must land together — otherwise `validateAgentMappings` finds no mapping for the agent and drops it from agentic mode.

No back-compat alias: any deployment overriding this agent must update its pillar to the new key.

## Note

Overlaps with #16093, which changes the values on these same `agentMapping` lines (`sonnet` -> `Claude Sonnet`). Whichever merges second will need a trivial rebase on that one line.