### PR TITLE
Batch Size and Retries

### DIFF
--- a/salt/soc/defaults.yaml
+++ b/salt/soc/defaults.yaml
@@ -1547,6 +1547,8 @@ soc:
           maxGlobalMemoriesToInclude: 5
           maxUserMemoriesToReconcile: 20
           maxGlobalMemoriesToReconcile: 20
+          memoryExtractBatchSize: 5
+          maxMemoryRetries: 2
           memoryModel: gemma@SOAI
           embedModel: amazon.titan-embed-text-v2@SOAI
           reconcileModel: gemma@SOAI

--- a/salt/soc/soc_soc.yaml
+++ b/salt/soc/soc_soc.yaml
@@ -909,7 +909,7 @@ soc:
             global: True
             advanced: True
           memoryExtractBatchSize:
-            description: How many messages to include in the transcript that the Memory agent will extract from.
+            description: Max number of a session's messages that will be processed for memory extractions at a time. Larger values are more efficient but risk exceeding the memory extraction LLM's size limits, due to the variable and unpredictable size of each message.
             global: True
             advanced: True
           maxMemoryRetries:

--- a/salt/soc/soc_soc.yaml
+++ b/salt/soc/soc_soc.yaml
@@ -908,6 +908,14 @@ soc:
             description: Milliseconds to wait between attempts to look up a tool request that has finished streaming but has not yet been saved to the database. The API retries up to toolUseTurnAttempts times, so this value times the attempt count is the maximum wait before auto-approval fails. Increase it if tool auto-approval fails intermittently.
             global: True
             advanced: True
+          memoryExtractBatchSize:
+            description: How many messages to include in the transcript that the Memory agent will extract from.
+            global: True
+            advanced: True
+          maxMemoryRetries:
+            description: The number of times to retry extracting memories from a session if errors occur.
+            global: True
+            advanced: True
       client:
         assistant:
           enabled:


### PR DESCRIPTION
## Description

<!-- 
Explain the purpose of the pull request. Be brief or detailed depending on the scope of the changes.
-->
2 new config fields. Batch size is used to limit how many message turns we put in the transcript when we ask the memory agent to extract facts. The retries helps limit how many times we ask the memory agent to process a problematic session.

## Related Issues

<!-- 
Optionally, list any related issues that this pull request addresses.
-->

## Checklist

- [ ] I have read and followed the [CONTRIBUTING.md](https://github.com/Security-Onion-Solutions/securityonion/blob/3/main/CONTRIBUTING.md) file.
- [ ] I have read and agree to the terms of the [Contributor License Agreement](https://securityonionsolutions.com/cla)

## Questions or Comments

<!--
If you have any questions or comments about this pull request, add them here.
-->