### PR TITLE
Lower default auto_apply batch size to 10%

### DIFF
--- a/salt/manager/tools/sbin/so-soup-grid-highstate
+++ b/salt/manager/tools/sbin/so-soup-grid-highstate
@@ -77,7 +77,7 @@ fi
 # command line, falling back to the same defaults orch.push_batch/salt.defaults use.
 if [ -z "$BATCH" ]; then
   BATCH=$(salt-call --out=newline_values_only pillar.get salt:auto_apply:batch 2>/dev/null)
-  [ -z "$BATCH" ] && BATCH='25%'
+  [ -z "$BATCH" ] && BATCH='10%'
 fi
 if [ -z "$BATCH_WAIT" ]; then
   BATCH_WAIT=$(salt-call --out=newline_values_only pillar.get salt:auto_apply:batch_wait 2>/dev/null)

--- a/salt/manager/tools/sbin/soup
+++ b/salt/manager/tools/sbin/soup
@@ -2154,7 +2154,7 @@ main() {
 
 
 
-This appears to be a distributed deployment. soup has dispatched a batched, grid-wide highstate to update the other nodes now: Elasticsearch data nodes (search/heavy nodes) first, then receivers, then sensors and the remaining nodes. Progress is logged to /opt/so/log/salt/so-soup-grid-highstate, and you can watch nodes update from the Grid section of SOC. Do not manually restart anything until you know that all the search/heavy nodes in your deployment are updated. This is especially important if you are using true clustering for Elasticsearch.
+This appears to be a distributed deployment. soup has dispatched a batched, grid-wide highstate to update the other nodes now: Elasticsearch data nodes (search/heavynodes) first, then receivers, then sensors and the remaining nodes. Progress is logged to /opt/so/log/salt/so-soup-grid-highstate, and you can watch nodes update from the Grid section of SOC. Do not manually restart anything until you know that all the search/heavynodes in your deployment are updated. This is especially important if you are using true clustering for Elasticsearch.
 
 Nodes are updated in batches, and things like network bandwidth can be a factor in how long the actual upgrade takes. If you have a heavy node on a slow link, it is going to take a while to get the containers to it. Depending on what changes happened between the versions, Elasticsearch might not be able to talk to said heavy node until the update is complete. Any node that is offline or missed a batch will converge on its own scheduled highstate (every 120 minutes by default).
 

--- a/salt/salt/defaults.yaml
+++ b/salt/salt/defaults.yaml
@@ -3,7 +3,7 @@ salt:
     enabled: true
     debounce_seconds: 30
     drain_interval: 15
-    batch: '25%'
+    batch: '10%'
     batch_wait: 15
   schedule:
     highstate_interval_minutes: 120


### PR DESCRIPTION
  - Lowers the default `salt:auto_apply:batch` from `25%` to `10%` so push
    orchestrations roll out in smaller waves. This shared default drives both the
    active-push drainer (`orch.push_batch`) and the soup grid highstate
    (`so-soup-grid-highstate`). Operators can still override it in the SOC UI.
  - Keeps the `so-soup-grid-highstate` degraded-path fallback in sync at `10%`.
  - Minor wording fix in soup's distributed-deployment message ("heavy nodes" → "heavynodes").