### PR TITLE
Remove icsnpp-modbus from defaults.yaml

### DIFF
--- a/salt/zeek/defaults.yaml
+++ b/salt/zeek/defaults.yaml
@@ -62,7 +62,6 @@ zeek:
         - securityonion/file-extraction
         - securityonion/community-id-extended
         - oui-logging
-        - icsnpp-modbus
         - icsnpp-dnp3
         - icsnpp-bacnet
         - icsnpp-ethercat


### PR DESCRIPTION
Removed 'icsnpp-modbus' from the list of modules to address major performance issue.