### PR TITLE
Use argv arrays for telegraf inputs.exec commands

### DIFF
--- a/salt/telegraf/etc/telegraf.conf
+++ b/salt/telegraf/etc/telegraf.conf
@@ -335,7 +335,7 @@
 {%-   do TELEGRAFMERGED.scripts[GLOBALS.role.split('-')[1]].remove('sostatus.sh') %}
 [[inputs.exec]]
    commands = [
-      "/scripts/sostatus.sh"
+      ["/scripts/sostatus.sh"]
    ]
    data_format = "influx"
    timeout = "15s"
@@ -346,7 +346,7 @@
 [[inputs.exec]]
    commands = [
 {%-   for script in TELEGRAFMERGED.scripts[GLOBALS.role.split('-')[1]] %}
-      "/scripts/{{script}}"{% if not loop.last %},{% endif %}
+      ["/scripts/{{script}}"]{% if not loop.last %},{% endif %}
 {%-   endfor %}
    ]
   data_format = "influx"
@@ -375,7 +375,7 @@
 {%- if GLOBALS.is_manager or GLOBALS.role == 'so-heavynode' %}
 [[ inputs.exec ]]
   commands = [
-    "/scripts/esindexsize.sh"
+    ["/scripts/esindexsize.sh"]
   ]
   data_format = "influx"
   interval = "1h"


### PR DESCRIPTION
Telegraf 1.39 deprecated bare string entries in `inputs.exec` `commands` and removes them in 1.45. Every telegraf start currently logs:

```
W! DeprecationWarning: Value "/scripts/esindexsize.sh" for option "command" of plugin "inputs.exec" deprecated since version 1.39.0 and will be removed in 1.45.0: Use array syntax instead: ["/scripts/esindexsize.sh"]
```

All three `inputs.exec` blocks in `salt/telegraf/etc/telegraf.conf` used the string form (sostatus, the per-role scripts loop, and esindexsize). Each entry is now a single-element argv array.

Array form skips shell parsing. That is safe here — every command is a bare script path: `defaults.yaml` lists plain `*.sh` filenames for all roles, and the SOC annotation states the script must be present in `salt/telegraf/scripts`, so there are no args or shell metacharacters.

Verified by rendering the template for manager, sensor, standalone, fleet, and idh roles and parsing the output as TOML:

```
so-manager -> [['/scripts/sostatus.sh']], [['/scripts/agentstatus.sh'], ['/scripts/influxdbsize.sh'], ...]
esindexsize -> [['/scripts/esindexsize.sh']]
```