### PR TITLE
Fix Regex

### DIFF
--- a/salt/soc/soc_soc.yaml
+++ b/salt/soc/soc_soc.yaml
@@ -855,7 +855,7 @@ soc:
             forcedType: bool
           dontScanBefore:
             description: A date specifying how far back to scan for memories. Must be in UTC format (2026-08-31T22:05:48Z).
-            regex: "^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z)?$"
+            regex: '^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z)?$'
             regexFailureMessage: Expecting date in RFC3339 format (2026-08-31T22:05:48Z)
             global: True
             advanced: True


### PR DESCRIPTION
Double quoted strings in yaml allow for escape sequences like `\n` and `\t` but, when used around a regex, salt will hang up on `\d` not being a valid escape sequence. Switching to single quotes so escapes aren't processed.

## Description

<!-- 
Explain the purpose of the pull request. Be brief or detailed depending on the scope of the changes.
-->

## Related Issues

<!-- 
Optionally, list any related issues that this pull request addresses.
-->

## Checklist

- [ ] I have read and followed the [CONTRIBUTING.md](https://github.com/Security-Onion-Solutions/securityonion/blob/3/main/CONTRIBUTING.md) file.
- [ ] I have read and agree to the terms of the [Contributor License Agreement](https://securityonionsolutions.com/cla)

## Questions or Comments

<!--
If you have any questions or comments about this pull request, add them here.
-->