### PR TITLE
Define ToolTurn Defaults

### DIFF
--- a/salt/soc/defaults.yaml
+++ b/salt/soc/defaults.yaml
@@ -1552,6 +1552,8 @@ soc:
           reconcileModel: gemma@SOAI
           memoryPersona: ""
           reconcilePersona: ""
+          toolUseTurnAttempts: 12
+          toolUseTurnDelayMs: 175
         onionconfig:
           saltstackDir: /opt/so/saltstack
           bypassEnabled: false

--- a/salt/soc/soc_soc.yaml
+++ b/salt/soc/soc_soc.yaml
@@ -900,6 +900,14 @@ soc:
             global: True
             readonlyUi: True
             multiline: True
+          toolUseTurnAttempts:
+            description: Number of times the API will retry looking up a tool request that has finished streaming but has not yet been saved to the database. Each retry waits toolUseTurnDelayMs before checking again. If tool auto-approval fails intermittently, increasing this value gives the message more time to be saved.
+            global: True
+            advanced: True
+          toolUseTurnDelayMs:
+            description: Milliseconds to wait between attempts to look up a tool request that has finished streaming but has not yet been saved to the database. The API retries up to toolUseTurnAttempts times, so this value times the attempt count is the maximum wait before auto-approval fails. Increase it if tool auto-approval fails intermittently.
+            global: True
+            advanced: True
       client:
         assistant:
           enabled:


### PR DESCRIPTION
When auto approving tools, we might approve a tool_request before it's been saved to ES. These vars describe some leniency in retrying when the message can't be found before giving up.

## Description

<!-- 
Explain the purpose of the pull request. Be brief or detailed depending on the scope of the changes.
-->

## Related Issues

<!-- 
Optionally, list any related issues that this pull request addresses.
-->

## Checklist

- [ ] I have read and followed the [CONTRIBUTING.md](https://github.com/Security-Onion-Solutions/securityonion/blob/3/main/CONTRIBUTING.md) file.
- [ ] I have read and agree to the terms of the [Contributor License Agreement](https://securityonionsolutions.com/cla)

## Questions or Comments

<!--
If you have any questions or comments about this pull request, add them here.
-->