### PR TITLE
Add x86-64-v3 CPU pre-flight check to soup

### DIFF
--- a/salt/manager/tools/sbin/soup
+++ b/salt/manager/tools/sbin/soup
@@ -120,6 +120,9 @@ check_err() {
       161)
         echo 'Required intermediate Elasticsearch upgrade not complete'
       ;;
+      162)
+        echo 'One or more Elastic Agent nodes do not support the x86-64-v3 CPU instruction set'
+      ;;
       170)
         echo "Intermediate upgrade completed successfully to $next_step_so_version, but next soup to Security Onion $originally_requested_so_version could not be started automatically."
         echo "Start soup again manually to continue the upgrade to Security Onion $originally_requested_so_version."
@@ -345,6 +348,83 @@ check_cluster_health() {
 
   printf "\nThe Elasticsearch cluster is not green. Resolve the cluster health issue so the cluster is green before running SOUP again.\n\n"
   exit 0
+}
+
+no_soup_for_you() {
+  echo ""
+  echo "No soup for you!"
+  exit 162
+}
+
+check_cpu_compatibility() {
+  # Roles running a container built from the so-elastic-agent image; mirrors the
+  # elasticagent and elasticfleet entries in salt/reactor/pillar_push_map.yaml.
+  local cpu_target='G@role:so-heavynode or G@role:so-eval or G@role:so-fleet or G@role:so-import or G@role:so-manager or G@role:so-managerhype or G@role:so-managersearch or G@role:so-standalone'
+  local expected_nodes cpu_results node result confirm
+  local -a unsupported=() offline=()
+
+  echo "Checking that Elastic Agent nodes support the x86-64-v3 CPU instruction set now required by Elastic."
+
+  if [[ "$SKIP_CPU_CHECK" == "true" ]]; then
+    printf "\nSkipping the x86-64-v3 CPU check because --skip-cpu-check was specified.\n\n"
+    return
+  fi
+
+  # Nodes that never answer are absent from the results, so diff against who should have.
+  expected_nodes=$(salt -C "$cpu_target" --preview-target --out=json 2>/dev/null | jq -r '.[]?') || true
+  if [[ -z "$expected_nodes" ]]; then
+    printf "\nCould not determine which nodes run the Elastic Agent, so the x86-64-v3 CPU check cannot run.\n"
+    no_soup_for_you
+  fi
+
+  cpu_results=$(salt -t 30 -C "$cpu_target" cmd.run "/lib64/ld-linux-x86-64.so.2 --help | grep x86-64-v3" --out=json 2>/dev/null) || true
+
+  while IFS= read -r node; do
+    [[ -z "$node" ]] && continue
+    result=$(jq -r --arg node "$node" '.[$node] // empty' <<< "$cpu_results" 2>/dev/null)
+    if [[ -z "$result" || "$result" == *"did not return"* ]]; then
+      offline+=("$node")
+    elif [[ "$result" != *"x86-64-v3 (supported"* ]]; then
+      # glibc appends "(supported, searched)" only when supported; the open paren keeps
+      # this from matching a future "(unsupported".
+      unsupported+=("$node")
+    fi
+  done <<< "$expected_nodes"
+
+  if [[ ${#unsupported[@]} -eq 0 && ${#offline[@]} -eq 0 ]]; then
+    printf "\nAll Elastic Agent nodes support x86-64-v3. We can proceed with SOUP.\n\n"
+    return
+  fi
+
+  echo ""
+  if [[ ${#unsupported[@]} -gt 0 ]]; then
+    echo "The following node(s) do NOT support the x86-64-v3 CPU instruction set:"
+    printf '  %s\n' "${unsupported[@]}"
+    echo ""
+    echo "Upstream Elastic now builds its binaries for x86-64-v3, so these nodes can no"
+    echo "longer run Elastic. Upgrading them WILL BREAK them."
+    echo ""
+  fi
+  if [[ ${#offline[@]} -gt 0 ]]; then
+    echo "The following node(s) did not respond and could not be checked:"
+    printf '  %s\n' "${offline[@]}"
+    echo ""
+    echo "These nodes are offline, so we cannot confirm they support x86-64-v3, which"
+    echo "upstream Elastic now requires."
+    echo ""
+  fi
+
+  if [[ -n $UNATTENDED ]]; then
+    echo "Unattended mode cannot prompt for an override. Re-run soup interactively, or pass --skip-cpu-check to bypass this check."
+    no_soup_for_you
+  fi
+
+  read -rp "Type 'override' to continue anyway, or press Enter to exit: " confirm
+  if [[ "${confirm,,}" == "override" ]]; then
+    printf "\nOverride accepted. Continuing at your own risk.\n\n"
+  else
+    no_soup_for_you
+  fi
 }
 
 check_fleet_server() {
@@ -1977,6 +2057,9 @@ main() {
 
   echo "Let's see if we need to update Security Onion."
   upgrade_check
+
+  check_cpu_compatibility
+
   upgrade_space
 
   echo "Verifying Elasticsearch version compatibility across the grid before upgrading."
@@ -2255,6 +2338,17 @@ fi
   echo "### soup has been served at $(date) ###"
 }
 
+SKIP_CPU_CHECK=false
+declare -a SOUP_ARGS=()
+for arg in "$@"; do
+  if [[ "$arg" == "--skip-cpu-check" ]]; then
+    SKIP_CPU_CHECK=true
+  else
+    SOUP_ARGS+=("$arg")
+  fi
+done
+set -- "${SOUP_ARGS[@]}"
+
 while getopts ":b:f:y" opt; do
   case ${opt} in
     b )
@@ -2278,7 +2372,7 @@ while getopts ":b:f:y" opt; do
       ISOLOC="$OPTARG"
     ;;
     \? )
-      echo "Usage: soup [-b] [-y] [-f <iso location>]"
+      echo "Usage: soup [-b] [-y] [-f <iso location>] [--skip-cpu-check]"
       exit 1
     ;;
     : )


### PR DESCRIPTION
## What

Adds a pre-flight gate to `soup` that verifies every node running a container built from the `so-elastic-agent` image supports the `x86-64-v3` CPU instruction set, before soup modifies anything.

### Why

This is driven by an upstream change in Elastic, not by a Security Onion decision. Elastic now ships binaries built for the `x86-64-v3` micro-architecture level, so a node whose CPU predates v3 (roughly pre-Haswell / pre-Excavator) can no longer run Elastic's own builds. Today the operator only finds out after the grid has already been changed, which is what this check prevents.

## Behavior

Runs from `main()` immediately after `upgrade_check` — so a grid that is already current exits without being prompted — and well ahead of `SOUP_UPGRADE_STARTED=true`, so bailing out leaves the grid untouched.

- **All nodes supported** — one success line, no prompt, soup continues.
- **A node is unsupported** — lists it, states that upgrading it WILL BREAK it, and prompts for an override.
- **A node is offline** — lists it, states that it could not be checked, and prompts for an override.
- **Override** — typing `override` (case-insensitive) continues; anything else exits **162** with `No soup for you!`.
- **Unattended (`-y`)** — never prompts; exits 162 if there is a problem.
- **`--skip-cpu-check`** — bypasses the gate entirely, for automation.

Exit code 162 is wired into `check_err()`. Since `SOUP_UPGRADE_STARTED` is still `false` at this point, the "UPGRADE INCOMPLETE" banner is correctly suppressed.

## Targeting

Only roles that run a container from the `so-elastic-agent` image:

- `salt/elasticagent/` → container `so-elastic-agent`, applied in `salt/top.sls` to `*_heavynode` only.
- `salt/elasticfleet/` → container `so-elastic-fleet`, built from the *same* image, applied to the manager-class roles and `so-fleet`.

The role list is copied from the `elasticagent` and `elasticfleet` entries already maintained in `salt/reactor/pillar_push_map.yaml`, rather than inventing a new one.

Nodes that only install Elastic Agent natively on the host via `elasticfleet.install_agent_grid` (searchnode, sensor, receiver, idh, hypervisor, desktop) are **not** checked.

Targeting is by role grain, not pillar: `elasticagent:enabled` is only written to the minion pillar by `so-minion`'s `createHEAVYNODE()`, and `elasticfleet: enabled: True` only by `createFLEET()` — manager-class roles get theirs from the SOC-generated pillar at runtime, so `I@` matching is not reliable from soup.

Offline nodes are found by diffing `salt -C ... --preview-target` against the `--out=json` result keys, the same expected-vs-returned approach `verify_es_version_compatibility` already uses.

## Testing

`bash -n` passes. The classification logic was exercised against fixture JSON with a stubbed `salt`, covering: all-supported, offline-as-absent-key, offline-as-`did not return`-string, unsupported (bare `x86-64-v3`), a hypothetical `(unsupported, searched)` wording, `override`/`OVERRIDE` continuing, Enter exiting 162, unattended refusing to prompt, `--skip-cpu-check` skipping, and an empty target list bailing out.

Argument parsing was verified for `--skip-cpu-check` alone and interleaved with `-b 5`, `-b 25%`, `-y`, and `-f`.

## Needs confirmation on a real grid

Two assumptions rest on documented Salt behavior and should be spot-checked before merge:

1. `salt -C '<target>' --preview-target --out=json` returns a JSON array of minion ids **including nodes that are currently down**. If it does not, the fallback is filtering `salt-key --out=json --list=accepted` by minion-id suffix — the idiom already used elsewhere in soup.
2. Which offline shape Salt actually produces (absent key vs. a `did not return` string). Both are handled, but only one will fire.


