### PR TITLE
Add default esheap value so nodes highstate without the pillar value

### DIFF
--- a/salt/elasticsearch/defaults.yaml
+++ b/salt/elasticsearch/defaults.yaml
@@ -1,5 +1,6 @@
 elasticsearch:
   enabled: false
+  esheap: '600m'
   version: 9.3.7
   index_clean: true
   data_retention_method: DLM

--- a/salt/vars/elasticsearch.map.jinja
+++ b/salt/vars/elasticsearch.map.jinja
@@ -1,10 +1,11 @@
 {% import 'vars/init.map.jinja' as INIT %}
+{% import_yaml 'elasticsearch/defaults.yaml' as ELASTICSEARCHDEFAULTS %}
 
 {%
   set ELASTICSEARCH_GLOBALS = {
     'elasticsearch': {
       'es_cluster_name': INIT.PILLAR.elasticsearch.config.cluster.name,
-      'es_heap': INIT.PILLAR.elasticsearch.esheap
+      'es_heap': INIT.PILLAR.elasticsearch.get('esheap', ELASTICSEARCHDEFAULTS.elasticsearch.esheap)
     }
   }
 %}


### PR DESCRIPTION
Previously salt/vars/elasticsearch.map.jinja read the elasticsearch heap size via a raw pillar access (INIT.PILLAR.elasticsearch.esheap). If the esheap key was missing from a minion pillar, building GLOBALS raised 'dict object has no attribute esheap', cascading into every state that imports GLOBALS (elasticsearch.enabled, logstash.config, telegraf.config, etc.) and blocking highstate entirely.

Add an esheap default ('600m', matching the es_heapsize() floor) to elasticsearch/defaults.yaml and fall back to it via dict .get() so a missing pillar value degrades gracefully. The per-node pillar value still wins when present.
